### PR TITLE
Fix : 모집공고 전체 조회 시 최근 모집글로 업데이트 안 되는 문제 해결

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/external/sejong/SejongLoginRestClient.java
+++ b/src/main/java/com/greedy/mokkoji/api/external/sejong/SejongLoginRestClient.java
@@ -3,8 +3,6 @@ package com.greedy.mokkoji.api.external.sejong;
 import com.greedy.mokkoji.api.user.dto.resopnse.StudentInformationResponse;
 import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.enums.message.FailMessage;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -17,6 +15,9 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 public class SejongLoginRestClient {

--- a/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
+++ b/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
@@ -61,7 +61,8 @@ public class FavoriteService {
         List<ClubResponse> clubResponses = favorites.stream()
                 .map(favorite -> {
                     final Club club = favorite.getClub();
-                    final Recruitment recruitment = recruitmentRepository.findByClubId(club.getId());
+                    Recruitment recruitment = recruitmentRepository.findTopByClubIdOrderByUpdatedAtDesc(club.getId())
+                            .orElse(null);
 
                     return ClubResponse.of(
                             club.getId(),
@@ -69,8 +70,8 @@ public class FavoriteService {
                             club.getClubCategory().getDescription(),
                             club.getClubAffiliation().getDescription(),
                             club.getDescription(),
-                            recruitment.getRecruitStart(),
-                            recruitment.getRecruitEnd(),
+                            recruitment != null ? recruitment.getRecruitStart() : null,
+                            recruitment != null ? recruitment.getRecruitEnd() : null,
                             appDataS3Client.getPresignedUrl(club.getLogo()),
                             true
                     );

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -12,11 +12,12 @@ import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.db.user.repository.UserRepository;
 import com.greedy.mokkoji.enums.message.FailMessage;
 import com.greedy.mokkoji.enums.user.UserRole;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryImpl.java
@@ -33,14 +33,14 @@ public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom {
                 .join(recruitment.club, club).fetchJoin()
                 .where(
                         equalAffiliation(affiliation),
-                        recruitment.recruitEnd.eq(
+                        recruitment.updatedAt.eq(
                                 JPAExpressions
-                                        .select(subRecruitment.recruitEnd.max())
+                                        .select(subRecruitment.updatedAt.max())
                                         .from(subRecruitment)
                                         .where(subRecruitment.club.id.eq(recruitment.club.id))
                         )
                 )
-                .orderBy(recruitment.recruitEnd.desc())
+                .orderBy(recruitment.updatedAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -51,9 +51,9 @@ public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom {
                 .join(recruitment.club, club)
                 .where(
                         equalAffiliation(affiliation),
-                        recruitment.recruitEnd.eq(
+                        recruitment.updatedAt.eq(
                                 JPAExpressions
-                                        .select(subRecruitment.recruitEnd.max())
+                                        .select(subRecruitment.updatedAt.max())
                                         .from(subRecruitment)
                                         .where(subRecruitment.club.id.eq(recruitment.club.id))
                         )

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryImpl.java
@@ -1,4 +1,5 @@
 package com.greedy.mokkoji.db.recruitment.repository;
+
 import com.greedy.mokkoji.db.recruitment.entity.QRecruitment;
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #193

## 👷 **작업한 내용**
모집공고 전체 조회 시 updateAt으로 최근 공고만 불러오게 수정

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
