### PR TITLE
Feat: 즐겨찾기 조회 API 구현

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/club/controller/ClubController.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/controller/ClubController.java
@@ -20,18 +20,19 @@ import org.springframework.web.bind.annotation.*;
 public class ClubController {
 
     private final ClubService clubService;
-    private static final Long USER_ID = 1L;
 
     @GetMapping("/{clubId}")
-    public ResponseEntity<APISuccessResponse<ClubDetailResponse>> getClub(@Authentication AuthCredential authCredential, @PathVariable("clubId") final Long clubId) {
+    public ResponseEntity<APISuccessResponse<ClubDetailResponse>> getClub(
+            @Authentication final AuthCredential authCredential,
+            @PathVariable("clubId") final Long clubId) {
         return APISuccessResponse.of(
                 HttpStatus.OK,
-                clubService.findClub(authCredential, clubId));
+                clubService.findClub(authCredential.userId(), clubId));
     }
 
     @GetMapping
     public ResponseEntity<APISuccessResponse<ClubSearchResponse>> getClubs(
-            @Authentication AuthCredential authCredential,
+            @Authentication final AuthCredential authCredential,
             @ModelAttribute(value = "clubSearchCond") final ClubSearchCond clubSearchCond,
             @RequestParam(value = "page") final int page,
             @RequestParam(value = "size") final int size
@@ -41,7 +42,7 @@ public class ClubController {
         return APISuccessResponse.of(
                 HttpStatus.OK,
                 clubService.findClubsByConditions(
-                        authCredential,
+                        authCredential.userId(),
                         clubSearchCond.keyword(),
                         clubSearchCond.category(),
                         clubSearchCond.affiliation(),

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -15,7 +15,6 @@ import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.message.FailMessage;
-import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -68,7 +67,7 @@ public class ClubService {
         return favoriteRepository.existsByUserIdAndClubId(userId, clubId);
     }
 
-    private ClubDetailResponse mapToClubDetailResponse(Club club, Recruitment recruitment, Boolean isFavorite) {
+    private ClubDetailResponse mapToClubDetailResponse(final Club club, final Recruitment recruitment, final Boolean isFavorite) {
         return ClubDetailResponse.of(
                 club.getId(),
                 club.getName(),

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -1,6 +1,5 @@
 package com.greedy.mokkoji.api.club.service;
 
-import com.greedy.mokkoji.api.auth.controller.argumentResolver.AuthCredential;
 import com.greedy.mokkoji.api.club.dto.club.ClubDetailResponse;
 import com.greedy.mokkoji.api.club.dto.club.ClubResponse;
 import com.greedy.mokkoji.api.club.dto.club.ClubSearchResponse;
@@ -12,6 +11,7 @@ import com.greedy.mokkoji.db.club.repository.ClubRepository;
 import com.greedy.mokkoji.db.favorite.repository.FavoriteRepository;
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.db.recruitment.repository.RecruitmentRepository;
+import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.message.FailMessage;
@@ -35,9 +35,7 @@ public class ClubService {
     private final AppDataS3Client appDataS3Client;
 
     @Transactional(readOnly = true)
-    public ClubDetailResponse findClub(AuthCredential authCredential, final Long clubId) {
-
-        Long userId = validateLoginUser(authCredential);
+    public ClubDetailResponse findClub(final Long userId, final Long clubId) {
 
         final Club club = clubRepository.findById(clubId)
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB));
@@ -48,15 +46,12 @@ public class ClubService {
     }
 
     @Transactional(readOnly = true)
-    public ClubSearchResponse findClubsByConditions(AuthCredential authCredential,
+    public ClubSearchResponse findClubsByConditions(final Long userId,
                                                     final String keyword,
                                                     final ClubCategory category,
                                                     final ClubAffiliation affiliation,
                                                     final RecruitStatus status,
                                                     final Pageable pageable) {
-
-
-        Long userId = validateLoginUser(authCredential);
 
         final Page<Club> clubPage = clubRepository.findClubs(keyword, category, affiliation, status, pageable);
 
@@ -66,14 +61,7 @@ public class ClubService {
         return new ClubSearchResponse(clubResponses, pageResponse);
     }
 
-    private Long validateLoginUser(AuthCredential authCredential) {
-        if (authCredential == null) {
-            return null;
-        }
-        return authCredential.userId();
-    }
-
-    private boolean getIsFavorite(Long userId, Long clubId) {
+    private boolean getIsFavorite(final Long userId, final Long clubId) {
         if (userId == null) { //회원 및 비회원 구별 로직
             return false;
         }

--- a/src/main/java/com/greedy/mokkoji/api/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/greedy/mokkoji/api/favorite/controller/FavoriteController.java
@@ -2,6 +2,7 @@ package com.greedy.mokkoji.api.favorite.controller;
 
 import com.greedy.mokkoji.api.auth.controller.argumentResolver.AuthCredential;
 import com.greedy.mokkoji.api.auth.controller.argumentResolver.Authentication;
+import com.greedy.mokkoji.api.club.dto.club.ClubResponse;
 import com.greedy.mokkoji.api.favorite.service.FavoriteService;
 import com.greedy.mokkoji.common.response.APISuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -9,25 +10,32 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("${api.prefix}/favorites")
 public class FavoriteController {
 
-    private static final Long USER_ID = 1L;
     private final FavoriteService favoriteService;
 
     @PostMapping("/{clubId}")
     public ResponseEntity<APISuccessResponse<Void>> addFavorite(
-            @Authentication AuthCredential authCredential,
+            @Authentication final AuthCredential authCredential,
             @PathVariable(name = "clubId") final Long clubId
     ) {
         return APISuccessResponse.of(HttpStatus.CREATED, favoriteService.addFavorite(authCredential.userId(), clubId));
     }
 
+    @GetMapping
+    public ResponseEntity<APISuccessResponse<List<ClubResponse>>> getFavoriteClubs(
+            @Authentication final AuthCredential authCredential) {
+        return APISuccessResponse.of(HttpStatus.OK, favoriteService.findFavoriteClubs(authCredential.userId()));
+    }
+
     @DeleteMapping("/{clubId}")
     public ResponseEntity<APISuccessResponse<Void>> deleteFavorite(
-            @Authentication AuthCredential authCredential,
+            @Authentication final AuthCredential authCredential,
             @PathVariable(name = "clubId") final Long clubId
     ) {
         return APISuccessResponse.of(HttpStatus.NO_CONTENT, favoriteService.deleteFavorite(authCredential.userId(), clubId));

--- a/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
+++ b/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
@@ -1,16 +1,22 @@
 package com.greedy.mokkoji.api.favorite.service;
 
+import com.greedy.mokkoji.api.club.dto.club.ClubResponse;
 import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.club.repository.ClubRepository;
 import com.greedy.mokkoji.db.favorite.entity.Favorite;
 import com.greedy.mokkoji.db.favorite.repository.FavoriteRepository;
+import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
+import com.greedy.mokkoji.db.recruitment.repository.RecruitmentRepository;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.db.user.repository.UserRepository;
 import com.greedy.mokkoji.enums.message.FailMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +25,7 @@ public class FavoriteService {
     private final FavoriteRepository favoriteRepository;
     private final UserRepository userRepository;
     private final ClubRepository clubRepository;
+    private final RecruitmentRepository recruitmentRepository;
 
     @Transactional
     public Void addFavorite(final Long userId, final Long clubId) {
@@ -38,6 +45,29 @@ public class FavoriteService {
         );
 
         return null;
+    }
+
+    @Transactional(readOnly = true)
+    public List<ClubResponse> findFavoriteClubs(final Long userId) {
+        final List<Favorite> favorites = favoriteRepository.findByUserId(userId);
+
+        return favorites.stream()
+                .map(favorite -> {
+                    final Club club = favorite.getClub();
+                    final Recruitment recruitment = recruitmentRepository.findByClubId(club.getId());
+
+                    return ClubResponse.of(
+                            club.getId(),
+                            club.getName(),
+                            club.getClubCategory().getDescription(),
+                            club.getClubAffiliation().getDescription(),
+                            club.getDescription(),
+                            recruitment.getRecruitStart(),
+                            recruitment.getRecruitEnd(),
+                            club.getLogo(),
+                            true
+                    );
+                }).collect(Collectors.toList());
     }
 
     @Transactional

--- a/src/main/java/com/greedy/mokkoji/common/handler/JwtAuthInterceptor.java
+++ b/src/main/java/com/greedy/mokkoji/common/handler/JwtAuthInterceptor.java
@@ -23,12 +23,19 @@ public class JwtAuthInterceptor implements HandlerInterceptor {
         String accessToken = request.getHeader(HttpHeaders.AUTHORIZATION);
 
         try {
-            jwtUtil.getUserIdFromToken(accessToken);
+            Long userId = jwtUtil.getUserIdFromToken(accessToken);
+            if (userId == null) { //로그인 미인증 사용자
+                log.info("미인증 사용자 요청");
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                return false;
+            }
             return true;
+
         } catch (ExpiredJwtException e) {
             log.warn("Access Token 만료됨");
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return false;
+
         } catch (JwtException e) {
             log.warn("유효하지 않은 Access Token이 입력됨");
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);

--- a/src/main/java/com/greedy/mokkoji/config/WebConfig.java
+++ b/src/main/java/com/greedy/mokkoji/config/WebConfig.java
@@ -16,6 +16,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     private final JwtAuthInterceptor jwtAuthInterceptor;
     private final UserAuthArgumentResolver userAuthArgumentResolver;
+
     @Value("${api.prefix}")
     private String prefixUrl;
 
@@ -31,7 +32,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtAuthInterceptor)
                 .addPathPatterns("/**")
-                .excludePathPatterns(prefixUrl + "/users/auth/login", prefixUrl + "/users/auth/refresh");
+                .excludePathPatterns(prefixUrl + "/users/auth/login", prefixUrl + "/users/auth/refresh", prefixUrl + "/clubs/**");
     }
 
     @Override

--- a/src/main/java/com/greedy/mokkoji/db/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/favorite/repository/FavoriteRepository.java
@@ -20,4 +20,6 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     void deleteByUserAndClub(final User user, final Club club);
 
     boolean existsByUserIdAndClubId(final Long userId, final Long id);
+
+    List<Favorite> findByUserId(Long userId);
 }

--- a/src/test/java/com/greedy/mokkoji/club/ClubSearchTest.java
+++ b/src/test/java/com/greedy/mokkoji/club/ClubSearchTest.java
@@ -1,6 +1,5 @@
 package com.greedy.mokkoji.club;
 
-import com.greedy.mokkoji.api.auth.controller.argumentResolver.AuthCredential;
 import com.greedy.mokkoji.api.club.dto.club.ClubDetailResponse;
 import com.greedy.mokkoji.api.club.dto.club.ClubSearchResponse;
 import com.greedy.mokkoji.api.club.service.ClubService;
@@ -98,8 +97,8 @@ class ClubSearchTest {
     @Test
     @DisplayName("전체 동아리 정보를 조회한다.")
     void findClubsByNoConditions() {
+        //given
         final Long userId = 1L;
-        final AuthCredential authCredential = new AuthCredential(userId);
         final Long clubId1 = club1.getId();
         final Long clubId2 = club2.getId();
         final Pageable pageable = PageRequest.of(0, 10);
@@ -114,8 +113,10 @@ class ClubSearchTest {
         BDDMockito.given(appDataS3Client.getPresignedUrl(club1.getLogo())).willReturn("testLogo1");
         BDDMockito.given(appDataS3Client.getPresignedUrl(club2.getLogo())).willReturn("testLogo2");
 
-        final ClubSearchResponse response = clubService.findClubsByConditions(authCredential, null, null, null, null, pageable);
+        //when
+        final ClubSearchResponse response = clubService.findClubsByConditions(userId, null, null, null, null, pageable);
 
+        //then
         assertThat(response.clubs()).hasSize(2);
 
         assertThat(response.clubs().get(0).name()).isEqualTo("testClub1");
@@ -146,8 +147,8 @@ class ClubSearchTest {
     @Test
     @DisplayName("동아리 상세 정보를 조회한다.")
     void findClubDetailInformation() {
+        //given
         final Long userId = 1L;
-        final AuthCredential authCredential = new AuthCredential(userId);
         final Long clubId = club1.getId();
 
         BDDMockito.given(clubRepository.findById(clubId)).willReturn(Optional.ofNullable(club1));
@@ -155,8 +156,10 @@ class ClubSearchTest {
         BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, clubId)).willReturn(true);
         BDDMockito.given(appDataS3Client.getPresignedUrl(club1.getLogo())).willReturn("testLogo1");
 
-        ClubDetailResponse response = clubService.findClub(authCredential, clubId);
+        //when
+        ClubDetailResponse response = clubService.findClub(userId, clubId);
 
+        //then
         assertThat(response).isNotNull();
         assertThat(response.name()).isEqualTo("testClub1");
         assertThat(response.category()).isEqualTo("학술/교양");

--- a/src/test/java/com/greedy/mokkoji/favorite/FavoriteTest.java
+++ b/src/test/java/com/greedy/mokkoji/favorite/FavoriteTest.java
@@ -1,11 +1,14 @@
 package com.greedy.mokkoji.favorite;
 
+import com.greedy.mokkoji.api.club.dto.club.ClubResponse;
 import com.greedy.mokkoji.api.favorite.service.FavoriteService;
 import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.club.repository.ClubRepository;
 import com.greedy.mokkoji.db.favorite.entity.Favorite;
 import com.greedy.mokkoji.db.favorite.repository.FavoriteRepository;
+import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
+import com.greedy.mokkoji.db.recruitment.repository.RecruitmentRepository;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.db.user.repository.UserRepository;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
@@ -21,9 +24,13 @@ import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 
@@ -44,13 +51,13 @@ public class FavoriteTest {
     @Mock
     FavoriteRepository favoriteRepository;
 
+    @Mock
+    RecruitmentRepository recruitmentRepository;
+
     @Test
     @DisplayName("동아리를 즐겨찾기할 수 있다.")
     void addFavorite() {
         // given
-        final Long userId = 1L;
-        final Long clubId = 1L;
-
         final User user = User.builder()
                 .name("사용자 이름")
                 .email("사용자 이메일")
@@ -58,6 +65,7 @@ public class FavoriteTest {
                 .department("사용자 학과")
                 .studentId("사용자 학번")
                 .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
 
         final Club club = Club.builder()
                 .name("동아리 이름")
@@ -67,27 +75,23 @@ public class FavoriteTest {
                 .description("동아리 설명")
                 .instagram("동아리 인스타그램 링크")
                 .build();
-
+        ReflectionTestUtils.setField(club, "id", 1L);
 
         BDDMockito.given(userRepository.findById(any())).willReturn(Optional.ofNullable(user));
         BDDMockito.given(clubRepository.findById(any())).willReturn(Optional.ofNullable(club));
         BDDMockito.given(favoriteRepository.existsByUserAndClub(any(), any())).willReturn(false);
 
         // when
-        favoriteService.addFavorite(userId, clubId);
+        favoriteService.addFavorite(user.getId(), club.getId());
 
         // then
         BDDMockito.verify(favoriteRepository, times(1)).save(any(Favorite.class));
-
     }
 
     @Test
     @DisplayName("즐겨찾기한 동아리를 삭제할 수 있다.")
     void deleteFavorite() {
         // given
-        final Long userId = 1L;
-        final Long clubId = 1L;
-
         final User user = User.builder()
                 .name("사용자 이름")
                 .email("사용자 이메일")
@@ -95,6 +99,7 @@ public class FavoriteTest {
                 .department("사용자 학과")
                 .studentId("사용자 학번")
                 .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
 
         final Club club = Club.builder()
                 .name("동아리 이름")
@@ -104,13 +109,14 @@ public class FavoriteTest {
                 .description("동아리 설명")
                 .instagram("동아리 인스타그램 링크")
                 .build();
+        ReflectionTestUtils.setField(club, "id", 1L);
 
         BDDMockito.given(userRepository.findById(any())).willReturn(Optional.ofNullable(user));
         BDDMockito.given(clubRepository.findById(any())).willReturn(Optional.ofNullable(club));
         BDDMockito.given(favoriteRepository.existsByUserAndClub(any(), any())).willReturn(true);
 
         // when
-        favoriteService.deleteFavorite(userId, clubId);
+        favoriteService.deleteFavorite(user.getId(), club.getId());
 
         // then
         BDDMockito.verify(favoriteRepository, times(1)).deleteByUserAndClub(user, club);
@@ -121,9 +127,6 @@ public class FavoriteTest {
     @DisplayName("즐겨찾기 시 이미 즐겨찾기가 되어 있는 경우 예외가 발생한다.")
     void foundPostLikWhenAdd() throws Exception {
         // given
-        final Long userId = 1L;
-        final Long clubId = 1L;
-
         final User user = User.builder()
                 .name("사용자 이름")
                 .email("사용자 이메일")
@@ -131,6 +134,7 @@ public class FavoriteTest {
                 .department("사용자 학과")
                 .studentId("사용자 학번")
                 .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
 
         final Club club = Club.builder()
                 .name("동아리 이름")
@@ -140,13 +144,14 @@ public class FavoriteTest {
                 .description("동아리 설명")
                 .instagram("동아리 인스타그램 링크")
                 .build();
+        ReflectionTestUtils.setField(club, "id", 1L);
 
         BDDMockito.given(userRepository.findById(any())).willReturn(Optional.ofNullable(user));
         BDDMockito.given(clubRepository.findById(any())).willReturn(Optional.ofNullable(club));
         BDDMockito.given(favoriteRepository.existsByUserAndClub(any(), any())).willReturn(true);
 
         // when, then
-        Assertions.assertThatThrownBy(() -> favoriteService.addFavorite(userId, clubId))
+        Assertions.assertThatThrownBy(() -> favoriteService.addFavorite(user.getId(), club.getId()))
                 .isInstanceOf(MokkojiException.class)
                 .hasMessageContaining(FailMessage.CONFLICT_FAVORITE.getMessage());
     }
@@ -155,9 +160,6 @@ public class FavoriteTest {
     @DisplayName("즐겨찾기 삭제 시 해당하는 즐겨찾기 동아리가 없는 경우 예외가 발생한다.")
     void notFoundPostLikWhenDelete() throws Exception {
         // given
-        final Long userId = 1L;
-        final Long clubId = 1L;
-
         final User user = User.builder()
                 .name("사용자 이름")
                 .email("사용자 이메일")
@@ -165,6 +167,7 @@ public class FavoriteTest {
                 .department("사용자 학과")
                 .studentId("사용자 학번")
                 .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
 
         final Club club = Club.builder()
                 .name("동아리 이름")
@@ -174,15 +177,72 @@ public class FavoriteTest {
                 .description("동아리 설명")
                 .instagram("동아리 인스타그램 링크")
                 .build();
+        ReflectionTestUtils.setField(club, "id", 1L);
 
         BDDMockito.given(userRepository.findById(any())).willReturn(Optional.ofNullable(user));
         BDDMockito.given(clubRepository.findById(any())).willReturn(Optional.ofNullable(club));
         BDDMockito.given(favoriteRepository.existsByUserAndClub(any(), any())).willReturn(false);
 
         // when, then
-        Assertions.assertThatThrownBy(() -> favoriteService.deleteFavorite(userId, clubId))
+        Assertions.assertThatThrownBy(() -> favoriteService.deleteFavorite(user.getId(), club.getId()))
                 .isInstanceOf(MokkojiException.class)
                 .hasMessageContaining(FailMessage.NOT_FOUND_FAVORITE.getMessage());
     }
 
+    @Test
+    @DisplayName("즐겨찾기한 동아리를 조회할 수 있다.")
+    void findFavorites() {
+        //given
+        final User user = User.builder()
+                .name("사용자 이름")
+                .email("사용자 이메일")
+                .grade("4")
+                .department("사용자 학과")
+                .studentId("사용자 학번")
+                .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        final Club club = Club.builder()
+                .name("동아리 이름")
+                .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
+                .clubCategory(ClubCategory.CULTURAL_ART)
+                .logo("동아리 로고")
+                .description("동아리 설명")
+                .instagram("동아리 인스타그램 링크")
+                .build();
+        ReflectionTestUtils.setField(club, "id", 1L);
+
+        final Recruitment recruitment = Recruitment.builder().
+                recruitStart(LocalDateTime.of(2025, 02, 01, 12, 00)).
+                recruitEnd(LocalDateTime.of(2025, 03, 30, 12, 00)).
+                content("동아리 모집 글").
+                build();
+        ReflectionTestUtils.setField(recruitment, "id", 1L);
+
+        final List<Favorite> favorites = List.of(
+                Favorite.builder().
+                        club(club).
+                        user(user).build()
+        );
+
+        BDDMockito.given(favoriteRepository.findByUserId(any())).willReturn(favorites);
+        BDDMockito.given(recruitmentRepository.findByClubId(any())).willReturn(recruitment);
+
+        //when
+        final List<ClubResponse> favoriteClubs = favoriteService.findFavoriteClubs(user.getId());
+
+        //then
+        assertThat(favoriteClubs.size()).isEqualTo(1);
+        assertThat(favoriteClubs.get(0).name()).isEqualTo("동아리 이름");
+        assertThat(favoriteClubs.get(0).category()).isEqualTo("문화/예술");
+        assertThat(favoriteClubs.get(0).affiliation()).isEqualTo("중앙동아리");
+        assertThat(favoriteClubs.get(0).description()).isEqualTo("동아리 설명");
+        assertThat(favoriteClubs.get(0).recruitStartDate()).isEqualTo("2025-02-01");
+        assertThat(favoriteClubs.get(0).recruitEndDate()).isEqualTo("2025-03-30");
+        assertThat(favoriteClubs.get(0).imageURL()).isEqualTo("동아리 로고");
+        assertThat(favoriteClubs.get(0).isFavorite()).isEqualTo(true);
+
+        BDDMockito.verify(favoriteRepository, times(1)).findByUserId(user.getId());
+        BDDMockito.verify(recruitmentRepository, times(1)).findByClubId(club.getId());
+    }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #27

## 👷 **작업한 내용**
- 즐겨찾기 조회 API 를 구현했습니다.
- 로그인 인증 기능이 적용 되어 있지 않은 기존 즐겨찾기 추가 및 삭제 부분에 로그인 인증 기능을 적용하였습니다.
- 그 외 로그인 인증 기능 관련하여 코드 리팩토링을 진행하였습니다. 
- 기능에 맞는 테스트 코드를 작성하였습니다.

아래 내용은 위 작업한 내용을 바탕으로 진행한 즐겨찾기 테스트입니다.

<초기 데이터>
1 : 세종 로타랙트
2 : 셀스(SELS)
3 : 죽순회

<로그인 인증 사용자일 경우>
- 즐겨찾기 추가 
<img width="1278" alt="스크린샷 2025-02-27 오전 8 33 44" src="https://github.com/user-attachments/assets/bbc091f1-7e36-45d0-82e1-a99f68d2a951" />
<img width="1251" alt="스크린샷 2025-02-27 오전 8 34 01" src="https://github.com/user-attachments/assets/2cd3c112-a7fc-4232-b603-1438d7b51bbe" />
<img width="1268" alt="스크린샷 2025-02-27 오전 8 34 36" src="https://github.com/user-attachments/assets/fc8ab36c-2517-4185-92f5-3c725395b55b" />


- 즐겨찾기 중복
<img width="1268" alt="스크린샷 2025-02-27 오전 8 34 27" src="https://github.com/user-attachments/assets/48b38586-96d1-48f3-b100-4bdf21b6c116" />


- 즐겨찾기 삭제
<img width="1273" alt="스크린샷 2025-02-27 오전 8 35 13" src="https://github.com/user-attachments/assets/a6b8edf9-68b0-4f46-b275-d2a2b8a38861" />


- 즐겨찾기 조회
<img width="1276" alt="스크린샷 2025-02-27 오전 8 35 34" src="https://github.com/user-attachments/assets/08bc733a-630a-4d25-9642-9fca9dacc6ac" />


<로그인 하지 않은 사용자 혹은 미인증 사용자일 경우>
<img width="1263" alt="스크린샷 2025-02-27 오전 9 31 28" src="https://github.com/user-attachments/assets/00a3d3d1-1b8c-4919-9fa1-5c157c0f6e61" />


<테스트 코드>
<img width="437" alt="스크린샷 2025-02-27 오전 8 02 35" src="https://github.com/user-attachments/assets/a516227e-fd8a-4b9a-8aa7-f2a6223e5872" />

## 🚨 **참고 사항**
-
