### PR TITLE
Fix: 동아리 모집 공고 조회 시 카테고리 별 조회 가능

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/controller/RecruitmentController.java
@@ -13,12 +13,21 @@ import com.greedy.mokkoji.api.recruitment.dto.response.updateRecruitment.UpdateR
 import com.greedy.mokkoji.api.recruitment.service.RecruitmentService;
 import com.greedy.mokkoji.common.response.APISuccessResponse;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
+import com.greedy.mokkoji.enums.club.ClubCategory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -71,7 +80,8 @@ public class RecruitmentController {
             @Authentication final AuthCredential authCredential,
             @PathVariable("recruitmentId") final Long recruitmentId
     ) {
-        DeleteRecruitmentResponse response = recruitmentService.deleteRecruitment(authCredential.userId(), recruitmentId);
+        DeleteRecruitmentResponse response = recruitmentService.deleteRecruitment(authCredential.userId(),
+                recruitmentId);
         return APISuccessResponse.of(HttpStatus.OK, response);
     }
 
@@ -101,13 +111,14 @@ public class RecruitmentController {
     public ResponseEntity<APISuccessResponse<AllRecruitmentResponse>> getAllRecruitment(
             @Authentication final AuthCredential authCredential,
             @RequestParam(value = "affiliation", required = false) final ClubAffiliation affiliation,
+            @RequestParam(value = "category", required = false) final ClubCategory category,
             @RequestParam(value = "page") final int page,
             @RequestParam(value = "size") final int size
     ) {
         final Pageable pageable = PageRequest.of(page - 1, size);
         return APISuccessResponse.of(
                 HttpStatus.OK,
-                recruitmentService.getAllRecruitment(authCredential.userId(), affiliation, pageable)
+                recruitmentService.getAllRecruitment(authCredential.userId(), affiliation, category, pageable)
         );
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -22,6 +22,7 @@ import com.greedy.mokkoji.db.recruitment.repository.RecruitmentRepository;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.db.user.repository.UserRepository;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
+import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.message.FailMessage;
 import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import com.greedy.mokkoji.enums.user.UserRole;
@@ -50,19 +51,19 @@ public class RecruitmentService {
 
     @Transactional
     public CreateRecruitmentResponse createRecruitment(
-        final Long userId,
-        final Long clubId,
-        final String title,
-        final String content,
-        final LocalDateTime recruitStart,
-        final LocalDateTime recruitEnd,
-        final List<String> images,
-        final String recruitForm) {
+            final Long userId,
+            final Long clubId,
+            final String title,
+            final String content,
+            final LocalDateTime recruitStart,
+            final LocalDateTime recruitEnd,
+            final List<String> images,
+            final String recruitForm) {
 
         validateAdmin(userId);
 
         Club club = clubRepository.findById(clubId)
-            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB));
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB));
 
         Recruitment recruitment = buildAndSaveRecruitment(club, title, content, recruitStart, recruitEnd, recruitForm);
         List<String> uploadImageUrls = uploadRecruitmentImages(recruitment, images);
@@ -72,19 +73,19 @@ public class RecruitmentService {
 
     @Transactional
     public UpdateRecruitmentResponse updateRecruitment(
-        final Long userId,
-        final Long recruitmentId,
-        final String title,
-        final String content,
-        final LocalDateTime recruitStart,
-        final LocalDateTime recruitEnd,
-        final List<String> newImages,
-        final String recruitForm
+            final Long userId,
+            final Long recruitmentId,
+            final String title,
+            final String content,
+            final LocalDateTime recruitStart,
+            final LocalDateTime recruitEnd,
+            final List<String> newImages,
+            final String recruitForm
     ) {
         validateAdmin(userId);
 
         Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
-            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUNT_RECRUITMENT));
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUNT_RECRUITMENT));
 
         recruitment.updateRecruitment(title, content, recruitStart, recruitEnd, recruitForm);
 
@@ -100,7 +101,7 @@ public class RecruitmentService {
         validateAdmin(userId);
 
         Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
-            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUNT_RECRUITMENT));
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUNT_RECRUITMENT));
 
         List<String> deleteImageUrls = deleteImages(recruitmentId);
         recruitmentRepository.delete(recruitment);
@@ -113,19 +114,19 @@ public class RecruitmentService {
         List<Recruitment> recruitments = recruitmentRepository.findAllByClubId(clubId);
 
         List<RecruitmentOfClubResponse> recruitmentList = recruitments.stream()
-            .sorted(Comparator.comparing(Recruitment::getRecruitEnd).reversed())
-            .map(recruitment -> RecruitmentOfClubResponse.builder()
-                .id(recruitment.getId())
-                .title(recruitment.getTitle())
-                .content(recruitment.getContent())
-                .recruitStart(recruitment.getRecruitStart())
-                .recruitEnd(recruitment.getRecruitEnd())
-                .status(RecruitStatus.from(recruitment.getRecruitStart(), recruitment.getRecruitEnd()))
-                .createdAt(recruitment.getCreatedAt())
-                .firstImage(getFirstImageUrl(recruitment.getId()))
-                .build()
-            )
-            .toList();
+                .sorted(Comparator.comparing(Recruitment::getRecruitEnd).reversed())
+                .map(recruitment -> RecruitmentOfClubResponse.builder()
+                        .id(recruitment.getId())
+                        .title(recruitment.getTitle())
+                        .content(recruitment.getContent())
+                        .recruitStart(recruitment.getRecruitStart())
+                        .recruitEnd(recruitment.getRecruitEnd())
+                        .status(RecruitStatus.from(recruitment.getRecruitStart(), recruitment.getRecruitEnd()))
+                        .createdAt(recruitment.getCreatedAt())
+                        .firstImage(getFirstImageUrl(recruitment.getId()))
+                        .build()
+                )
+                .toList();
 
         return AllRecruitmentOfClubResponse.of(recruitmentList);
     }
@@ -133,40 +134,41 @@ public class RecruitmentService {
     @Transactional
     public SpecificRecruitmentResponse getSpecificRecruitment(final Long userId, final Long recruitmentId) {
         Recruitment recruitment = recruitmentRepository.findRecruitmentById(recruitmentId)
-            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUNT_RECRUITMENT));
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUNT_RECRUITMENT));
 
         List<RecruitmentImage> recruitmentImages = recruitmentImageRepository.findByRecruitmentIdOrderByIdAsc(
-            recruitmentId);
+                recruitmentId);
 
         List<String> imageUrls = recruitmentImages.stream()
-            .map(image -> appDataS3Client.getPresignedUrl(image.getImage()))
-            .toList();
+                .map(image -> appDataS3Client.getPresignedUrl(image.getImage()))
+                .toList();
 
         Club club = recruitment.getClub();
 
         return SpecificRecruitmentResponse.of(
-            recruitment.getId(),
-            recruitment.getTitle(),
-            club.getName(),
-            club.getId(),
-            recruitment.getContent(),
-            recruitment.getRecruitStart(),
-            recruitment.getRecruitEnd(),
-            RecruitStatus.from(recruitment.getRecruitStart(), recruitment.getRecruitEnd()),
-            recruitment.getCreatedAt(),
-            imageUrls,
-            recruitment.getRecruitForm(),
-            isFavorite(userId, club.getId()),
-            club.getInstagram(),
-            club.getClubCategory().getDescription()
+                recruitment.getId(),
+                recruitment.getTitle(),
+                club.getName(),
+                club.getId(),
+                recruitment.getContent(),
+                recruitment.getRecruitStart(),
+                recruitment.getRecruitEnd(),
+                RecruitStatus.from(recruitment.getRecruitStart(), recruitment.getRecruitEnd()),
+                recruitment.getCreatedAt(),
+                imageUrls,
+                recruitment.getRecruitForm(),
+                isFavorite(userId, club.getId()),
+                club.getInstagram(),
+                club.getClubCategory().getDescription()
         );
     }
 
     @Transactional
     public AllRecruitmentResponse getAllRecruitment(final Long userId, final ClubAffiliation affiliation,
-        final Pageable pageable) {
+                                                    final ClubCategory category,
+                                                    final Pageable pageable) {
 
-        Page<Recruitment> recruitmentPage = recruitmentRepository.findRecruitments(affiliation, pageable);
+        Page<Recruitment> recruitmentPage = recruitmentRepository.findRecruitments(affiliation, category, pageable);
         List<Recruitment> filteredRecruitments = recruitmentPage.getContent();
 
         // 페이징 처리
@@ -177,16 +179,16 @@ public class RecruitmentService {
 
         // DTO 변환 및 정렬
         List<RecruitmentPreviewResponse> recruitmentResponses = paged.stream()
-            .map(recruitment -> mapToRecruitmentPreviewResponse(userId, recruitment))
-            .sorted(getFinalComparator(userId))
-            .toList();
+                .map(recruitment -> mapToRecruitmentPreviewResponse(userId, recruitment))
+                .sorted(getFinalComparator(userId))
+                .toList();
 
         // 페이징 정보 생성
         PageResponse pageResponse = PageResponse.of(
-            paged.getNumber() + 1,
-            paged.getSize(),
-            paged.getTotalPages(),
-            (int) paged.getTotalElements()
+                paged.getNumber() + 1,
+                paged.getSize(),
+                paged.getTotalPages(),
+                (int) paged.getTotalElements()
         );
 
         return new AllRecruitmentResponse(recruitmentResponses, pageResponse);
@@ -198,7 +200,7 @@ public class RecruitmentService {
         }
 
         User user = userRepository.findById(userId)
-            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
 
         //Todo: 권한 설정에 대해서 추가적으로 이야기 해보기
         if (user.getRole().equals(UserRole.NORMAL)) {
@@ -207,15 +209,16 @@ public class RecruitmentService {
     }
 
     private Recruitment buildAndSaveRecruitment(Club club, String title, String content,
-        LocalDateTime recruitStart, LocalDateTime recruitEnd, String recruitForm) {
+                                                LocalDateTime recruitStart, LocalDateTime recruitEnd,
+                                                String recruitForm) {
         Recruitment recruitment = Recruitment.builder()
-            .club(club)
-            .title(title)
-            .content(content)
-            .recruitStart(recruitStart)
-            .recruitEnd(recruitEnd)
-            .recruitForm(recruitForm)
-            .build();
+                .club(club)
+                .title(title)
+                .content(content)
+                .recruitStart(recruitStart)
+                .recruitEnd(recruitEnd)
+                .recruitForm(recruitForm)
+                .build();
 
         recruitmentRepository.save(recruitment);
         return recruitment;
@@ -229,19 +232,19 @@ public class RecruitmentService {
             String clubName = recruitment.getClub().getName().replaceAll("\\s+", "-").toLowerCase();
 
             List<RecruitmentImage> recruitmentImages = imageKeys.stream()
-                .map(originalName -> {
-                    String extension = extractExtension(originalName);
-                    String uniqueKey = "recruitment/" + clubName + "/" + UUID.randomUUID() + extension;
+                    .map(originalName -> {
+                        String extension = extractExtension(originalName);
+                        String uniqueKey = "recruitment/" + clubName + "/" + UUID.randomUUID() + extension;
 
-                    String presignedPutUrl = appDataS3Client.getPresignedPutUrl(uniqueKey);
-                    imageUrls.add(presignedPutUrl);
+                        String presignedPutUrl = appDataS3Client.getPresignedPutUrl(uniqueKey);
+                        imageUrls.add(presignedPutUrl);
 
-                    return RecruitmentImage.builder()
-                        .recruitment(recruitment)
-                        .image(uniqueKey)
-                        .build();
-                })
-                .toList();
+                        return RecruitmentImage.builder()
+                                .recruitment(recruitment)
+                                .image(uniqueKey)
+                                .build();
+                    })
+                    .toList();
 
             recruitmentImageRepository.saveAll(recruitmentImages);
         }
@@ -252,8 +255,8 @@ public class RecruitmentService {
         List<RecruitmentImage> oldImages = recruitmentImageRepository.findByRecruitmentId(recruitmentId);
 
         List<String> deleteImageUrls = oldImages.stream()
-            .map(image -> appDataS3Client.getPresignedDeleteUrl(image.getImage()))
-            .toList();
+                .map(image -> appDataS3Client.getPresignedDeleteUrl(image.getImage()))
+                .toList();
 
         recruitmentImageRepository.deleteAll(oldImages);
 
@@ -270,9 +273,9 @@ public class RecruitmentService {
 
     private String getFirstImageUrl(Long recruitmentId) {
         return recruitmentImageRepository.findByRecruitmentIdOrderByIdAsc(recruitmentId).stream()
-            .findFirst()
-            .map(image -> appDataS3Client.getPresignedUrl(image.getImage()))
-            .orElse(null);
+                .findFirst()
+                .map(image -> appDataS3Client.getPresignedUrl(image.getImage()))
+                .orElse(null);
     }
 
     private boolean isFavorite(final Long userId, final Long clubId) {
@@ -286,36 +289,36 @@ public class RecruitmentService {
         boolean isFavorite = isFavorite(userId, recruitment.getClub().getId());
 
         ClubPreviewResponse clubPreview = new ClubPreviewResponse(
-            recruitment.getClub().getId(),
-            recruitment.getClub().getName(),
-            recruitment.getClub().getDescription(),
-            recruitment.getClub().getClubCategory(),
-            recruitment.getClub().getClubAffiliation(),
-            appDataS3Client.getPresignedUrl(recruitment.getClub().getLogo())
+                recruitment.getClub().getId(),
+                recruitment.getClub().getName(),
+                recruitment.getClub().getDescription(),
+                recruitment.getClub().getClubCategory(),
+                recruitment.getClub().getClubAffiliation(),
+                appDataS3Client.getPresignedUrl(recruitment.getClub().getLogo())
         );
 
         return new RecruitmentPreviewResponse(
-            clubPreview,
-            recruitment.getId(),
-            recruitment.getTitle(),
-            recruitment.getRecruitStart(),
-            recruitment.getRecruitEnd(),
-            RecruitStatus.from(recruitment.getRecruitStart(), recruitment.getRecruitEnd()),
-            isFavorite
+                clubPreview,
+                recruitment.getId(),
+                recruitment.getTitle(),
+                recruitment.getRecruitStart(),
+                recruitment.getRecruitEnd(),
+                RecruitStatus.from(recruitment.getRecruitStart(), recruitment.getRecruitEnd()),
+                isFavorite
         );
     }
 
     // 즐겨찾기 여부 → 모집 상태 → 마감일 순으로 정렬하는 Comparator 생성
     private Comparator<RecruitmentPreviewResponse> getFinalComparator(Long userId) {
         Comparator<RecruitmentPreviewResponse> comparator =
-            Comparator.comparing(
-                (RecruitmentPreviewResponse r) ->
-                    RecruitStatus.from(r.recruitStart(), r.recruitEnd()).getPriority()
-            ).thenComparing(RecruitmentPreviewResponse::recruitEnd);
+                Comparator.comparing(
+                        (RecruitmentPreviewResponse r) ->
+                                RecruitStatus.from(r.recruitStart(), r.recruitEnd()).getPriority()
+                ).thenComparing(RecruitmentPreviewResponse::recruitEnd);
 
         if (userId != null) {
             comparator = Comparator.comparing(RecruitmentPreviewResponse::isFavorite).reversed()
-                .thenComparing(comparator);
+                    .thenComparing(comparator);
         }
 
         return comparator;

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryCustom.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryCustom.java
@@ -2,12 +2,14 @@ package com.greedy.mokkoji.db.recruitment.repository;
 
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
+import com.greedy.mokkoji.enums.club.ClubCategory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface RecruitmentRepositoryCustom {
     Page<Recruitment> findRecruitments(
             final ClubAffiliation affiliation,
+            final ClubCategory category,
             final Pageable pageable
     );
 }

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryImpl.java
@@ -1,23 +1,23 @@
 package com.greedy.mokkoji.db.recruitment.repository;
 
+import static com.greedy.mokkoji.db.club.entity.QClub.club;
+import static com.greedy.mokkoji.db.recruitment.entity.QRecruitment.recruitment;
+
 import com.greedy.mokkoji.db.recruitment.entity.QRecruitment;
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
+import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
-import java.util.Optional;
-
-import static com.greedy.mokkoji.db.club.entity.QClub.club;
-import static com.greedy.mokkoji.db.recruitment.entity.QRecruitment.recruitment;
 
 @Repository
 @RequiredArgsConstructor
@@ -26,7 +26,7 @@ public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Recruitment> findRecruitments(ClubAffiliation affiliation, Pageable pageable) {
+    public Page<Recruitment> findRecruitments(ClubAffiliation affiliation, ClubCategory category, Pageable pageable) {
 
         QRecruitment subRecruitment = new QRecruitment("subRecruitment");
 
@@ -34,6 +34,7 @@ public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom {
                 .join(recruitment.club, club).fetchJoin()
                 .where(
                         equalAffiliation(affiliation),
+                        equalCategory(category),
                         recruitment.updatedAt.eq(
                                 JPAExpressions
                                         .select(subRecruitment.updatedAt.max())
@@ -67,5 +68,9 @@ public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom {
 
     private BooleanExpression equalAffiliation(ClubAffiliation affiliation) {
         return affiliation != null ? club.clubAffiliation.eq(affiliation) : null;
+    }
+
+    private BooleanExpression equalCategory(ClubCategory category) {
+        return category != null ? club.clubCategory.eq(category) : null;
     }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #199 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 동아리 모집 공고 조회 시 카테고리 필터링이 되도록 설정했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
