### PR TITLE
fix: 모집글이 없거나 여러개인 경우 오류 발생 해결

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubResponse.java
@@ -34,8 +34,8 @@ public record ClubResponse(
                 .category(category)
                 .affiliation(affiliation)
                 .description(description)
-                .recruitStartDate(recruitStartDate.format(DateTimeFormatter.ISO_LOCAL_DATE))
-                .recruitEndDate(recruitEndDate.format(DateTimeFormatter.ISO_LOCAL_DATE))
+                .recruitStartDate(recruitStartDate != null ? recruitStartDate.format(DateTimeFormatter.ISO_LOCAL_DATE) : null)
+                .recruitEndDate(recruitEndDate != null ? recruitEndDate.format(DateTimeFormatter.ISO_LOCAL_DATE) : null)
                 .logo(logo)
                 .isFavorite(isFavorite)
                 .build();

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -42,7 +42,9 @@ public class ClubService {
 
         final Club club = clubRepository.findById(clubId)
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB));
-        final Recruitment recruitment = recruitmentRepository.findByClubId(club.getId());
+        final Recruitment recruitment = recruitmentRepository
+            .findTopByClubIdOrderByRecruitStartDesc(club.getId())
+            .orElse(null);
         final Boolean isFavorite = getIsFavorite(userId, clubId);
 
         return mapToClubDetailResponse(club, recruitment, isFavorite);
@@ -130,27 +132,28 @@ public class ClubService {
                 club.getClubCategory().getDescription(),
                 club.getClubAffiliation().getDescription(),
                 club.getDescription(),
-                recruitment.getRecruitStart(),
-                recruitment.getRecruitEnd(),
+                recruitment != null ? recruitment.getRecruitStart() : null,
+                recruitment != null ? recruitment.getRecruitEnd() : null,
                 appDataS3Client.getPresignedUrl(club.getLogo()),
                 isFavorite,
                 club.getInstagram(),
-                recruitment.getContent()
+                recruitment != null ? recruitment.getContent() : null
         );
     }
 
     private List<ClubResponse> mapToClubResponses(final Long userId, final List<Club> clubs) {
         return clubs.stream()
                 .map(club -> {
-                    Recruitment recruitment = recruitmentRepository.findByClubId(club.getId());
+                    Recruitment recruitment = recruitmentRepository.findTopByClubIdOrderByRecruitStartDesc(club.getId())
+                        .orElse(null);
                     boolean isFavorite = getIsFavorite(userId, club.getId());
                     return ClubResponse.of(club.getId(),
                             club.getName(),
                             club.getClubCategory().getDescription(),
                             club.getClubAffiliation().getDescription(),
                             club.getDescription(),
-                            recruitment.getRecruitStart(),
-                            recruitment.getRecruitEnd(),
+                            recruitment != null ? recruitment.getRecruitStart() : null,
+                            recruitment != null ? recruitment.getRecruitEnd() : null,
                             appDataS3Client.getPresignedUrl(club.getLogo()),
                             isFavorite);
                 })

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepository.java
@@ -31,4 +31,6 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
     List<Recruitment> findAllByClubId(final Long id);
 
     List<Recruitment> findByClubIdIn(List<Long> clubIds);
+
+    Optional<Recruitment> findTopByClubIdOrderByRecruitStartDesc(Long clubId);
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #158 

## 👷 **작업한 내용**
모집글이 없거나 여러 개인 경우 에러가 발생했습니다.
이는 싱크가 맞지 않아 서로 다른 컨텍스트를 이해하고 있어서 생긴 문제였습니다.
앞으로 커뮤니케이션이 더 필요할 듯 싶습니다!

recruitment를 모두 조회하고 그 중 모집 시작일을 기준으로 제일 최신 모집글을 불러왔습니다.
해당 동아리의 recruitment가 없는 경우, null을 반환합니다.

## 🚨 **참고 사항**
