### PR TITLE
Fix : 검색 필터에 동아리명, 동아리소개 포함

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,17 @@
 
 # 🍀 Mokkoji (모꼬지) 🍀
 
-**모꼬지** 팀은 동아리 홍보 및 정보 탐색의 불편함을 인지하고, 이를 해결하고자 동아리 통합 서비스를 만들었어요. 
-동아리 입장에서는 에브리타임에 동아리 홍보글을 올려도 글이 계속 묻혀 동아리를 홍보하기 어렵다는 문제가 있어요. 
-학우분들 입장에서도 어떤 동아리가 있는지 한 번에 확인하기 어렵다는 문제가 있죠. 
+**모꼬지** 팀은 동아리 홍보 및 정보 탐색의 불편함을 인지하고, 이를 해결하고자 동아리 통합 서비스를 만들었어요.
+동아리 입장에서는 에브리타임에 동아리 홍보글을 올려도 글이 계속 묻혀 동아리를 홍보하기 어렵다는 문제가 있어요.
+학우분들 입장에서도 어떤 동아리가 있는지 한 번에 확인하기 어렵다는 문제가 있죠.
 이러한 학우분들의 불편함을 조금이라도 덜어드리고자 열심히 개발했습니다.
 
 ---
 
 ## 🖥️ Technology Stack (기술 스택)
 
-### 🟢 Frontend  
+### 🟢 Frontend
+
 <p align="left">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/react/react-original.svg" alt="React" width="50" height="50"/>
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/typescript/typescript-original.svg" alt="TypeScript" width="50" height="50"/>
@@ -19,7 +20,8 @@
   <img src="https://github.com/user-attachments/assets/c42e1189-b47e-4121-88d6-e51ac6c8ecff" width="50" height="50"/>
 </p>
 
-### 🟢 Backend  
+### 🟢 Backend
+
 <p align="left">
   <img src="https://github.com/user-attachments/assets/f04fb377-ca6c-4078-be40-277d474fccc3" width="50" height="50"/>
   <img src="https://github.com/user-attachments/assets/241ec7bc-9f52-4144-b36d-36f0224bba53" width="50" height="50"/>  
@@ -27,7 +29,8 @@
   <img src="https://github.com/user-attachments/assets/106a82ed-f425-44a9-a2bd-ca9b06c7e9a0" width="50" height="50"/>
 </p>
 
-### 🟢 Cooperation (협업 도구)  
+### 🟢 Cooperation (협업 도구)
+
 <p align="left">
   <img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/github/github-original.svg" alt="GitHub" width="50" height="50"/>
   <img src="https://upload.wikimedia.org/wikipedia/commons/4/45/Notion_app_logo.png" alt="Notion" width="50" height="50"/>
@@ -35,9 +38,11 @@
 </p>
 
 ---
+
 ## 👥 Team Members
 
-### 🟢 Front-End Team  
+### 🟢 Front-End Team
+
 <table>
   <tr>
     <th><a href="https://github.com/sins051301">신혁수</a></th>
@@ -67,10 +72,11 @@
   </tr>
 </table>
 
-### 🟢 Back-End Team  
+### 🟢 Back-End Team
+
 <table>
   <tr>
-    <th><a href="https://github.com/shin378378">신혜빈</a></th>
+    <th><a href="https://github.com/c0mputurtle">신혜빈</a></th>
     <th><a href="https://github.com/goldm0ng">안금서</a></th>
     <th><a href="https://github.com/davidolleh">황승준</a></th>
     <th><a href="https://github.com/sansan20535">김의진</a></th>
@@ -105,10 +111,11 @@
 
 </div>
 
-### 🟢 Design Team  
+### 🟢 Design Team
+
 <table>
   <tr>
-    <th><a href="https://github.com/shin378378">김성림</a></th>
+    <th><a href="https://github.com/">김성림</a></th>
   </tr>
   <tr>
     <td>
@@ -128,43 +135,51 @@
 ## 주요 기능 소개
 
 ### ✅ **세종대 모든 동아리를 한 곳애서!**
+
 - 학술, 공연, 체육, 봉사, 종교 등 다양한 분야의 동아리 정보를 한 눈에 볼 수 있어요.
-  
+
 <img width="1699" height="964" alt="스크린샷 2025-08-21 오후 10 29 34" src="https://github.com/user-attachments/assets/6e780c0b-aad6-486b-81d3-b3a4a301637e" />
 
 ### ✅ **동아리 검색 기능**
+
 동아리 이름이나 키워드를 입력하면 원하는 동아리를 빠르게 검색할 수 있어요!
 
 <img width="1620" height="979" alt="스크린샷 2025-08-21 오후 10 45 27" src="https://github.com/user-attachments/assets/dc2934b9-10c6-4ec6-b58c-30a68daabce9" />
 
 ### ✅ **동아리 별 최신 모집 공고 제공**
+
 - 활동 내용, 모집 일정, 가입 방법까지 한 페이지에서 확인할 수 있어요.
 - 실시간 모집 현황을 확인할 수 있어요.
 
 <img width="1547" height="972" alt="스크린샷 2025-08-21 오후 10 40 40" src="https://github.com/user-attachments/assets/85e4ab0c-ce87-4885-8af0-2e4a1aac6b31" />
 
 ### ✅ **동아리 상세 페이지**
-- 선택한 동아리에 대한 상세 정보(모집기간, 인스타 링크, 모집공고 등)를 확인할 수 있어요. 
+
+- 선택한 동아리에 대한 상세 정보(모집기간, 인스타 링크, 모집공고 등)를 확인할 수 있어요.
 
 <img width="1550" height="978" alt="스크린샷 2025-08-21 오후 11 01 59" src="https://github.com/user-attachments/assets/00f3e0ea-3373-46c5-a317-70704bd37495" />
 
-
 ### ✅ **모집 공고 상세 페이지**
+
 - 선택한 동아리에 대한 상세 정보(모집기간, 인스타 링크, 모집공고 등)를 확인할 수 있어요.
-  
+
 <img width="1568" height="981" alt="스크린샷 2025-08-21 오후 11 01 27" src="https://github.com/user-attachments/assets/00e34ee0-384a-4739-8969-eca9560eba99" />
 
 ### ✅ **동아리 즐겨찾기 기능**
+
 - 즐겨찾기를 통해 관심 있는 동아리를 한 눈에 확인할 수 있어요.
 - 캘린더에서 즐겨찾기한 동아리의 모집 기한을 확인하고 모집 기한을 놓치지 마세요!
-  
+
 <img width="1427" height="780" alt="스크린샷 2025-08-21 오후 10 43 50" src="https://github.com/user-attachments/assets/565d8fa3-f817-4d9c-90b7-e445c3b28698" />
 
 ### ✅ **동아리 모집 알림 메일 기능**
+
 - 즐겨찾기 해둔 동아리의 모집 기한을 잊지 않도록, 메일로 알림을 보내드려요.
 
 ---
+
 ### ✅ **로그인 기능**
+
 - 사용자는 학사정보시스템 로그인을을 통해 다양한 기능을 사용할 수 있어요.
 - 로그인 안내사항 확인 및 동의 후 로그인이 가능해요.
 
@@ -172,15 +187,20 @@
 <img width="923" height="695" alt="스크린샷 2025-08-21 오후 10 57 24" src="https://github.com/user-attachments/assets/1f717cc4-6331-43f5-857b-31b7f9a60d50" />
 
 ### ✅ **마이페이지 및 정보 수정**
+
 - 자신의 정보를 확인하고 수정할 수 있어요.
 
 <img width="535" height="257" alt="스크린샷 2025-08-21 오후 10 48 37" src="https://github.com/user-attachments/assets/2d5e7a4b-fdb2-45e0-b6f8-256d71a11344" />
 
 ---
+
 ### 동아리 회장
+
 ### ✅ **동아리 정보 입력**
+
 - 검증된 동아리 회장은 동아리 모집 공고를 올릴 수 있어요.
 - 에타에 매번 글을 올리지 않아도 돼요.
 
 ---
+
 ## 대학 생활의 꽃, 동아리 활동을 모꼬지와 함께 해봐요! 🌻

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
@@ -72,7 +72,9 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
 
     private BooleanExpression likeClubName(final String keyword) {
         if (StringUtils.hasText(keyword)) {
-            return recruitment.content.like("%" + keyword + "%");
+            return club.name.like("%" + keyword + "%")
+                    .or(club.description.like("%" + keyword + "%"))
+                    .or(recruitment.content.like("%" + keyword + "%"));
         }
         return null;
     }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #222

## 👷 작업한 내용
동아리명, 동아리 소개까지 검색 필터에 포함하기
+ 리드미 쬐금한 거라서 여기 포함 시켰습니다. (신혜빈 깃허브 주소 수정)

## 🚨 참고 사항
추가 논의 사항

검색 필터링 우선순위 정할건지 (포함 단어 빈도 수 정렬이라던지, 동아리명 -> 동아리소개-> 동아리 모집글순으로 필터링 할 건지)
-> 현재는 그냥 동아리명, 동아리소개, 동아리 모집글 싹 다 합해서 true, false 방식으로 포함되기만 하면 검색결과에 노출
