### PR TITLE
Fix: 댓글 조회 시 토큰이 없는 경우에도 정상 조회되도록 변경

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/auth/controller/argumentResolver/UserAuthArgumentResolver.java
+++ b/src/main/java/com/greedy/mokkoji/api/auth/controller/argumentResolver/UserAuthArgumentResolver.java
@@ -18,7 +18,7 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class UserAuthArgumentResolver implements HandlerMethodArgumentResolver {
 
-    private static final Set<String> EXCLUDE_PATTERNS = Set.of("/clubs", "/recruitments");
+    private static final Set<String> EXCLUDE_PATTERNS = Set.of("/clubs", "/recruitments", "/comments");
     private final BearerAuthExtractor bearerAuthExtractor;
     private final JwtUtil jwtUtil;
 

--- a/src/main/java/com/greedy/mokkoji/api/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/greedy/mokkoji/api/comment/dto/request/CommentCreateRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Min;
 public record CommentCreateRequest(
         @Min(0)
         @Max(5)
-        Integer rate,
+        Double rate,
         String content
 ) {
 }

--- a/src/main/java/com/greedy/mokkoji/api/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/greedy/mokkoji/api/comment/dto/request/CommentUpdateRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Min;
 public record CommentUpdateRequest(
         @Min(0)
         @Max(5)
-        Integer rate,
+        Double rate,
         String content
 ) {
 }

--- a/src/main/java/com/greedy/mokkoji/api/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/comment/dto/response/CommentResponse.java
@@ -5,12 +5,12 @@ import java.time.LocalDateTime;
 public record CommentResponse(
         Long id,
         String content,
-        Integer rate,
+        Double rate,
         boolean isModified,
         LocalDateTime time,
         boolean isWriter
 ) {
-    public static CommentResponse of(final Long id, final String content, final Integer rate, final boolean isModified, final LocalDateTime time, final boolean isWriter) {
+    public static CommentResponse of(final Long id, final String content, final Double rate, final boolean isModified, final LocalDateTime time, final boolean isWriter) {
         return new CommentResponse(id, content, rate, isModified, time, isWriter);
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/comment/service/CommentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/comment/service/CommentService.java
@@ -25,7 +25,7 @@ public class CommentService {
     private final UserRepository userRepository;
 
     @Transactional
-    public void createComment(final Long userId, final Long clubId, final Integer rate, final String content) {
+    public void createComment(final Long userId, final Long clubId, final Double rate, final String content) {
         if (userId == null) {
             throw new MokkojiException(FailMessage.UNAUTHORIZED);
         }
@@ -82,7 +82,7 @@ public class CommentService {
 
     //ToDo: 비슷한 로직이 많아 이를 리팩토링 할 예정
     @Transactional
-    public void updateComment(final Long userId, final Long commentId, final Integer rate, final String content) {
+    public void updateComment(final Long userId, final Long commentId, final Double rate, final String content) {
         if (userId == null) {
             throw new MokkojiException(FailMessage.UNAUTHORIZED);
         }

--- a/src/main/java/com/greedy/mokkoji/config/RedisConfig.java
+++ b/src/main/java/com/greedy/mokkoji/config/RedisConfig.java
@@ -3,6 +3,7 @@ package com.greedy.mokkoji.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -25,6 +26,7 @@ public class RedisConfig {
     }
 
     @Bean
+    @Primary
     public RedisTemplate<String, String> redisTemplate() {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());

--- a/src/main/java/com/greedy/mokkoji/config/WebConfig.java
+++ b/src/main/java/com/greedy/mokkoji/config/WebConfig.java
@@ -17,7 +17,7 @@ import java.util.Set;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    private final Set<String> excludedPaths = Set.of("/users/auth/login", "/users/auth/refresh", "/clubs/**", "/test/health-check/**", "/recruitments/**", "/kakao/**");
+    private final Set<String> excludedPaths = Set.of("/users/auth/login", "/users/auth/refresh", "/clubs/**", "/test/health-check/**", "/recruitments/**", "/comments/**");
 
     private final JwtAuthInterceptor jwtAuthInterceptor;
     private final UserAuthArgumentResolver userAuthArgumentResolver;

--- a/src/main/java/com/greedy/mokkoji/db/comment/entity/Comment.java
+++ b/src/main/java/com/greedy/mokkoji/db/comment/entity/Comment.java
@@ -21,7 +21,7 @@ public class Comment extends BaseTime {
     private Long id;
 
     @Column(name = "rate", columnDefinition = "double", nullable = false)
-    private Integer rate;
+    private Double rate;
 
     @Column(name = "content", columnDefinition = "text", nullable = false)
     private String content;
@@ -35,14 +35,14 @@ public class Comment extends BaseTime {
     private User user;
 
     @Builder
-    public Comment(final Integer rate, final String content, final Club club, final User user) {
+    public Comment(final Double rate, final String content, final Club club, final User user) {
         this.rate = rate;
         this.content = content;
         this.club = club;
         this.user = user;
     }
 
-    public void updateComment(final Integer rate, final String content) {
+    public void updateComment(final Double rate, final String content) {
         this.rate = rate;
         this.content = content;
     }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #143 

## 👷 **작업한 내용**
댓글 조회 시, 토큰이 없는 경우도 정상 조회가 되어야 합니다.
댓글은 사용자 모두가 볼 수 있어야 하니까요!

기존 문제: 토큰 없이 요청이 올 경우 Interceptor 및 argumentResolver에서 401 예외가 뜨는 것을 확인했습니다.
따라서, 댓글 공통 엔드포인트를 제외시켜 정상 작동하도록 해주었습니다.
공통 엔드포인트를 제외시켜서, 토큰이 필요한 post/patch/delete 요청은 사용자 정보가 확인이 안 되는 거 아닌가? 하는 생각이 들 수 있습니다. 
하지만, RegumentResolver에서 정상적으로 처리하는 것을 확인하실 수 있으며, 해당 api 검증까지 완료했습니다.

## 🚨 **참고 사항**
이는 2차 스프린트로 새롭게 구현한 api라 테스트 코드 작성이 필요합니다!
