### PR TITLE
Fix : 동아리장 변경 시 동아리장 role을 바꿔주기

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/auth/controller/argumentResolver/UserAuthArgumentResolver.java
+++ b/src/main/java/com/greedy/mokkoji/api/auth/controller/argumentResolver/UserAuthArgumentResolver.java
@@ -32,10 +32,10 @@ public class UserAuthArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public Object resolveArgument(
-        final MethodParameter parameter,
-        final ModelAndViewContainer mavContainer,
-        final NativeWebRequest webRequest,
-        final WebDataBinderFactory binderFactory
+            final MethodParameter parameter,
+            final ModelAndViewContainer mavContainer,
+            final NativeWebRequest webRequest,
+            final WebDataBinderFactory binderFactory
     ) throws Exception {
         final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         final String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -109,7 +109,9 @@ public class ClubService {
         String oldLogoKey = club.getLogo();
         String newLogoKey = extractNewLogoKey(logo);
 
-        if (clubMasterStudentId != null) changeClubMasterRole(club.getClubMasterStudentId(), clubMasterStudentId);
+        if (clubMasterStudentId != null) {
+            changeClubMasterRole(club.getClubMasterStudentId(), clubMasterStudentId);
+        }
 
         club.updateIfPresent(name, category, affiliation, description, clubMasterStudentId, logo, instagram);
 

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/controller/RecruitmentController.java
@@ -19,15 +19,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/specificRecruitment/SpecificRecruitmentResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/specificRecruitment/SpecificRecruitmentResponse.java
@@ -1,28 +1,11 @@
 package com.greedy.mokkoji.api.recruitment.dto.response.specificRecruitment;
 
 import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record SpecificRecruitmentResponse(
-    Long id,
-    String title,
-    String clubName,
-    String logo,
-    Long clubId,
-    String content,
-    LocalDateTime recruitStart,
-    LocalDateTime recruitEnd,
-    RecruitStatus status,
-    LocalDateTime createdAt,
-    List<String> imageUrls,
-    String recruitForm,
-    Boolean isFavorite,
-    String instagramUrl,
-    String category
-) {
-
-    public static SpecificRecruitmentResponse of(
         Long id,
         String title,
         String clubName,
@@ -38,11 +21,29 @@ public record SpecificRecruitmentResponse(
         Boolean isFavorite,
         String instagramUrl,
         String category
+) {
+
+    public static SpecificRecruitmentResponse of(
+            Long id,
+            String title,
+            String clubName,
+            String logo,
+            Long clubId,
+            String content,
+            LocalDateTime recruitStart,
+            LocalDateTime recruitEnd,
+            RecruitStatus status,
+            LocalDateTime createdAt,
+            List<String> imageUrls,
+            String recruitForm,
+            Boolean isFavorite,
+            String instagramUrl,
+            String category
     ) {
         return new SpecificRecruitmentResponse(
-            id, title, clubName, logo, clubId, content, recruitStart, recruitEnd,
-            status, createdAt, imageUrls, recruitForm,
-            isFavorite, instagramUrl, category
+                id, title, clubName, logo, clubId, content, recruitStart, recruitEnd,
+                status, createdAt, imageUrls, recruitForm,
+                isFavorite, instagramUrl, category
         );
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -27,16 +27,16 @@ import com.greedy.mokkoji.enums.message.FailMessage;
 import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import com.greedy.mokkoji.enums.user.UserRole;
 import jakarta.transaction.Transactional;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
@@ -34,7 +34,7 @@ public class UserController {
 
     @PostMapping("/auth/refresh")
     public ResponseEntity<APISuccessResponse<RefreshResponse>> refresh(
-        @RequestHeader("Authorization") String bearerToken
+            @RequestHeader("Authorization") String bearerToken
     ) {
         final String refreshToken = bearerAuthExtractor.extractTokenValue(bearerToken);
 

--- a/src/main/java/com/greedy/mokkoji/common/handler/JwtAuthInterceptor.java
+++ b/src/main/java/com/greedy/mokkoji/common/handler/JwtAuthInterceptor.java
@@ -19,9 +19,9 @@ public class JwtAuthInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(
-        final HttpServletRequest request,
-        final HttpServletResponse response,
-        final Object handler
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final Object handler
     ) {
         if (CorsUtils.isPreFlightRequest(request)) {
             return true;

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepository.java
@@ -9,5 +9,6 @@ import java.util.List;
 @Repository
 public interface ClubRepository extends JpaRepository<Club, Long>, ClubRepositoryCustom {
     List<Club> findByClubMasterStudentId(String studentId);
+
     boolean existsByClubMasterStudentId(String studentId);
 }

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryImpl.java
@@ -1,8 +1,5 @@
 package com.greedy.mokkoji.db.recruitment.repository;
 
-import static com.greedy.mokkoji.db.club.entity.QClub.club;
-import static com.greedy.mokkoji.db.recruitment.entity.QRecruitment.recruitment;
-
 import com.greedy.mokkoji.db.recruitment.entity.QRecruitment;
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
@@ -11,13 +8,17 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.greedy.mokkoji.db.club.entity.QClub.club;
+import static com.greedy.mokkoji.db.recruitment.entity.QRecruitment.recruitment;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/com/greedy/mokkoji/db/user/entity/User.java
+++ b/src/main/java/com/greedy/mokkoji/db/user/entity/User.java
@@ -51,7 +51,7 @@ public class User {
         this.email = email;
     }
 
-    public void grantRole(UserRole newRole) {
+    public void updateRole(UserRole newRole) {
         this.role = newRole;
     }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #217

## 👷 **작업한 내용**
1. 동아리 정보수정 부분에서 동아리장 변경 시, 
기존 동아리장의 권한을 normal로 새로운 동아리장의 권한을 club_master로 바꿔주는 로직을 추가했습니다.

2. grantUserRole과 updateUserRole의 코드가 똑같아 이름을 updateUserRole로 정하여 통일 시켜주었습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
