### PR TITLE
Fix: 도커 컨테이너 실행 시 jar 파일이 생성되지 않는 문제 해결

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -11,7 +11,5 @@ services:
     image: mokkojiteam/mokkoji:dev
     ports:
       - "8080:8080"
-    volumes:
-      - .:/app
     depends_on:
       - redis


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #239 

## 👷 **작업한 내용**
도커 컨테이너 실행 시 jar 파일이 생성되지 않아 
`Error: Unable to access jarfile /app/mokkoji.jar` 에러가 발생하는 문제가 있었습니다.

우선, 도커 이미지에는 해당 jar 파일이 존재합니다.
하지만, 컨테이너에는 존재하지 않습니다.
docker-compose 파일에 volumes: - .:/app가 존재하는데, 이는 컨테이너 실행 시 호스트의 현재 디렉토리로 /app을 덮어씌워서 생기는 문제 아닐까 추측해봅니다...

## 🚨 **참고 사항**
해당 문제의 원인이 뭐라고 생각하시는지 의견 주시면 감사하겠습니다!
