### PR TITLE
HotFix : 동아리장 권한 자동 수정 안 되는 오류 해결

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -36,17 +36,23 @@ public class UserService {
 
         final StudentInformationResponse studentInformationResponse = sejongLoginClient.getStudentInformation(studentId, password);
 
-        return userRepository.findByStudentId(studentId).orElseGet(() -> {
-            final User newUser = User.builder()
-                    .studentId(studentId)
-                    .name(studentInformationResponse.name())
-                    .department(studentInformationResponse.department())
-                    .grade(studentInformationResponse.grade())
-                    .role(determineUserRole(studentId))
-                    .build();
+        final UserRole role = determineUserRole(studentId);
 
-            return userRepository.save(newUser);
-        });
+        return userRepository.findByStudentId(studentId)
+                .map(user -> {
+                    user.updateRole(role);
+                    return userRepository.save(user);
+                }).orElseGet(() -> {
+                    final User newUser = User.builder()
+                            .studentId(studentId)
+                            .name(studentInformationResponse.name())
+                            .department(studentInformationResponse.department())
+                            .grade(studentInformationResponse.grade())
+                            .role(role)
+                            .build();
+
+                    return userRepository.save(newUser);
+                });
     }
 
     private UserRole determineUserRole(final String studentId) {

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -41,7 +41,7 @@ public class UserService {
         return userRepository.findByStudentId(studentId)
                 .map(user -> {
                     user.updateRole(role);
-                    return userRepository.save(user);
+                    return user;
                 }).orElseGet(() -> {
                     final User newUser = User.builder()
                             .studentId(studentId)


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #228

## 👷 **작업한 내용**
<문제상황>
유저가 로그인을 할 때 그 유저가 동아리장인 지, 아닌지를 확인을 하게 되는 데,
신규유저 일때만 확인을 하고, 기존 유저일 때는 따로 확인하지 않아서 
기존 유저가 동아리장으로 업데이트되거나 임기를 마친 경우, 권한 수정이 자동으로 일어나지 않음

<해결>
기존 유저도 자동 권한 업데이트

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
