### PR TITLE
Feat: 동아리 상세 조회 응답값에 모집 공고 ID 필드 추가

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubDetailResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubDetailResponse.java
@@ -12,6 +12,7 @@ public record ClubDetailResponse(
         String category,
         String affiliation,
         String description,
+        Long recruitmentId,
         String recruitStartDate,
         String recruitEndDate,
         String logo,
@@ -25,6 +26,7 @@ public record ClubDetailResponse(
             final String category,
             final String affiliation,
             final String description,
+            final Long recruitmentId,
             final LocalDateTime recruitStartDate,
             final LocalDateTime recruitEndDate,
             final String logo,
@@ -39,6 +41,7 @@ public record ClubDetailResponse(
                 .category(category)
                 .affiliation(affiliation)
                 .description(description)
+                .recruitmentId(recruitmentId)
                 .recruitStartDate(recruitStartDate != null ? recruitStartDate.format(DateTimeFormatter.ISO_LOCAL_DATE) : null)
                 .recruitEndDate(recruitEndDate != null ? recruitEndDate.format(DateTimeFormatter.ISO_LOCAL_DATE) : null)
                 .logo(logo)

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -133,6 +133,7 @@ public class ClubService {
                 club.getClubCategory().getDescription(),
                 club.getClubAffiliation().getDescription(),
                 club.getDescription(),
+                recruitment != null ? recruitment.getId() : null,
                 recruitment != null ? recruitment.getRecruitStart() : null,
                 recruitment != null ? recruitment.getRecruitEnd() : null,
                 appDataS3Client.getPresignedUrl(club.getLogo()),


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #215 

## 문제 상황
사용자 활동 분석 결과, 사용자들 대다수가 에브리타임으로 유입이 됩니다. 즉 모바일 환경이 대다수입니다.

---
<웹 환경>
<img width="1580" height="124" alt="스크린샷 2025-08-23 오후 11 49 30" src="https://github.com/user-attachments/assets/8976ac03-c5fe-4241-8912-797ecd8cd13f" />

위 사진과 같이, 웹 환경에서는 페이지 분류가 바 형태로 되어 있어 사용자가 메인 페이지 이외에도 다른 페이지를 쉽게 접근할 수 있습니다.

---
<모바일 환경>
<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/b96f8a89-08f5-4199-adaa-7a2bad9d9dc8" />

하지만, 모바일에서는 메뉴 버튼을 눌러야만 메인 페이지 이외의 다른 페이지들에 접근할 수 있습니다.
사용자 활동 분석을 해봤을 때, 대다수의 사용자는 메인페이지에서 **동아리 검색 및 키워드 검색만 하고 이탈하는 경우**가 많습니다.
메인페이지에서 검색 및 카테고리 필터링이 적용될 경우, 사용자는 동아리 소개 페이지를 보게 됩니다.
여기서 문제는 각 동아리의 한 줄 소개에서는 유의미한 동아리 정보를 얻을 수 없다는 점입니다.
이에 따라, 어떻게 하면 사용자가 유입이 되었을 때 유의미한 동아리 정보를 함께 제공할 수 있을까 생각해보았습니다.

- 저희 모꼬지 서비스의 핵심이라고 말할 수 있는 "**모집 공고**" 페이지를 함께 노출 시키는 방안은 어떨까요?
이는 지난 스프린트 회의 때 나왔던 기획 중 하나입니다.

예상 시나리오를 적어보겠습니다.

> 1. 사용자가 모바일로 접속한다.
> 2. 원하는 동아리를 검색하거나 키워드를 검색한다. 혹은 카테고리 필터링 기능을 사용하여 정보를 검색한다.
> 3. 원하는 동아리를 클릭하여 동아리 상세 페이지에 접근한다.
> 4. 동아리 소개와, 동아리와 관련된 모집 공고를 볼 수 있다.
> - 기존에는 동아리 소개만 노출되었습니다.

<img width="377" height="727" alt="image" src="https://github.com/user-attachments/assets/a90fffbc-a66b-47ea-b8b2-0147e604b88e" />

위 사진은 예시 사진입니다.
현재 프론트 한 분과 의견을 나눈 상태이며, 논의 사항을 공유드립니다.

---
제가 생각하는 현재 방식의 장단점은 다음과 같습니다.

<장점>
사용자에게 동아리 소개와 모집 공고 정보를 한 번에 제공함으로써, 모바일로 유입이 되었을 때 유의미한 정보를 제공할 수 있습니다.
사용자 경험을 개선할 수 있습니다.

<단점>
모집 공고 페이지가 따로 존재하기 때문에,, 뭔가 사용자에게 더 혼란을 줄 수 있지 않을까 합니다. 
추후 논의를 거쳐 전체 동아리 페이지와 모집 공고 페이지를 하나로 통합하는 방안도 괜찮을 것 같습니다.

의견 주시면 감사하겠습니다~!

## 👷 **작업한 내용**
앞서 언급드린 문제 사항을 해결 하기 위해, 동아리 상세 페이지 응답값에 가장 최신 모집 공고 ID를 반환하도록 하였습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
