### PR TITLE
Fix: 모집글 이미지 키 변환 로직 삭제

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -228,20 +228,14 @@ public class RecruitmentService {
         List<String> imageUrls = new ArrayList<>();
 
         if (imageKeys != null && !imageKeys.isEmpty()) {
-            //ex) "Greedy Club" -> "greedy-club"
-            String clubName = recruitment.getClub().getName().replaceAll("\\s+", "-").toLowerCase();
-
             List<RecruitmentImage> recruitmentImages = imageKeys.stream()
-                    .map(originalName -> {
-                        String extension = extractExtension(originalName);
-                        String uniqueKey = "recruitment/" + clubName + "/" + UUID.randomUUID() + extension;
-
-                        String presignedPutUrl = appDataS3Client.getPresignedPutUrl(uniqueKey);
+                    .map(imageKey -> {
+                        String presignedPutUrl = appDataS3Client.getPresignedPutUrl(imageKey);
                         imageUrls.add(presignedPutUrl);
 
                         return RecruitmentImage.builder()
                                 .recruitment(recruitment)
-                                .image(uniqueKey)
+                                .image(imageKey)
                                 .build();
                     })
                     .toList();


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #201 

## 👷 **작업한 내용**
모집글 이미지 키 변환 로직을 삭제했습니다. 
프론트 측에서 변환 후 백엔드로 보내줍니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
