### PR TITLE
Fix: 모집 공고 상세 조회 시 응답값에 동아리 로고 추가

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/specificRecruitment/SpecificRecruitmentResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/specificRecruitment/SpecificRecruitmentResponse.java
@@ -8,6 +8,7 @@ public record SpecificRecruitmentResponse(
     Long id,
     String title,
     String clubName,
+    String clubLogo,
     Long clubId,
     String content,
     LocalDateTime recruitStart,
@@ -25,6 +26,7 @@ public record SpecificRecruitmentResponse(
         Long id,
         String title,
         String clubName,
+        String clubLogo,
         Long clubId,
         String content,
         LocalDateTime recruitStart,
@@ -38,7 +40,7 @@ public record SpecificRecruitmentResponse(
         String category
     ) {
         return new SpecificRecruitmentResponse(
-            id, title, clubName, clubId, content, recruitStart, recruitEnd,
+            id, title, clubName, clubLogo, clubId, content, recruitStart, recruitEnd,
             status, createdAt, imageUrls, recruitForm,
             isFavorite, instagramUrl, category
         );

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -149,6 +149,7 @@ public class RecruitmentService {
                 recruitment.getId(),
                 recruitment.getTitle(),
                 club.getName(),
+                appDataS3Client.getPresignedUrl(club.getLogo()),
                 club.getId(),
                 recruitment.getContent(),
                 recruitment.getRecruitStart(),


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #205 

## 👷 **작업한 내용**
모집 공고 상세 조회 시 응답값에 동아리 로고를 추가하여 동아리 이미지를 보여줍니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
