### PR TITLE
Fix: 모집글 기반으로 검색 키워드가 조회되도록 수정

### DIFF
--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
@@ -68,7 +68,7 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
 
     private BooleanExpression likeClubName(final String keyword) {
         if (StringUtils.hasText(keyword)) {
-            return club.name.like("%" + keyword + "%");
+            return recruitment.content.like("%" + keyword + "%");
         }
         return null;
     }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #63

## 👷 **작업한 내용**
기존에는 동아리 키워드 검색 시 동아리 이름들을 기준으로만 키워드 조회가 되었다면,
현재는 모집글을 기준으로 키워드 조회가 되도록 구현하여 검색의 불편함을 해소하였습니다.
## 🚨 **참고 사항**
모집글을 기준으로 키워드를 조회한다면 검색의 다양성을 높일 수 있다는 장점이 있습니다!
하지만, 다음과 같은 드문 예외들도 존재합니다.
ex) "농구"를 검색했을 시, 교내 농구 동아리 Rush만 뜨는 것이 정상이지만
       배드민턴 동아리 세콕세콕도 같이 조회됩니다. 모집글에는 ("농구화 ~")처럼 검색 키워드가 검색 의도와는 맞지 않게 포함되는 경우죠.
       이 부분은 다같이 고민해서 더 개선시키는 방향을 찾아봐야 할 것 같네요.