### PR TITLE
fix : 동아리명, 동아리 소개까지 검색 필터에 포함

### DIFF
--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
@@ -72,10 +72,13 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
 
     private BooleanExpression likeClubName(final String keyword) {
         if (StringUtils.hasText(keyword)) {
-            return recruitment.content.like("%" + keyword + "%");
+            return club.name.like("%" + keyword + "%")
+                    .or(club.description.like("%" + keyword + "%"))
+                    .or(recruitment.content.like("%" + keyword + "%"));
         }
         return null;
     }
+
 
     private BooleanExpression equalCategory(final ClubCategory category) {
         if (category != null) {

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
@@ -79,7 +79,6 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
         return null;
     }
 
-
     private BooleanExpression equalCategory(final ClubCategory category) {
         if (category != null) {
             return club.clubCategory.eq(category);


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #219

## 👷 **작업한 내용**
동아리명, 동아리 소개까지 검색 필터에 포함하기

## 🚨 **참고 사항**
추가 논의 사항
1. 검색 필터링 우선순위 정할건지 (포함 단어 빈도 수 정렬이라던지, 동아리명 -> 동아리소개-> 동아리 모집글순으로 필터링 할 건지)
-> 현재는 그냥 동아리명, 동아리소개, 동아리 모집글 싹 다 합해서 true, false 방식으로 포함되기만 하면 검색결과에 노출 
