### PR TITLE
Fix: 비밀번호 복호화 적용

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/external/SejongLoginClient.java
+++ b/src/main/java/com/greedy/mokkoji/api/external/SejongLoginClient.java
@@ -4,19 +4,26 @@ import com.greedy.mokkoji.api.user.dto.resopnse.StudentInformationResponse;
 import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.enums.message.FailMessage;
 import jakarta.transaction.Transactional;
-import okhttp3.*;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
-import javax.net.ssl.*;
 import java.io.IOException;
 import java.net.CookieManager;
 import java.net.CookiePolicy;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import okhttp3.FormBody;
+import okhttp3.JavaNetCookieJar;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 @Component
 public class SejongLoginClient {

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -9,6 +9,7 @@ import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.db.user.repository.UserRepository;
 import com.greedy.mokkoji.enums.message.FailMessage;
 import com.greedy.mokkoji.enums.user.UserRole;
+import com.greedy.mokkoji.util.PasswordDecoder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,12 +24,13 @@ public class UserService {
     private final JwtUtil jwtUtil;
     private final TokenService tokenService;
     private final SejongLoginClient sejongLoginClient;
+    private final PasswordDecoder passwordDecoder;
 
     //ToDo: 생 유저 정보를 넘기는 게 아니라 DTO처리해서 넘기는 것도 좋아보임
     @Transactional
     public User login(final String studentId, final String password) {
 
-        final StudentInformationResponse studentInformationResponse = sejongLoginClient.getStudentInformation(studentId, password);
+        final StudentInformationResponse studentInformationResponse = sejongLoginClient.getStudentInformation(studentId, passwordDecoder.decode(password));
 
         return userRepository.findByStudentId(studentId).orElseGet(() -> {
             final User newUser = User.builder()

--- a/src/main/java/com/greedy/mokkoji/enums/message/FailMessage.java
+++ b/src/main/java/com/greedy/mokkoji/enums/message/FailMessage.java
@@ -20,6 +20,7 @@ public enum FailMessage {
     UNAUTHORIZED_EXPIRED(HttpStatus.UNAUTHORIZED, 40101, "토큰 기간이 만료 되었습니다."),
     UNAUTHORIZED_EMPTY_HEADER(HttpStatus.UNAUTHORIZED, 40102, "인증 정보가 없습니다."),
     UNAUTHORIZED_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 40103, "토큰의 정보가 올바르지 않습니다."),
+    UNAUTHORIZED_INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, 40104, "패스워드가 잘못되었습니다."),
 
     //403
     FORBIDDEN(HttpStatus.FORBIDDEN, 40300, "권한이 없습니다."),

--- a/src/main/java/com/greedy/mokkoji/util/PasswordDecoder.java
+++ b/src/main/java/com/greedy/mokkoji/util/PasswordDecoder.java
@@ -1,0 +1,35 @@
+package com.greedy.mokkoji.util;
+
+import com.greedy.mokkoji.common.exception.MokkojiException;
+import com.greedy.mokkoji.enums.message.FailMessage;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PasswordDecoder {
+
+    @Value("${aes.secret-key}")
+    private String secretKey;
+
+    @Value("${aes.IV}")
+    private String initVector;
+
+    public String decode(String rawPassword) {
+        try {
+            IvParameterSpec iv = new IvParameterSpec(initVector.getBytes("UTF-8"));
+            SecretKeySpec skeySpec = new SecretKeySpec(secretKey.getBytes("UTF-8"), "AES");
+
+            Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+            cipher.init(Cipher.DECRYPT_MODE, skeySpec, iv);
+
+            byte[] original = cipher.doFinal(Base64.getDecoder().decode(rawPassword));
+            return new String(original);
+        } catch (Exception e) {
+            throw new MokkojiException(FailMessage.UNAUTHORIZED_INVALID_PASSWORD);
+        }
+    }
+}


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #126 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 해당 작업은 비밀번호 -> 암호화 -> 복호화 -> 전달 플로우로 이루어져 있어서 단방향 암호화로는 불가능했습니다.
* 따라서 양방향 암호화 방법을 찾다가 보안 수준이 높다고 알려진 AES 양방향 암호화를 적용하는 게 좋을 것 같아 이를 적용했고, 테스트를 했습니다.

<img width="795" height="380" alt="image" src="https://github.com/user-attachments/assets/4ea4771e-70f4-446c-8acf-a69fc1ae27fe" />


## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
* AES 암호화에는 두 가지 값이 필요합니다. (16자리의 secretKey, 16자리의 initVetor)
* 이 두 개의 값은 yml파일에 저장했고 이를 불러왔습니다.