### PR TITLE
Feat: 모집 공고 동아리 소속 필터링 기능 적용

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/controller/RecruitmentController.java
@@ -12,6 +12,7 @@ import com.greedy.mokkoji.api.recruitment.dto.response.specificRecruitment.Speci
 import com.greedy.mokkoji.api.recruitment.dto.response.updateRecruitment.UpdateRecruitmentResponse;
 import com.greedy.mokkoji.api.recruitment.service.RecruitmentService;
 import com.greedy.mokkoji.common.response.APISuccessResponse;
+import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -98,13 +99,14 @@ public class RecruitmentController {
     @GetMapping
     public ResponseEntity<APISuccessResponse<AllRecruitmentResponse>> getAllRecruitment(
             @Authentication final AuthCredential authCredential,
+            @RequestParam(value = "affiliation") final ClubAffiliation affiliation,
             @RequestParam(value = "page") final int page,
             @RequestParam(value = "size") final int size
     ) {
         final Pageable pageable = PageRequest.of(page - 1, size);
         return APISuccessResponse.of(
                 HttpStatus.OK,
-                recruitmentService.getAllRecruitment(authCredential.userId(), pageable)
+                recruitmentService.getAllRecruitment(authCredential.userId(), affiliation, pageable)
         );
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -21,6 +21,7 @@ import com.greedy.mokkoji.db.recruitment.repository.RecruitmentImageRepository;
 import com.greedy.mokkoji.db.recruitment.repository.RecruitmentRepository;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.db.user.repository.UserRepository;
+import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.message.FailMessage;
 import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import com.greedy.mokkoji.enums.user.UserRole;
@@ -36,7 +37,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -240,10 +240,10 @@ public class RecruitmentService {
     }
 
     @Transactional
-    public AllRecruitmentResponse getAllRecruitment(final Long userId, final Pageable pageable) {
+    public AllRecruitmentResponse getAllRecruitment(final Long userId, final ClubAffiliation affiliation, final Pageable pageable) {
 
-        List<Recruitment> allRecruitments = recruitmentRepository.findAll();
-        List<Recruitment> filteredRecruitments = filterLatestRecruitmentPerClub(allRecruitments);
+        Page<Recruitment> recruitmentPage = recruitmentRepository.findRecruitments(affiliation, pageable);
+        List<Recruitment> filteredRecruitments = recruitmentPage.getContent();
 
         // 페이징 처리
         int start = (int) pageable.getOffset();
@@ -266,17 +266,6 @@ public class RecruitmentService {
         );
 
         return new AllRecruitmentResponse(recruitmentResponses, pageResponse);
-    }
-
-    private List<Recruitment> filterLatestRecruitmentPerClub(List<Recruitment> recruitments) {
-        return recruitments.stream()
-                .collect(Collectors.toMap(
-                        r -> r.getClub().getId(), r -> r,
-                        (r1, r2) -> r1.getRecruitEnd().isAfter(r2.getRecruitEnd()) ? r1 : r2
-                ))
-                .values()
-                .stream()
-                .toList();
     }
 
     private RecruitmentPreviewResponse mapToRecruitmentPreviewResponse(Long userId, Recruitment recruitment) {

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> {
+public interface RecruitmentRepository extends JpaRepository<Recruitment, Long>, RecruitmentRepositoryCustom {
     @Query("SELECT r FROM Recruitment r WHERE FUNCTION('DATE', r.recruitStart) = :currentDate")
     List<Recruitment> findAllByRecruitStartToday(LocalDate currentDate);
 

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryCustom.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.greedy.mokkoji.db.recruitment.repository;
+
+import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
+import com.greedy.mokkoji.enums.club.ClubAffiliation;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface RecruitmentRepositoryCustom {
+    Page<Recruitment> findRecruitments(
+        final ClubAffiliation affiliation,
+        final Pageable pageable
+    );
+}

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryImpl.java
@@ -1,0 +1,70 @@
+package com.greedy.mokkoji.db.recruitment.repository;
+
+import static com.greedy.mokkoji.db.club.entity.QClub.club;
+import static com.greedy.mokkoji.db.recruitment.entity.QRecruitment.recruitment;
+
+import com.greedy.mokkoji.db.recruitment.entity.QRecruitment;
+import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
+import com.greedy.mokkoji.enums.club.ClubAffiliation;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Recruitment> findRecruitments(ClubAffiliation affiliation, Pageable pageable) {
+
+        QRecruitment subRecruitment = new QRecruitment("subRecruitment");
+
+        List<Recruitment> recruitments = queryFactory.selectFrom(recruitment)
+            .join(recruitment.club, club).fetchJoin()
+            .where(
+                equalAffiliation(affiliation),
+                recruitment.recruitEnd.eq(
+                    JPAExpressions
+                        .select(subRecruitment.recruitEnd.max())
+                        .from(subRecruitment)
+                        .where(subRecruitment.club.id.eq(recruitment.club.id))
+                )
+            )
+            .orderBy(recruitment.recruitEnd.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(recruitment.count())
+            .from(recruitment)
+            .join(recruitment.club, club)
+            .where(
+                equalAffiliation(affiliation),
+                recruitment.recruitEnd.eq(
+                    JPAExpressions
+                        .select(subRecruitment.recruitEnd.max())
+                        .from(subRecruitment)
+                        .where(subRecruitment.club.id.eq(recruitment.club.id))
+                )
+            );
+
+        long total = Optional.ofNullable(countQuery.fetchOne()).orElse(0L);
+
+        return new PageImpl<>(recruitments, pageable, total);
+    }
+
+    private BooleanExpression equalAffiliation(ClubAffiliation affiliation) {
+        return affiliation != null ? club.clubAffiliation.eq(affiliation) : null;
+    }
+}


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #161 

## 👷 **작업한 내용**
모집 공고 전체 조회 시 동아리 소속 필터링 기능을 추가했습니다.
기존에 같은 동아리 내의 모집글이 여러개 존재하는 경우, 가장 최신 걸로 불러오는 로직 또한 QueryDSL 서브쿼리로 구현했습니다.
정렬 기능은 이미 잘 구현되어 있는 것 같아 따로 건드리지 않았습니다.
현재 변경 지점에 대한 검증은 완료했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
