### PR TITLE
hotfix: 카카오 소셜 로그인 dto 네이밍 매핑 오류 해결

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/user/dto/resopnse/KakaoAccountResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/dto/resopnse/KakaoAccountResponse.java
@@ -1,6 +1,10 @@
 package com.greedy.mokkoji.api.user.dto.resopnse;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record KakaoAccountResponse (
-        KakaoProfileResponse kakaoProfileResponse
+        KakaoProfileResponse profile
 ) {
 }

--- a/src/main/java/com/greedy/mokkoji/api/user/dto/resopnse/KakaoProfileResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/dto/resopnse/KakaoProfileResponse.java
@@ -1,5 +1,9 @@
 package com.greedy.mokkoji.api.user.dto.resopnse;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record KakaoProfileResponse(
         String nickname,
         boolean isDefaultNickname

--- a/src/main/java/com/greedy/mokkoji/api/user/dto/resopnse/KakaoUserInfoResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/dto/resopnse/KakaoUserInfoResponse.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record KakaoUserInfoResponse(
         String id,
-        KakaoAccountResponse kakaoAccountResponse
+        KakaoAccountResponse kakaoAccount
 ) {
 }
 

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -29,10 +29,10 @@ public class UserService {
 
         return userRepository.findByUniqueId(userInfo.id()).orElseGet(() -> {
             final User newUser = User.builder()
-                    .uniqueId(userInfo.id())
-                    .nickname(userInfo.kakaoAccountResponse().kakaoProfileResponse().nickname())
-                    .role(UserRole.NORMAL)
-                    .build();
+                .uniqueId(userInfo.id())
+                .nickname(userInfo.kakaoAccount().profile().nickname())
+                .role(UserRole.NORMAL)
+                .build();
             return userRepository.save(newUser);
         });
     }
@@ -57,7 +57,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public User findUser(final Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
     }
 
     @Transactional


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #123 

## 👷 **작업한 내용**
로그인 요청을 보냈을 때, 500 에러가 발생하였습니다.
지난 작업에 dto 구조 리팩토링 작업을 했을 때 바뀐 변수명이 원인이었습니다.
카카오 developer 에서 제공하는 문서에 따라, 변수명을 맞춰 수정하였습니다.

## 🚨 **참고 사항**
앞으로 변경 사항이 생기면, 포스트맨 검증 or 테스트는 꼭 필수로 해주셨으면 좋겠습니다!!