### PR TITLE
Fix: S3 접근할 수 있는 presignedUrl 만료 시간 완화

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
+++ b/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
@@ -33,7 +33,7 @@ public class AppDataS3Client {
                 .build();
 
         final GetObjectPresignRequest getObjectPresignRequest = GetObjectPresignRequest.builder()
-                .signatureDuration(Duration.ofMinutes(5)) // 5분간 접근 허용
+                .signatureDuration(Duration.ofMinutes(15)) // 15분간 접근 허용
                 .getObjectRequest(getObjectRequest)
                 .build();
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #207 

## 👷 **작업한 내용**
프론트에서 캐싱 시간이 짧아, 사진 데이터 불러오는 속도가 느린 문제가 있습니다.
따라서, presignedUrl 만료 시간을 완화하여 캐싱 시간을 늘려주어 해당 문제를 해결하고자 합니다.
다른 방안이 있다면 알려주세요!

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
