### PR TITLE
Fix : 즐겨찾기한 동아리 조회 시 오류 해결

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
+++ b/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
@@ -61,7 +61,8 @@ public class FavoriteService {
         List<ClubResponse> clubResponses = favorites.stream()
                 .map(favorite -> {
                     final Club club = favorite.getClub();
-                    final Recruitment recruitment = recruitmentRepository.findByClubId(club.getId());
+                    Recruitment recruitment = recruitmentRepository.findTopByClubIdOrderByUpdatedAtDesc(club.getId())
+                            .orElse(null);
 
                     return ClubResponse.of(
                             club.getId(),
@@ -69,8 +70,8 @@ public class FavoriteService {
                             club.getClubCategory().getDescription(),
                             club.getClubAffiliation().getDescription(),
                             club.getDescription(),
-                            recruitment.getRecruitStart(),
-                            recruitment.getRecruitEnd(),
+                            recruitment != null ? recruitment.getRecruitStart() : null,
+                            recruitment != null ? recruitment.getRecruitEnd() : null,
                             appDataS3Client.getPresignedUrl(club.getLogo()),
                             true
                     );


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #186

## 👷 **작업한 내용**
모집글이 여러개인 즐겨찾기 동아리 조회 시 나는 오류 해결
-> 즐겨찾기한 동아리 로직에 모집글 조회 로직이 포함되어 있었음(club 조회 시와 똑같이 해결)

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
