### PR TITLE
Fix: 메일 전송 동아리 모집글 범위 모집글 당일, 마감 3일전, 마감 당일로 수정

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/scheduler/service/RecruitmentNotificationScheduler.java
+++ b/src/main/java/com/greedy/mokkoji/api/scheduler/service/RecruitmentNotificationScheduler.java
@@ -27,6 +27,8 @@ public class RecruitmentNotificationScheduler {
 
         List<Recruitment> recruitments = recruitmentRepository.findTodayRecruitStartDate(currentDate);
 
+        recruitments.addAll(recruitmentRepository.findAllByRecruitmentDeadlineTodayOrInThreeDays(currentDate));
+
         recruitments.forEach(
                 recruitment -> {
                     Club club = recruitment.getClub();

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepository.java
@@ -21,6 +21,6 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
 
     List<Recruitment> findAllByClubId(final Long id);
 
-    @Query("SELECT r FROM Recruitment r WHERE FUNCTION('DATE', r.recruitEnd) = :currentDate OR FUNCTION('DATE', r.recruitEnd) = :currentDate + 3")
+    @Query("SELECT r FROM Recruitment r WHERE FUNCTION('DATE', r.recruitEnd) = :currentDate OR FUNCTION('DATE', r.recruitEnd) = :currentDate - 3")
     List<Recruitment> findAllByRecruitmentDeadlineTodayOrInThreeDays(LocalDate currentDate);
 }

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepository.java
@@ -21,4 +21,6 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
 
     List<Recruitment> findAllByClubId(final Long id);
 
+    @Query("SELECT r FROM Recruitment r WHERE FUNCTION('DATE', r.recruitEnd) = :currentDate OR FUNCTION('DATE', r.recruitEnd) = :currentDate + 3")
+    List<Recruitment> findAllByRecruitmentDeadlineTodayOrInThreeDays(LocalDate currentDate);
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #118 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 마감 3일전, 마감 당일인 모집글을 모아 전송하도록 수정했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
* 제가 생각했을 때 중복으로 들어갈 걱정은 하고 있지는 않고 있긴 합니다. (ex : 모집 당일, 모집 3일전이 같은 동아리) 그래서 이에 대한 부분은 고려하지 않았는데 혹시 우려되는 점이 있으시다면 편하게 말씀해주세요!
* queryDSL로 수정하게 되면 기존에 있던 부분과 합치면 좋을 듯 싶습니다!
