### PR TITLE
Fix: 동아리장 권한 교체 자동화 로직 수정

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -12,12 +12,11 @@ import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.db.user.repository.UserRepository;
 import com.greedy.mokkoji.enums.message.FailMessage;
 import com.greedy.mokkoji.enums.user.UserRole;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -34,31 +33,44 @@ public class UserService {
     @Transactional
     public User login(final String studentId, final String password) {
 
-        final StudentInformationResponse studentInformationResponse = sejongLoginClient.getStudentInformation(studentId, password);
+        final StudentInformationResponse studentInformationResponse = sejongLoginClient.getStudentInformation(studentId,
+            password);
 
         final UserRole role = determineUserRole(studentId);
 
         return userRepository.findByStudentId(studentId)
-                .map(user -> {
-                    user.updateRole(role);
-                    return user;
-                }).orElseGet(() -> {
-                    final User newUser = User.builder()
-                            .studentId(studentId)
-                            .name(studentInformationResponse.name())
-                            .department(studentInformationResponse.department())
-                            .grade(studentInformationResponse.grade())
-                            .role(role)
-                            .build();
+            .map(user -> {
+                user.updateRole(role);
+                return user;
+            }).orElseGet(() -> {
+                final User newUser = User.builder()
+                    .studentId(studentId)
+                    .name(studentInformationResponse.name())
+                    .department(studentInformationResponse.department())
+                    .grade(studentInformationResponse.grade())
+                    .role(role)
+                    .build();
 
-                    return userRepository.save(newUser);
-                });
+                return userRepository.save(newUser);
+            });
     }
 
     private UserRole determineUserRole(final String studentId) {
+        User user = userRepository.findByStudentId(studentId)
+            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+
+        if (user.getRole().equals(UserRole.GREEDY_ADMIN)) {
+            return UserRole.GREEDY_ADMIN;
+        }
+
+        if (user.getRole().equals(UserRole.CLUB_ADMIN)) {
+            return UserRole.CLUB_ADMIN;
+        }
+
         if (clubRepository.existsByClubMasterStudentId(studentId)) {
             return UserRole.CLUB_MASTER;
         }
+
         return UserRole.NORMAL;
     }
 
@@ -83,7 +95,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public User findUser(final Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
     }
 
     @Transactional
@@ -94,23 +106,23 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserRoleResponse getUserRole(final Long userId) {
         final User user = userRepository.findById(userId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
 
         return UserRoleResponse.of(
-                user.getRole().toString()
+            user.getRole().toString()
         );
     }
 
     @Transactional
     public UserManageClubsResponse getUserManageClubs(final Long userId) {
         final User user = userRepository.findById(userId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
 
         String studentId = user.getStudentId();
 
         List<UserManageClubResponse> clubs = clubRepository.findByClubMasterStudentId(studentId).stream()
-                .map(club -> new UserManageClubResponse(club.getId(), club.getName()))
-                .toList();
+            .map(club -> new UserManageClubResponse(club.getId(), club.getName()))
+            .toList();
 
         return UserManageClubsResponse.of(clubs);
     }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #230 

## 👷 **작업한 내용**
동아리장이 교체 되었을 때 권한 교체를 자동화하는 기존 로직에 문제가 있었습니다.
기존 로직에는 기본 사용자 및 동아리장의 경우만 고려하고 있었기 때문에,
그리디 개발자 및 총동연 관리자의 경우 모두 일반사용자로 바뀌었습니다.
해당 로직을 개선하였습니다.

## 🚨 **참고 사항**
시나리오 별 포스트맨 정상작동 확인했습니다.
