### PR TITLE
Fix: 동아리 즐겨찾기 조회 시, 중복 오류 해결

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
+++ b/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
@@ -105,24 +105,24 @@ public class FavoriteService {
             return null;
         }
 
-        List<Recruitment> recruitments = recruitmentRepository.findByClubIdIn(favoriteClubIds);
+        final List<Recruitment> recruitments = recruitmentRepository.findLatestRecruitmentsByFavoriteClubs(favoriteClubIds);
 
         return recruitments.stream()
-                .filter(r -> isSameMonth(r, yearMonth))
-                .map(r -> RecruitClubsResponse.of(
-                        r.getClub().getId(),
-                        r.getClub().getName(),
-                        r.getRecruitStart(),
-                        r.getRecruitEnd()
-                ))
-                .toList();
+            .filter(recruitment -> isSameMonth(recruitment, yearMonth))
+            .map(recruitment -> RecruitClubsResponse.of(
+                recruitment.getClub().getId(),
+                recruitment.getClub().getName(),
+                recruitment.getRecruitStart(),
+                recruitment.getRecruitEnd()
+            ))
+            .toList();
     }
 
-    private boolean isSameMonth(Recruitment r, YearMonth yearMonth) {
-        YearMonth startMonth = YearMonth.from(r.getRecruitStart());
+    private boolean isSameMonth(Recruitment recruitment, YearMonth yearMonth) {
+        YearMonth startMonth = YearMonth.from(recruitment.getRecruitStart());
         if (startMonth.equals(yearMonth)) return true;
 
-        YearMonth endMonth = YearMonth.from(r.getRecruitEnd());
+        YearMonth endMonth = YearMonth.from(recruitment.getRecruitEnd());
         if (endMonth.equals(yearMonth)) return true;
 
         return false;

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepository.java
@@ -1,14 +1,13 @@
 package com.greedy.mokkoji.db.recruitment.repository;
 
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long>, RecruitmentRepositoryCustom {
@@ -29,8 +28,6 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long>,
     Optional<Recruitment> findRecruitmentById(Long id);
 
     List<Recruitment> findAllByClubId(final Long id);
-
-    List<Recruitment> findByClubIdIn(List<Long> clubIds);
 
     Optional<Recruitment> findTopByClubIdOrderByUpdatedAtDesc(Long clubId);
 }

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryCustom.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryCustom.java
@@ -3,13 +3,16 @@ package com.greedy.mokkoji.db.recruitment.repository;
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface RecruitmentRepositoryCustom {
     Page<Recruitment> findRecruitments(
-            final ClubAffiliation affiliation,
-            final ClubCategory category,
-            final Pageable pageable
+        final ClubAffiliation affiliation,
+        final ClubCategory category,
+        final Pageable pageable
     );
+
+    public List<Recruitment> findLatestRecruitmentsByFavoriteClubs(List<Long> favoriteClubIds);
 }

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryImpl.java
@@ -1,5 +1,8 @@
 package com.greedy.mokkoji.db.recruitment.repository;
 
+import static com.greedy.mokkoji.db.club.entity.QClub.club;
+import static com.greedy.mokkoji.db.recruitment.entity.QRecruitment.recruitment;
+
 import com.greedy.mokkoji.db.recruitment.entity.QRecruitment;
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
@@ -8,17 +11,13 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
-import java.util.Optional;
-
-import static com.greedy.mokkoji.db.club.entity.QClub.club;
-import static com.greedy.mokkoji.db.recruitment.entity.QRecruitment.recruitment;
 
 @Repository
 @RequiredArgsConstructor
@@ -32,39 +31,58 @@ public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom {
         QRecruitment subRecruitment = new QRecruitment("subRecruitment");
 
         List<Recruitment> recruitments = queryFactory.selectFrom(recruitment)
-                .join(recruitment.club, club).fetchJoin()
-                .where(
-                        equalAffiliation(affiliation),
-                        equalCategory(category),
-                        recruitment.updatedAt.eq(
-                                JPAExpressions
-                                        .select(subRecruitment.updatedAt.max())
-                                        .from(subRecruitment)
-                                        .where(subRecruitment.club.id.eq(recruitment.club.id))
-                        )
+            .join(recruitment.club, club).fetchJoin()
+            .where(
+                equalAffiliation(affiliation),
+                equalCategory(category),
+                recruitment.updatedAt.eq(
+                    JPAExpressions
+                        .select(subRecruitment.updatedAt.max())
+                        .from(subRecruitment)
+                        .where(subRecruitment.club.id.eq(recruitment.club.id))
                 )
-                .orderBy(recruitment.updatedAt.desc())
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .fetch();
+            )
+            .orderBy(recruitment.updatedAt.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
 
         JPAQuery<Long> countQuery = queryFactory
-                .select(recruitment.count())
-                .from(recruitment)
-                .join(recruitment.club, club)
-                .where(
-                        equalAffiliation(affiliation),
-                        recruitment.updatedAt.eq(
-                                JPAExpressions
-                                        .select(subRecruitment.updatedAt.max())
-                                        .from(subRecruitment)
-                                        .where(subRecruitment.club.id.eq(recruitment.club.id))
-                        )
-                );
+            .select(recruitment.count())
+            .from(recruitment)
+            .join(recruitment.club, club)
+            .where(
+                equalAffiliation(affiliation),
+                recruitment.updatedAt.eq(
+                    JPAExpressions
+                        .select(subRecruitment.updatedAt.max())
+                        .from(subRecruitment)
+                        .where(subRecruitment.club.id.eq(recruitment.club.id))
+                )
+            );
 
         long total = Optional.ofNullable(countQuery.fetchOne()).orElse(0L);
 
         return new PageImpl<>(recruitments, pageable, total);
+    }
+
+    @Override
+    public List<Recruitment> findLatestRecruitmentsByFavoriteClubs(List<Long> favoriteClubIds) {
+        QRecruitment subRecruitment = new QRecruitment("subRecruitment");
+
+        return queryFactory.selectFrom(recruitment)
+            .join(recruitment.club, club).fetchJoin()
+            .where(
+                club.id.in(favoriteClubIds),
+                recruitment.updatedAt.eq(
+                    JPAExpressions
+                        .select(subRecruitment.updatedAt.max())
+                        .from(subRecruitment)
+                        .where(subRecruitment.club.id.eq(recruitment.club.id))
+                )
+            )
+            .orderBy(recruitment.updatedAt.desc())
+            .fetch();
     }
 
     private BooleanExpression equalAffiliation(ClubAffiliation affiliation) {

--- a/src/test/java/com/greedy/mokkoji/favorite/servcie/FavoriteServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/favorite/servcie/FavoriteServiceTest.java
@@ -282,13 +282,30 @@ public class FavoriteServiceTest {
             .build();
         ReflectionTestUtils.setField(club, "id", 1L);
 
-        final Recruitment recruitment = Recruitment.builder()
+        final Recruitment recruitment1 = Recruitment.builder()
+            .club(club)
+            .recruitStart(LocalDateTime.of(2024, 2, 1, 12, 0))
+            .recruitEnd(LocalDateTime.of(2024, 3, 30, 12, 0))
+            .content("동아리 모집 글")
+            .build();
+
+        final Recruitment recruitment2 = Recruitment.builder()
             .club(club)
             .recruitStart(LocalDateTime.of(2025, 2, 1, 12, 0))
             .recruitEnd(LocalDateTime.of(2025, 3, 30, 12, 0))
             .content("동아리 모집 글")
             .build();
-        ReflectionTestUtils.setField(recruitment, "id", 1L);
+
+        final Recruitment recruitment3 = Recruitment.builder()
+            .club(club)
+            .recruitStart(LocalDateTime.of(2025, 2, 1, 12, 0))
+            .recruitEnd(LocalDateTime.of(2025, 3, 30, 12, 0))
+            .content("동아리 모집 글")
+            .build();
+
+        ReflectionTestUtils.setField(recruitment1, "id", 1L);
+        ReflectionTestUtils.setField(recruitment2, "id", 2L);
+        ReflectionTestUtils.setField(recruitment3, "id", 3L);
 
         final List<Favorite> favorites = List.of(
             Favorite.builder().
@@ -298,7 +315,7 @@ public class FavoriteServiceTest {
 
         BDDMockito.given(favoriteRepository.findClubIdsByUserId(1L)).willReturn(List.of(1L));
         BDDMockito.given(recruitmentRepository.findLatestRecruitmentsByFavoriteClubs(List.of(1L)))
-            .willReturn(List.of(recruitment));
+            .willReturn(List.of(recruitment3));
 
         // when
         List<RecruitClubsResponse> result = favoriteService.getRecruitClubs(1L, YearMonth.of(2025, 2));
@@ -339,13 +356,30 @@ public class FavoriteServiceTest {
             .build();
         ReflectionTestUtils.setField(club, "id", 1L);
 
-        final Recruitment recruitment = Recruitment.builder()
+        final Recruitment recruitment1 = Recruitment.builder()
+            .club(club)
+            .recruitStart(LocalDateTime.of(2024, 2, 1, 12, 0))
+            .recruitEnd(LocalDateTime.of(2024, 3, 30, 12, 0))
+            .content("동아리 모집 글")
+            .build();
+
+        final Recruitment recruitment2 = Recruitment.builder()
             .club(club)
             .recruitStart(LocalDateTime.of(2025, 2, 1, 12, 0))
             .recruitEnd(LocalDateTime.of(2025, 3, 30, 12, 0))
             .content("동아리 모집 글")
             .build();
-        ReflectionTestUtils.setField(recruitment, "id", 1L);
+
+        final Recruitment recruitment3 = Recruitment.builder()
+            .club(club)
+            .recruitStart(LocalDateTime.of(2025, 2, 1, 12, 0))
+            .recruitEnd(LocalDateTime.of(2025, 3, 30, 12, 0))
+            .content("동아리 모집 글")
+            .build();
+
+        ReflectionTestUtils.setField(recruitment1, "id", 1L);
+        ReflectionTestUtils.setField(recruitment2, "id", 2L);
+        ReflectionTestUtils.setField(recruitment3, "id", 3L);
 
         final List<Favorite> favorites = List.of(
             Favorite.builder().
@@ -355,7 +389,7 @@ public class FavoriteServiceTest {
 
         BDDMockito.given(favoriteRepository.findClubIdsByUserId(1L)).willReturn(List.of(1L));
         BDDMockito.given(recruitmentRepository.findLatestRecruitmentsByFavoriteClubs(List.of(1L)))
-            .willReturn(List.of(recruitment));
+            .willReturn(List.of(recruitment3));
 
         // when
         List<RecruitClubsResponse> result = favoriteService.getRecruitClubs(1L, YearMonth.of(2025, 3));
@@ -397,13 +431,30 @@ public class FavoriteServiceTest {
             .build();
         ReflectionTestUtils.setField(club, "id", 1L);
 
-        final Recruitment recruitment = Recruitment.builder()
+        final Recruitment recruitment1 = Recruitment.builder()
+            .club(club)
+            .recruitStart(LocalDateTime.of(2024, 2, 1, 12, 0))
+            .recruitEnd(LocalDateTime.of(2024, 3, 30, 12, 0))
+            .content("동아리 모집 글")
+            .build();
+
+        final Recruitment recruitment2 = Recruitment.builder()
             .club(club)
             .recruitStart(LocalDateTime.of(2025, 2, 1, 12, 0))
             .recruitEnd(LocalDateTime.of(2025, 3, 30, 12, 0))
             .content("동아리 모집 글")
             .build();
-        ReflectionTestUtils.setField(recruitment, "id", 1L);
+
+        final Recruitment recruitment3 = Recruitment.builder()
+            .club(club)
+            .recruitStart(LocalDateTime.of(2025, 2, 1, 12, 0))
+            .recruitEnd(LocalDateTime.of(2025, 3, 30, 12, 0))
+            .content("동아리 모집 글")
+            .build();
+
+        ReflectionTestUtils.setField(recruitment1, "id", 1L);
+        ReflectionTestUtils.setField(recruitment2, "id", 2L);
+        ReflectionTestUtils.setField(recruitment3, "id", 3L);
 
         final List<Favorite> favorites = List.of(
             Favorite.builder().
@@ -413,7 +464,7 @@ public class FavoriteServiceTest {
 
         BDDMockito.given(favoriteRepository.findClubIdsByUserId(1L)).willReturn(List.of(1L));
         BDDMockito.given(recruitmentRepository.findLatestRecruitmentsByFavoriteClubs(List.of(1L)))
-            .willReturn(List.of(recruitment));
+            .willReturn(List.of(recruitment3));
 
         // when
         List<RecruitClubsResponse> result = favoriteService.getRecruitClubs(1L, YearMonth.of(2025, 10));

--- a/src/test/java/com/greedy/mokkoji/favorite/servcie/FavoriteServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/favorite/servcie/FavoriteServiceTest.java
@@ -2,6 +2,7 @@ package com.greedy.mokkoji.favorite.servcie;
 
 import com.greedy.mokkoji.api.club.dto.response.ClubsPaginationResponse;
 import com.greedy.mokkoji.api.external.AppDataS3Client;
+import com.greedy.mokkoji.api.favorite.dto.response.RecruitClubsResponse;
 import com.greedy.mokkoji.api.favorite.service.FavoriteService;
 import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.db.club.entity.Club;
@@ -15,6 +16,7 @@ import com.greedy.mokkoji.db.user.repository.UserRepository;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.message.FailMessage;
+import java.time.YearMonth;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -245,8 +247,8 @@ public class FavoriteServiceTest {
         //then
         assertThat(favoriteClubs.clubs().size()).isEqualTo(1);
         assertThat(favoriteClubs.clubs().get(0).name()).isEqualTo("동아리 이름");
-        assertThat(favoriteClubs.clubs().get(0).category()).isEqualTo("공연");
-        assertThat(favoriteClubs.clubs().get(0).affiliation()).isEqualTo("중앙동아리");
+        assertThat(favoriteClubs.clubs().get(0).category()).isEqualTo("문화/예술");
+        assertThat(favoriteClubs.clubs().get(0).affiliation()).isEqualTo("중앙");
         assertThat(favoriteClubs.clubs().get(0).description()).isEqualTo("동아리 설명");
         assertThat(favoriteClubs.clubs().get(0).recruitStartDate()).isEqualTo("2025-02-01");
         assertThat(favoriteClubs.clubs().get(0).recruitEndDate()).isEqualTo("2025-03-30");
@@ -255,5 +257,168 @@ public class FavoriteServiceTest {
 
         BDDMockito.verify(favoriteRepository, times(1)).findByUserId(user.getId(), PageRequest.of(0, 10));
         BDDMockito.verify(recruitmentRepository, times(1)).findByClubId(club.getId());
+    }
+
+    @DisplayName("특정 연월에 모집 중인 즐겨찾기 동아리의 최신 모집 정보를 조회한다. - 모집 시작일이 겹치는 경우")
+    @Test
+    void getRecruitClubsWhenRecruitStartInYearMonth() {
+        // given
+        final User user = User.builder()
+            .name("사용자 이름")
+            .email("사용자 이메일")
+            .grade("4")
+            .department("사용자 학과")
+            .studentId("사용자 학번")
+            .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        final Club club = Club.builder()
+            .name("동아리 이름")
+            .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
+            .clubCategory(ClubCategory.CULTURAL_ART)
+            .logo("동아리 로고")
+            .description("동아리 설명")
+            .instagram("동아리 인스타그램 링크")
+            .build();
+        ReflectionTestUtils.setField(club, "id", 1L);
+
+        final Recruitment recruitment = Recruitment.builder()
+            .club(club)
+            .recruitStart(LocalDateTime.of(2025, 2, 1, 12, 0))
+            .recruitEnd(LocalDateTime.of(2025, 3, 30, 12, 0))
+            .content("동아리 모집 글")
+            .build();
+        ReflectionTestUtils.setField(recruitment, "id", 1L);
+
+        final List<Favorite> favorites = List.of(
+            Favorite.builder().
+                club(club).
+                user(user).build()
+        );
+
+        BDDMockito.given(favoriteRepository.findClubIdsByUserId(1L)).willReturn(List.of(1L));
+        BDDMockito.given(recruitmentRepository.findLatestRecruitmentsByFavoriteClubs(List.of(1L)))
+            .willReturn(List.of(recruitment));
+
+        // when
+        List<RecruitClubsResponse> result = favoriteService.getRecruitClubs(1L, YearMonth.of(2025, 2));
+
+        // then
+        assertThat(result).hasSize(1);
+
+        RecruitClubsResponse response = result.get(0);
+        assertThat(response.clubId()).isEqualTo(1L);
+        assertThat(response.clubName()).isEqualTo("동아리 이름");;
+        assertThat(response.recruitStart()).isEqualTo("2025-02-01T12:00:00");
+        assertThat(response.recruitEnd()).isEqualTo("2025-03-30T12:00:00");
+
+        BDDMockito.verify(favoriteRepository, times(1)).findClubIdsByUserId(1L);
+        BDDMockito.verify(recruitmentRepository, times(1)).findLatestRecruitmentsByFavoriteClubs(List.of(1L));
+    }
+
+    @DisplayName("특정 연월에 모집 중인 즐겨찾기 동아리의 최신 모집 정보를 조회한다. - 모집 마감일이 겹치는 경우")
+    @Test
+    void getRecruitClubsWhenRecruitEndInYearMonth() {
+        // given
+        final User user = User.builder()
+            .name("사용자 이름")
+            .email("사용자 이메일")
+            .grade("4")
+            .department("사용자 학과")
+            .studentId("사용자 학번")
+            .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        final Club club = Club.builder()
+            .name("동아리 이름")
+            .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
+            .clubCategory(ClubCategory.CULTURAL_ART)
+            .logo("동아리 로고")
+            .description("동아리 설명")
+            .instagram("동아리 인스타그램 링크")
+            .build();
+        ReflectionTestUtils.setField(club, "id", 1L);
+
+        final Recruitment recruitment = Recruitment.builder()
+            .club(club)
+            .recruitStart(LocalDateTime.of(2025, 2, 1, 12, 0))
+            .recruitEnd(LocalDateTime.of(2025, 3, 30, 12, 0))
+            .content("동아리 모집 글")
+            .build();
+        ReflectionTestUtils.setField(recruitment, "id", 1L);
+
+        final List<Favorite> favorites = List.of(
+            Favorite.builder().
+                club(club).
+                user(user).build()
+        );
+
+        BDDMockito.given(favoriteRepository.findClubIdsByUserId(1L)).willReturn(List.of(1L));
+        BDDMockito.given(recruitmentRepository.findLatestRecruitmentsByFavoriteClubs(List.of(1L)))
+            .willReturn(List.of(recruitment));
+
+        // when
+        List<RecruitClubsResponse> result = favoriteService.getRecruitClubs(1L, YearMonth.of(2025, 3));
+
+        //then
+        assertThat(result).hasSize(1);
+
+        RecruitClubsResponse response = result.get(0);
+        assertThat(response.clubId()).isEqualTo(1L);
+        assertThat(response.clubName()).isEqualTo("동아리 이름");;
+        assertThat(response.recruitStart()).isEqualTo("2025-02-01T12:00:00");
+        assertThat(response.recruitEnd()).isEqualTo("2025-03-30T12:00:00");
+
+        BDDMockito.verify(favoriteRepository, times(1)).findClubIdsByUserId(1L);
+        BDDMockito.verify(recruitmentRepository, times(1)).findLatestRecruitmentsByFavoriteClubs(List.of(1L));
+    }
+
+
+    @DisplayName("특정 연월에 해당하는 즐겨찾기 동아리의 모집글이 없으면 빈 리스트를 반환한다.")
+    @Test
+    void getRecruitClubsWhenNoRecruitmentInYearMonth() {
+        // given
+        final User user = User.builder()
+            .name("사용자 이름")
+            .email("사용자 이메일")
+            .grade("4")
+            .department("사용자 학과")
+            .studentId("사용자 학번")
+            .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+
+        final Club club = Club.builder()
+            .name("동아리 이름")
+            .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
+            .clubCategory(ClubCategory.CULTURAL_ART)
+            .logo("동아리 로고")
+            .description("동아리 설명")
+            .instagram("동아리 인스타그램 링크")
+            .build();
+        ReflectionTestUtils.setField(club, "id", 1L);
+
+        final Recruitment recruitment = Recruitment.builder()
+            .club(club)
+            .recruitStart(LocalDateTime.of(2025, 2, 1, 12, 0))
+            .recruitEnd(LocalDateTime.of(2025, 3, 30, 12, 0))
+            .content("동아리 모집 글")
+            .build();
+        ReflectionTestUtils.setField(recruitment, "id", 1L);
+
+        final List<Favorite> favorites = List.of(
+            Favorite.builder().
+                club(club).
+                user(user).build()
+        );
+
+        BDDMockito.given(favoriteRepository.findClubIdsByUserId(1L)).willReturn(List.of(1L));
+        BDDMockito.given(recruitmentRepository.findLatestRecruitmentsByFavoriteClubs(List.of(1L)))
+            .willReturn(List.of(recruitment));
+
+        // when
+        List<RecruitClubsResponse> result = favoriteService.getRecruitClubs(1L, YearMonth.of(2025, 10));
+
+        //then
+        assertThat(result).isEmpty();
     }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #232 

## 👷 **작업한 내용**
모꼬지 핵심 기능 중 하나인 달력 기능에서 제공되는 API 관련한 작업입니다.

`favorites/recruit`
위 API는 "연도-월"을 기반으로, 사용자가 즐겨찾기한 동아리 중 해당 연월에 모집하는 동아리가 존재하면 모집 정보를 반환하는 역할을 합니다.

## 문제 상황
해당 API에서 발생한 문제는 동아리 모집 정보가 중복으로 반환된다는 것이었습니다.
<img width="1344" height="240" alt="image" src="https://github.com/user-attachments/assets/005665c3-f0f0-44cd-ab05-9822cfd10dc4" />


## 문제 원인 분석
사용자가 즐겨찾기한 동아리의 모집 기한이 현재 조회하는 연도/월과 매치되는 모집글이 존재할 때, 해당 모집글이 여러 개 존재하는 경우 중복 조회가 이루어진 것입니다.

> Ex)
> 조회하고자 하는 연도와 월: 2025-08
> 즐겨찾기한 동아리의 모집 기한: 2025-08-17 ~2025-08-31
> 해당 동아리의 모집글 
> 1. 즐겨찾기한 동아리의 모집글1
>  -  그리디 3기를 모집합니다! 
> 2. 즐겨찾기한 동아리의 모집글2
>  - 그리디 3기를 모집합니다! 

---
## 검증
실제 운영 데이터 기반으로 포스트맨 정상 동작 확인하였습니다.
테스트 코드 또한 작성했습니다. 

## 🚨 **참고 사항**
테스트는 기존 Service 테스트 코드에 작성된 것을 기반으로 포맷을 맞춰서 짜보았습니다.
현재는 Mock을 이용해 검증하고 있는데, 실제 Repository 기반으로 동작하는 것을 검증하는 방법도 한 번 고민해보는 것이 좋을 것 같아요!
간단한 통합 테스트라도 추가해두면 쿼리 동작 확인이나 리팩토링 시 안정성 확보에 도움이 될 것 같습니다 :)
