### PR TITLE
Fix: CORS preflight 요청 에러 해결 & 헤더 없이 clubs 관련 api 호출 안되던 오류 해결

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/auth/controller/argumentResolver/UserAuthArgumentResolver.java
+++ b/src/main/java/com/greedy/mokkoji/api/auth/controller/argumentResolver/UserAuthArgumentResolver.java
@@ -4,7 +4,6 @@ import com.greedy.mokkoji.api.jwt.BearerAuthExtractor;
 import com.greedy.mokkoji.api.jwt.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
@@ -16,7 +15,6 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 import java.util.Set;
 
 @Component
-@Slf4j
 @RequiredArgsConstructor
 public class UserAuthArgumentResolver implements HandlerMethodArgumentResolver {
 

--- a/src/main/java/com/greedy/mokkoji/api/jwt/BearerAuthExtractor.java
+++ b/src/main/java/com/greedy/mokkoji/api/jwt/BearerAuthExtractor.java
@@ -3,19 +3,23 @@ package com.greedy.mokkoji.api.jwt;
 import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.enums.message.FailMessage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class BearerAuthExtractor {
     private static final String BEARER_TYPE = "Bearer";
 
     public String extractTokenValue(final String bearerToken) {
         if (bearerToken == null || bearerToken.isEmpty()) {
+            log.warn("Autherizaiton 헤더 값이 없습니다.");
             throw new MokkojiException(FailMessage.UNAUTHORIZED_EMPTY_HEADER);
         }
 
         if (!bearerToken.toLowerCase().startsWith(BEARER_TYPE.toLowerCase())) {
+            log.warn("AuthHeader의 값이 Bearer로 시작하지 않습니다: {}", bearerToken);
             throw new MokkojiException(FailMessage.UNAUTHORIZED_INVALID_TOKEN);
         }
 

--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
@@ -36,9 +36,9 @@ public class UserController {
 
     @PostMapping("/auth/refresh")
     public ResponseEntity<APISuccessResponse<RefreshResponse>> refresh(
-            @RequestHeader("Authorization") String authHeader
+            @RequestHeader("Authorization") String bearerToken
     ) {
-        final String refreshToken = bearerAuthExtractor.extractTokenValue(authHeader);
+        final String refreshToken = bearerAuthExtractor.extractTokenValue(bearerToken);
 
         final String newAccessToken = userService.refreshAccessToken(refreshToken);
 

--- a/src/main/java/com/greedy/mokkoji/common/handler/JwtAuthInterceptor.java
+++ b/src/main/java/com/greedy/mokkoji/common/handler/JwtAuthInterceptor.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 @Slf4j
@@ -20,10 +21,14 @@ public class JwtAuthInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if (CorsUtils.isPreFlightRequest(request)) {
+            return true;
+        }
+
         String header = request.getHeader(HttpHeaders.AUTHORIZATION);
         final String token = bearerAuthExtractor.extractTokenValue(header);
         final Long userId = jwtUtil.getUserIdFromToken(token);
-
         return userId != null;
     }
+
 }

--- a/src/main/java/com/greedy/mokkoji/common/handler/JwtAuthInterceptor.java
+++ b/src/main/java/com/greedy/mokkoji/common/handler/JwtAuthInterceptor.java
@@ -5,13 +5,11 @@ import com.greedy.mokkoji.api.jwt.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthInterceptor implements HandlerInterceptor {
@@ -30,5 +28,4 @@ public class JwtAuthInterceptor implements HandlerInterceptor {
         final Long userId = jwtUtil.getUserIdFromToken(token);
         return userId != null;
     }
-
 }

--- a/src/main/java/com/greedy/mokkoji/common/handler/JwtAuthInterceptor.java
+++ b/src/main/java/com/greedy/mokkoji/common/handler/JwtAuthInterceptor.java
@@ -25,7 +25,7 @@ public class JwtAuthInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        final String header = request.getHeader(HttpHeaders.AUTHORIZATION);
         final String token = bearerAuthExtractor.extractTokenValue(header);
         final Long userId = jwtUtil.getUserIdFromToken(token);
         return userId != null;


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #55 

## 👷 **작업한 내용**
- 브라우저 요청 중 preflight 요청시 에러가 발생 하던 것을 해결하였습니다.
- clubs 관련 api 호출 안되던 오류를 해결하였습니다.
- interceptor를 거치지 않는 url들을 필드로 만들어 두었습니다.

## 🚨 **참고 사항**
- 프론트에서 서버에 authorizaiton 정보를 가지고 서버에 요청을 하게되면 
1. 브라우저가 보안을 위해 예비 요청(Preflight Request)을 보내게 됩니다.
2. Preflight Request는 Options method를 가지고 spring 서버에 들어오게 됩니다.
3. 우리는 interceptor를 설정했기에 cors관련 정보를 프론트에 넘겨주기 전에  Preflight Request는 interceptor를 거치게 됩니다.
4.  Preflight Request는 헤더 정보 없이 보내지다 보니 interceptor에서 로직을 돌던 와중 401오류를 뱉게 됩니다.

4번 과정에서 401오류를 안 뱉고 Preflight Request은 통과 할 수 있도록 설정해 두었습니다.