### PR TITLE
Fix: 상시모집 로직 수정

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/controller/RecruitmentController.java
@@ -43,7 +43,8 @@ public class RecruitmentController {
                         request.recruitStart(),
                         request.recruitEnd(),
                         request.images(),
-                        request.recruitForm()
+                        request.recruitForm(),
+                        request.isAlwaysRecruiting()
                 )
         );
     }
@@ -62,7 +63,8 @@ public class RecruitmentController {
                 request.recruitStart(),
                 request.recruitEnd(),
                 request.images(),
-                request.recruitForm()
+                request.recruitForm(),
+                request.isAlwaysRecruiting()
         );
         return APISuccessResponse.of(HttpStatus.OK, response);
     }

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/dto/request/CreateRecruitmentRequest.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/dto/request/CreateRecruitmentRequest.java
@@ -9,6 +9,7 @@ public record CreateRecruitmentRequest(
         String content,
         LocalDateTime recruitStart,
         LocalDateTime recruitEnd,
-        String recruitForm
+        String recruitForm,
+        boolean isAlwaysRecruiting
 ) {
 }

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/dto/request/UpdateRecruitmentRequest.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/dto/request/UpdateRecruitmentRequest.java
@@ -9,7 +9,8 @@ public record UpdateRecruitmentRequest(
         String content,
         LocalDateTime recruitStart,
         LocalDateTime recruitEnd,
-        String recruitForm
+        String recruitForm,
+        boolean isAlwaysRecruiting
 ) {
 }
 

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/AllRecruitment/RecruitmentPreviewResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/AllRecruitment/RecruitmentPreviewResponse.java
@@ -13,6 +13,7 @@ public record RecruitmentPreviewResponse(
         LocalDateTime recruitStart,
         LocalDateTime recruitEnd,
         RecruitStatus status,
-        boolean isFavorite
+        boolean isFavorite,
+        boolean isAlwaysRecruiting
 ) {
 }

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/allRecruitmentOfClub/RecruitmentOfClubResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/allRecruitmentOfClub/RecruitmentOfClubResponse.java
@@ -14,6 +14,7 @@ public record RecruitmentOfClubResponse(
         LocalDateTime recruitEnd,
         RecruitStatus status,
         LocalDateTime createdAt,
-        String firstImage
+        String firstImage,
+        boolean isAlwaysRecruiting
 ) {
 }

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/specificRecruitment/SpecificRecruitmentResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/specificRecruitment/SpecificRecruitmentResponse.java
@@ -20,7 +20,8 @@ public record SpecificRecruitmentResponse(
         String recruitForm,
         Boolean isFavorite,
         String instagramUrl,
-        String category
+        String category,
+        boolean isAlwaysRecruiting
 ) {
 
     public static SpecificRecruitmentResponse of(
@@ -38,12 +39,13 @@ public record SpecificRecruitmentResponse(
             String recruitForm,
             Boolean isFavorite,
             String instagramUrl,
-            String category
+            String category,
+            boolean isAlwaysRecruiting
     ) {
         return new SpecificRecruitmentResponse(
                 id, title, clubName, logo, clubId, content, recruitStart, recruitEnd,
                 status, createdAt, imageUrls, recruitForm,
-                isFavorite, instagramUrl, category
+                isFavorite, instagramUrl, category, isAlwaysRecruiting
         );
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -58,14 +58,15 @@ public class RecruitmentService {
             final LocalDateTime recruitStart,
             final LocalDateTime recruitEnd,
             final List<String> images,
-            final String recruitForm) {
+            final String recruitForm,
+            final boolean isAlwaysRecruiting) {
 
         validateAdmin(userId);
 
         Club club = clubRepository.findById(clubId)
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB));
 
-        Recruitment recruitment = buildAndSaveRecruitment(club, title, content, recruitStart, recruitEnd, recruitForm);
+        Recruitment recruitment = buildAndSaveRecruitment(club, title, content, recruitStart, recruitEnd, recruitForm, isAlwaysRecruiting);
         List<String> uploadImageUrls = uploadRecruitmentImages(recruitment, images);
 
         return CreateRecruitmentResponse.of(recruitment.getId(), uploadImageUrls);
@@ -80,14 +81,15 @@ public class RecruitmentService {
             final LocalDateTime recruitStart,
             final LocalDateTime recruitEnd,
             final List<String> newImages,
-            final String recruitForm
+            final String recruitForm,
+            final boolean isAlwaysRecruiting
     ) {
         validateAdmin(userId);
 
         Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUNT_RECRUITMENT));
 
-        recruitment.updateRecruitment(title, content, recruitStart, recruitEnd, recruitForm);
+        recruitment.updateRecruitment(title, content, recruitStart, recruitEnd, recruitForm, isAlwaysRecruiting);
 
         List<String> deleteImageUrls = deleteImages(recruitment.getId());
 
@@ -124,6 +126,7 @@ public class RecruitmentService {
                         .status(RecruitStatus.from(recruitment.getRecruitStart(), recruitment.getRecruitEnd()))
                         .createdAt(recruitment.getCreatedAt())
                         .firstImage(getFirstImageUrl(recruitment.getId()))
+                        .isAlwaysRecruiting(recruitment.isAlwaysRecruiting())
                         .build()
                 )
                 .toList();
@@ -160,7 +163,8 @@ public class RecruitmentService {
                 recruitment.getRecruitForm(),
                 isFavorite(userId, club.getId()),
                 club.getInstagram(),
-                club.getClubCategory().getDescription()
+                club.getClubCategory().getDescription(),
+                recruitment.isAlwaysRecruiting()
         );
     }
 
@@ -211,7 +215,7 @@ public class RecruitmentService {
 
     private Recruitment buildAndSaveRecruitment(Club club, String title, String content,
                                                 LocalDateTime recruitStart, LocalDateTime recruitEnd,
-                                                String recruitForm) {
+                                                String recruitForm, boolean isAlwaysRecruiting) {
         Recruitment recruitment = Recruitment.builder()
                 .club(club)
                 .title(title)
@@ -219,6 +223,7 @@ public class RecruitmentService {
                 .recruitStart(recruitStart)
                 .recruitEnd(recruitEnd)
                 .recruitForm(recruitForm)
+                .isAlwaysRecruiting(isAlwaysRecruiting)
                 .build();
 
         recruitmentRepository.save(recruitment);
@@ -299,7 +304,8 @@ public class RecruitmentService {
                 recruitment.getRecruitStart(),
                 recruitment.getRecruitEnd(),
                 RecruitStatus.from(recruitment.getRecruitStart(), recruitment.getRecruitEnd()),
-                isFavorite
+                isFavorite,
+                recruitment.isAlwaysRecruiting()
         );
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/scheduler/service/RecruitmentNotificationScheduler.java
+++ b/src/main/java/com/greedy/mokkoji/api/scheduler/service/RecruitmentNotificationScheduler.java
@@ -32,10 +32,12 @@ public class RecruitmentNotificationScheduler {
         recruitments.addAll(recruitmentRepository.findAllByRecruitEndToday(today));
         recruitments.addAll(recruitmentRepository.findAllByRecruitEndInThreeDays(threeDaysLater));
 
-        recruitments.forEach(recruitment -> {
-            Club club = recruitment.getClub();
-            notificationService.sendNotification(club, recruitment);
-        });
+        recruitments.stream()
+                .filter(recruitment -> !recruitment.isAlwaysRecruiting())
+                .forEach(recruitment -> {
+                    Club club = recruitment.getClub();
+                    notificationService.sendNotification(club, recruitment);
+                });
     }
 }
 

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
@@ -95,7 +95,8 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
 
     private BooleanExpression filterByRecruitStatus(final RecruitStatus status, final LocalDateTime now) {
         if (status == OPEN) {
-            return recruitment.recruitStart.loe(now).and(recruitment.recruitEnd.gt(now));
+            return recruitment.isAlwaysRecruiting.isTrue()
+                    .or(recruitment.recruitStart.loe(now).and(recruitment.recruitEnd.gt(now)));
         }
         return null;
     }

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/entity/Recruitment.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/entity/Recruitment.java
@@ -40,21 +40,26 @@ public class Recruitment extends BaseTime {
     @Column(name = "recruit_form", columnDefinition = "text")
     private String recruitForm;
 
+    @Column(name = "is_always_recruiting", columnDefinition = "tinyint(1)", nullable = false)
+    private boolean isAlwaysRecruiting;
+
     @Builder
-    public Recruitment(final Club club, final String title, final String content, final LocalDateTime recruitStart, final LocalDateTime recruitEnd, final String recruitForm) {
+    public Recruitment(final Club club, final String title, final String content, final LocalDateTime recruitStart, final LocalDateTime recruitEnd, final String recruitForm, final boolean isAlwaysRecruiting) {
         this.club = club;
         this.title = title;
         this.content = content;
         this.recruitStart = recruitStart;
         this.recruitEnd = recruitEnd;
         this.recruitForm = recruitForm;
+        this.isAlwaysRecruiting = isAlwaysRecruiting;
     }
 
-    public void updateRecruitment(final String title, final String content, final LocalDateTime recruitStart, final LocalDateTime recruitEnd, final String recruitForm) {
+    public void updateRecruitment(final String title, final String content, final LocalDateTime recruitStart, final LocalDateTime recruitEnd, final String recruitForm, final boolean isAlwaysRecruiting) {
         this.title = title;
         this.content = content;
         this.recruitStart = recruitStart;
         this.recruitEnd = recruitEnd;
         this.recruitForm = recruitForm;
+        this.isAlwaysRecruiting = isAlwaysRecruiting;
     }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #245 

## 👷 **작업한 내용**
recruitment 필드에 isAlwaysRecruiting 필드를 추가해서 상시 모집 처리를 했습니다.
사용자가 모집 중인 동아리 보기 선택 시 상시모집 동아리는 항상 결과에 포함하도록 구현했습니다.
RecruitmentNotificationScheduler의 sendDailyRecruitmentNotifications 메서드에서 상시모집 공고는 알림 발송 대상에서 제외하도록 필터링을 추가했습니다.


## 🚨 **참고 사항**
엔티티 수정이 필요한 작업이라 기존 구조를 최대한 유지하는 방향으로 구현했습니다.
코드와 컨벤션이 아직 익숙하지 않아 혹시 틀린 부분이나 개선할 점이 있다면 피드백 부탁드립니다 🙏
프론트와 상시 모집 체크 시 어떤 형태로 데이터를 전달할지 얘기 나눠봐야 할 것 같아요.