### PR TITLE
Refactor : s3 주소 백엔드에서 만들기 & s3 주소 수정

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -107,7 +107,7 @@ public class ClubService {
         Club club = validateClubManagerAuthority(userId, clubId);
 
         String oldLogoKey = club.getLogo();
-        String newLogoKey = extractLogoKey(club, logo);
+        String newLogoKey = extractLogoKey(clubId, logo);
 
         if (clubMasterStudentId != null) {
             changeClubMasterRole(club.getClubMasterStudentId(), clubMasterStudentId);
@@ -225,12 +225,11 @@ public class ClubService {
     }
 
     @Nullable
-    private String extractLogoKey(Club club, String logo) {
+    private String extractLogoKey(Long clubId, String logo) {
         if (logo != null && !logo.isBlank()) {
             return null;
         }
-        String category = club.getClubCategory().name();
-        String logoKey = String.format("club-logo/%s/%d/%s", category, club.getId(), logo);
+        String logoKey = String.format("club-logo/%d/%s", clubId, logo);
         return logoKey;
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -107,7 +107,7 @@ public class ClubService {
         Club club = validateClubManagerAuthority(userId, clubId);
 
         String oldLogoKey = club.getLogo();
-        String newLogoKey = extractNewLogoKey(club, logo);
+        String newLogoKey = extractLogoKey(club, logo);
 
         if (clubMasterStudentId != null) {
             changeClubMasterRole(club.getClubMasterStudentId(), clubMasterStudentId);
@@ -225,13 +225,13 @@ public class ClubService {
     }
 
     @Nullable
-    private String extractNewLogoKey(Club club, String logo) {
+    private String extractLogoKey(Club club, String logo) {
         if (logo != null && !logo.isBlank()) {
             return null;
         }
         String category = club.getClubCategory().name();
-        String newLogoKey = String.format("club-logo/%s/%d/%s", category, club.getId(), logo);
-        return newLogoKey;
+        String logoKey = String.format("club-logo/%s/%d/%s", category, club.getId(), logo);
+        return logoKey;
     }
 
     @Nullable

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -107,7 +107,7 @@ public class ClubService {
         Club club = validateClubManagerAuthority(userId, clubId);
 
         String oldLogoKey = club.getLogo();
-        String newLogoKey = extractNewLogoKey(logo);
+        String newLogoKey = extractNewLogoKey(club, logo);
 
         if (clubMasterStudentId != null) {
             changeClubMasterRole(club.getClubMasterStudentId(), clubMasterStudentId);
@@ -225,10 +225,13 @@ public class ClubService {
     }
 
     @Nullable
-    private String extractNewLogoKey(String logo) {
-        return (logo != null && !logo.isBlank())
-                ? logo
-                : null;
+    private String extractNewLogoKey(Club club, String logo) {
+        if (logo != null && !logo.isBlank()) {
+            return null;
+        }
+        String category = club.getClubCategory().name();
+        String newLogoKey = String.format("club-logo/%s/%d/%s", category, club.getId(), logo);
+        return newLogoKey;
     }
 
     @Nullable

--- a/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
+++ b/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
@@ -72,19 +72,18 @@ public class AppDataS3Client {
 
     private String appendUUID(String fileKey) {
         int dotIndex = fileKey.lastIndexOf('.');
+        int sliceIndex = fileKey.lastIndexOf('/');
         String uuid = UUID.randomUUID().toString();
 
-        // recruitmentImage인 경우
-        if (dotIndex == 0) {
-            return uuid + fileKey;
+        String prevDot = fileKey.substring(0, dotIndex);
+        String nextDot = fileKey.substring(dotIndex); //jpg와 같은 확장자 의미
+
+        if (dotIndex == (sliceIndex + 1)) {
+            return prevDot + uuid + nextDot;
         }
 
-
-        String name = fileKey.substring(0, dotIndex);
-        String ext = fileKey.substring(dotIndex);
-        return name + "_" + uuid + ext;
+        return prevDot + "_" + uuid + nextDot;
     }
-
 
     public String getPresignedDeleteUrl(final String fileKey) {
         if (fileKey == null || fileKey.isBlank()) {

--- a/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
+++ b/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.*;
 
 import java.time.Duration;
+import java.util.UUID;
 
 @Component
 public class AppDataS3Client {
@@ -46,15 +47,16 @@ public class AppDataS3Client {
         return url;
     }
 
-    //TODO: UUID 사용하여 filename 중복 문제 해결하기
     public String getPresignedPutUrl(final String filename) {
         if (filename == null || filename.isBlank()) {
             return null;
         }
 
+        String uniqueFilename = appendUUID(filename);
+
         final PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucketName)
-                .key(filename)
+                .key(uniqueFilename)
                 .build();
 
         final PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
@@ -87,5 +89,14 @@ public class AppDataS3Client {
                 .presignDeleteObject(presignRequest);
 
         return presignedDeleteObjectRequest.url().toString();
+    }
+
+    private String appendUUID(String filename) {
+        int dotIndex = filename.lastIndexOf('.');
+        String uuid = UUID.randomUUID().toString();
+
+        String name = filename.substring(0, dotIndex);
+        String ext = filename.substring(dotIndex);
+        return name + "_" + uuid + ext;
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
+++ b/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
@@ -43,7 +43,6 @@ public class AppDataS3Client {
         //presigned url 반환
         final String url = presignedGetObjectRequest.url().toString();
 
-        s3Presigner.close();
         return url;
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
+++ b/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
@@ -23,14 +23,14 @@ public class AppDataS3Client {
         this.s3Presigner = awsConfig.getPresigner();
     }
 
-    public String getPresignedUrl(final String filename) {
-        if (filename == null || filename.equals("")) {
+    public String getPresignedUrl(final String fileKey) {
+        if (fileKey == null || fileKey.equals("")) {
             return null;
         }
 
         final GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucketName)
-                .key(filename)
+                .key(fileKey)
                 .build();
 
         final GetObjectPresignRequest getObjectPresignRequest = GetObjectPresignRequest.builder()
@@ -47,16 +47,16 @@ public class AppDataS3Client {
         return url;
     }
 
-    public String getPresignedPutUrl(final String filename) {
-        if (filename == null || filename.isBlank()) {
+    public String getPresignedPutUrl(final String fileKey) {
+        if (fileKey == null || fileKey.isBlank()) {
             return null;
         }
 
-        String uniqueFilename = appendUUID(filename);
+        String uniqueFileKey = appendUUID(fileKey);
 
         final PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucketName)
-                .key(uniqueFilename)
+                .key(uniqueFileKey)
                 .build();
 
         final PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
@@ -70,23 +70,30 @@ public class AppDataS3Client {
         return presignedPutObjectRequest.url().toString();
     }
 
-    private String appendUUID(String filename) {
-        int dotIndex = filename.lastIndexOf('.');
+    private String appendUUID(String fileKey) {
+        int dotIndex = fileKey.lastIndexOf('.');
         String uuid = UUID.randomUUID().toString();
 
-        String name = filename.substring(0, dotIndex);
-        String ext = filename.substring(dotIndex);
+        // recruitmentImage인 경우
+        if (dotIndex == 0) {
+            return uuid + fileKey;
+        }
+
+
+        String name = fileKey.substring(0, dotIndex);
+        String ext = fileKey.substring(dotIndex);
         return name + "_" + uuid + ext;
     }
 
-    public String getPresignedDeleteUrl(final String filename) {
-        if (filename == null || filename.isBlank()) {
+
+    public String getPresignedDeleteUrl(final String fileKey) {
+        if (fileKey == null || fileKey.isBlank()) {
             return null;
         }
 
         final DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
                 .bucket(bucketName)
-                .key(filename)
+                .key(fileKey)
                 .build();
 
         final DeleteObjectPresignRequest presignRequest = DeleteObjectPresignRequest.builder()

--- a/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
+++ b/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
@@ -76,7 +76,7 @@ public class AppDataS3Client {
         String uuid = UUID.randomUUID().toString();
 
         String prevDot = fileKey.substring(0, dotIndex);
-        String nextDot = fileKey.substring(dotIndex); //jpg와 같은 확장자 의미
+        String nextDot = fileKey.substring(dotIndex); //jpg와 같은 확장자 부분
 
         if (dotIndex == (sliceIndex + 1)) {
             return prevDot + uuid + nextDot;

--- a/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
+++ b/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
@@ -70,6 +70,15 @@ public class AppDataS3Client {
         return presignedPutObjectRequest.url().toString();
     }
 
+    private String appendUUID(String filename) {
+        int dotIndex = filename.lastIndexOf('.');
+        String uuid = UUID.randomUUID().toString();
+
+        String name = filename.substring(0, dotIndex);
+        String ext = filename.substring(dotIndex);
+        return name + "_" + uuid + ext;
+    }
+
     public String getPresignedDeleteUrl(final String filename) {
         if (filename == null || filename.isBlank()) {
             return null;
@@ -89,14 +98,5 @@ public class AppDataS3Client {
                 .presignDeleteObject(presignRequest);
 
         return presignedDeleteObjectRequest.url().toString();
-    }
-
-    private String appendUUID(String filename) {
-        int dotIndex = filename.lastIndexOf('.');
-        String uuid = UUID.randomUUID().toString();
-
-        String name = filename.substring(0, dotIndex);
-        String ext = filename.substring(dotIndex);
-        return name + "_" + uuid + ext;
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/controller/RecruitmentController.java
@@ -61,7 +61,8 @@ public class RecruitmentController {
                 request.content(),
                 request.recruitStart(),
                 request.recruitEnd(),
-                request.imageCount(),
+                request.newImageCount(),
+                request.deleteImageKeys(),
                 request.recruitForm()
         );
         return APISuccessResponse.of(HttpStatus.OK, response);

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/controller/RecruitmentController.java
@@ -61,7 +61,7 @@ public class RecruitmentController {
                 request.content(),
                 request.recruitStart(),
                 request.recruitEnd(),
-                request.images(),
+                request.imageCount(),
                 request.recruitForm()
         );
         return APISuccessResponse.of(HttpStatus.OK, response);

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/controller/RecruitmentController.java
@@ -42,7 +42,7 @@ public class RecruitmentController {
                         request.content(),
                         request.recruitStart(),
                         request.recruitEnd(),
-                        request.images(),
+                        request.imageCount(),
                         request.recruitForm()
                 )
         );

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/dto/request/CreateRecruitmentRequest.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/dto/request/CreateRecruitmentRequest.java
@@ -1,11 +1,10 @@
 package com.greedy.mokkoji.api.recruitment.dto.request;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public record CreateRecruitmentRequest(
         String title,
-        List<String> images,
+        int imageCount,
         String content,
         LocalDateTime recruitStart,
         LocalDateTime recruitEnd,

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/dto/request/UpdateRecruitmentRequest.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/dto/request/UpdateRecruitmentRequest.java
@@ -1,10 +1,12 @@
 package com.greedy.mokkoji.api.recruitment.dto.request;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public record UpdateRecruitmentRequest(
         String title,
-        int imageCount,
+        List<String> deleteImageKeys,
+        int newImageCount,
         String content,
         LocalDateTime recruitStart,
         LocalDateTime recruitEnd,

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/dto/request/UpdateRecruitmentRequest.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/dto/request/UpdateRecruitmentRequest.java
@@ -1,11 +1,10 @@
 package com.greedy.mokkoji.api.recruitment.dto.request;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 public record UpdateRecruitmentRequest(
         String title,
-        List<String> images,
+        int imageCount,
         String content,
         LocalDateTime recruitStart,
         LocalDateTime recruitEnd,

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -270,14 +270,6 @@ public class RecruitmentService {
         return deleteImageUrls;
     }
 
-    private String extractExtension(String fileName) {
-        int dotIndex = fileName.lastIndexOf('.');
-        if (dotIndex != -1 && dotIndex < fileName.length() - 1) {
-            return fileName.substring(dotIndex);
-        }
-        return "";
-    }
-
     private String getFirstImageUrl(Long recruitmentId) {
         return recruitmentImageRepository.findByRecruitmentIdOrderByIdAsc(recruitmentId).stream()
                 .findFirst()

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -57,7 +57,7 @@ public class RecruitmentService {
             final String content,
             final LocalDateTime recruitStart,
             final LocalDateTime recruitEnd,
-            final List<String> images,
+            final int imageCount,
             final String recruitForm) {
 
         validateAdmin(userId);
@@ -66,7 +66,7 @@ public class RecruitmentService {
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB));
 
         Recruitment recruitment = buildAndSaveRecruitment(club, title, content, recruitStart, recruitEnd, recruitForm);
-        List<String> uploadImageUrls = uploadRecruitmentImages(recruitment, images);
+        List<String> uploadImageUrls = uploadRecruitmentImages(recruitment, imageCount);
 
         return CreateRecruitmentResponse.of(recruitment.getId(), uploadImageUrls);
     }
@@ -225,25 +225,37 @@ public class RecruitmentService {
         return recruitment;
     }
 
-    private List<String> uploadRecruitmentImages(Recruitment recruitment, List<String> imageKeys) {
-        List<String> imageUrls = new ArrayList<>();
+    private List<String> uploadRecruitmentImages(Recruitment recruitment, int imageCount) {
+        List<String> presignedUrls = new ArrayList<>();
 
-        if (imageKeys != null && !imageKeys.isEmpty()) {
-            List<RecruitmentImage> recruitmentImages = imageKeys.stream()
-                    .map(imageKey -> {
-                        String presignedPutUrl = appDataS3Client.getPresignedPutUrl(imageKey);
-                        imageUrls.add(presignedPutUrl);
-
-                        return RecruitmentImage.builder()
-                                .recruitment(recruitment)
-                                .image(imageKey)
-                                .build();
-                    })
-                    .toList();
-
-            recruitmentImageRepository.saveAll(recruitmentImages);
+        if (imageCount == 0) {
+            return presignedUrls;
         }
-        return imageUrls;
+
+        List<RecruitmentImage> recruitmentImages = new ArrayList<>();
+        for (int i = 1; i <= imageCount; i++) {
+            String imageKey = extractImageKey(recruitment, i);
+            String presignedPutUrl = appDataS3Client.getPresignedPutUrl(imageKey);
+            presignedUrls.add(presignedPutUrl);
+
+            RecruitmentImage recruitmentImage = RecruitmentImage.builder()
+                    .recruitment(recruitment)
+                    .image(imageKey)
+                    .build();
+            recruitmentImages.add(recruitmentImage);
+        }
+
+        recruitmentImageRepository.saveAll(recruitmentImages);
+
+        return presignedUrls;
+    }
+
+    private String extractImageKey(Recruitment recruitment, int imageNumber) {
+        String fileName = String.format("%d.jpg", imageNumber);
+        Club club = recruitment.getClub();
+
+        String imageKey = String.format("recruitment-image/%d/%d/%s", club.getId(), recruitment.getId(), fileName);
+        return imageKey;
     }
 
     private List<String> deleteImages(Long recruitmentId) {

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -233,8 +233,8 @@ public class RecruitmentService {
         }
 
         List<RecruitmentImage> recruitmentImages = new ArrayList<>();
-        for (int i = 1; i <= imageCount; i++) {
-            String imageKey = extractImageKey(recruitment, i);
+        for (int i = 0; i < imageCount; i++) {
+            String imageKey = extractImageKey(recruitment);
             String presignedPutUrl = appDataS3Client.getPresignedPutUrl(imageKey);
             presignedUrls.add(presignedPutUrl);
 
@@ -250,8 +250,8 @@ public class RecruitmentService {
         return presignedUrls;
     }
 
-    private String extractImageKey(Recruitment recruitment, int imageNumber) {
-        String fileName = String.format("%d.jpg", imageNumber);
+    private String extractImageKey(Recruitment recruitment) {
+        String fileName = ".jpg";
         Club club = recruitment.getClub();
 
         String imageKey = String.format("recruitment-image/%d/%d/%s", club.getId(), recruitment.getId(), fileName);

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -137,7 +137,7 @@ public class RecruitmentService {
         Recruitment recruitment = recruitmentRepository.findRecruitmentById(recruitmentId)
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUNT_RECRUITMENT));
 
-        List<RecruitmentImage> recruitmentImages = recruitmentImageRepository.findByRecruitmentIdOrderByIdAsc(
+        List<RecruitmentImage> recruitmentImages = recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(
                 recruitmentId);
 
         List<String> imageUrls = recruitmentImages.stream()
@@ -285,7 +285,7 @@ public class RecruitmentService {
     }
 
     private String getFirstImageUrl(Long recruitmentId) {
-        return recruitmentImageRepository.findByRecruitmentIdOrderByIdAsc(recruitmentId).stream()
+        return recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(recruitmentId).stream()
                 .findFirst()
                 .map(image -> appDataS3Client.getPresignedUrl(image.getImage()))
                 .orElse(null);

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -79,7 +79,7 @@ public class RecruitmentService {
             final String content,
             final LocalDateTime recruitStart,
             final LocalDateTime recruitEnd,
-            final List<String> newImages,
+            final int imageCount,
             final String recruitForm
     ) {
         validateAdmin(userId);
@@ -91,7 +91,7 @@ public class RecruitmentService {
 
         List<String> deleteImageUrls = deleteImages(recruitment.getId());
 
-        List<String> uploadImageUrls = uploadRecruitmentImages(recruitment, newImages);
+        List<String> uploadImageUrls = uploadRecruitmentImages(recruitment, imageCount);
 
         return UpdateRecruitmentResponse.of(recruitment.getId(), deleteImageUrls, uploadImageUrls);
     }

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -79,7 +79,8 @@ public class RecruitmentService {
             final String content,
             final LocalDateTime recruitStart,
             final LocalDateTime recruitEnd,
-            final int imageCount,
+            final int newImageCount,
+            final List<String> deleteImageKeys,
             final String recruitForm
     ) {
         validateAdmin(userId);
@@ -89,9 +90,9 @@ public class RecruitmentService {
 
         recruitment.updateRecruitment(title, content, recruitStart, recruitEnd, recruitForm);
 
-        List<String> deleteImageUrls = deleteImages(recruitment.getId());
+        List<String> deleteImageUrls = deleteSpecificImages(deleteImageKeys);
+        List<String> uploadImageUrls = uploadRecruitmentImages(recruitment, newImageCount);
 
-        List<String> uploadImageUrls = uploadRecruitmentImages(recruitment, imageCount);
 
         return UpdateRecruitmentResponse.of(recruitment.getId(), deleteImageUrls, uploadImageUrls);
     }
@@ -203,7 +204,6 @@ public class RecruitmentService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
 
-        //Todo: 권한 설정에 대해서 추가적으로 이야기 해보기
         if (user.getRole().equals(UserRole.NORMAL)) {
             throw new MokkojiException(FailMessage.FORBIDDEN);
         }
@@ -256,6 +256,20 @@ public class RecruitmentService {
 
         String imageKey = String.format("recruitment-image/%d/%d/%s", club.getId(), recruitment.getId(), fileName);
         return imageKey;
+    }
+
+    private List<String> deleteSpecificImages(List<String> deleteImageKeys) {
+        if (deleteImageKeys == null || deleteImageKeys.isEmpty()) {
+            return List.of();
+        }
+
+        List<RecruitmentImage> imagesToDelete = recruitmentImageRepository.findAllByImageIn(deleteImageKeys);
+        List<String> deleteImageUrls = imagesToDelete.stream()
+                .map(img -> appDataS3Client.getPresignedDeleteUrl(img.getImage()))
+                .toList();
+
+        recruitmentImageRepository.deleteAll(imagesToDelete);
+        return deleteImageUrls;
     }
 
     private List<String> deleteImages(Long recruitmentId) {

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -12,11 +12,12 @@ import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.db.user.repository.UserRepository;
 import com.greedy.mokkoji.enums.message.FailMessage;
 import com.greedy.mokkoji.enums.user.UserRole;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -34,47 +35,47 @@ public class UserService {
     public User login(final String studentId, final String password) {
 
         final StudentInformationResponse studentInformationResponse = sejongLoginClient.getStudentInformation(studentId,
-            password);
+                password);
 
         final UserRole role = determineUserRole(studentId);
 
         return userRepository.findByStudentId(studentId)
-            .map(user -> {
-                user.updateRole(role);
-                return user;
-            }).orElseGet(() -> {
-                final User newUser = User.builder()
-                    .studentId(studentId)
-                    .name(studentInformationResponse.name())
-                    .department(studentInformationResponse.department())
-                    .grade(studentInformationResponse.grade())
-                    .role(role)
-                    .build();
+                .map(user -> {
+                    user.updateRole(role);
+                    return user;
+                }).orElseGet(() -> {
+                    final User newUser = User.builder()
+                            .studentId(studentId)
+                            .name(studentInformationResponse.name())
+                            .department(studentInformationResponse.department())
+                            .grade(studentInformationResponse.grade())
+                            .role(role)
+                            .build();
 
-                return userRepository.save(newUser);
-            });
+                    return userRepository.save(newUser);
+                });
     }
 
     private UserRole determineUserRole(final String studentId) {
         return userRepository.findByStudentId(studentId)
-            .map(user -> {
-                if (user.getRole() == UserRole.GREEDY_ADMIN) {
-                    return UserRole.GREEDY_ADMIN;
-                }
-                if (user.getRole() == UserRole.CLUB_ADMIN) {
-                    return UserRole.CLUB_ADMIN;
-                }
-                if (clubRepository.existsByClubMasterStudentId(studentId)) {
-                    return UserRole.CLUB_MASTER;
-                }
-                return UserRole.NORMAL;
-            })
-            .orElseGet(() -> {
-                if (clubRepository.existsByClubMasterStudentId(studentId)) {
-                    return UserRole.CLUB_MASTER;
-                }
-                return UserRole.NORMAL;
-            });
+                .map(user -> {
+                    if (user.getRole() == UserRole.GREEDY_ADMIN) {
+                        return UserRole.GREEDY_ADMIN;
+                    }
+                    if (user.getRole() == UserRole.CLUB_ADMIN) {
+                        return UserRole.CLUB_ADMIN;
+                    }
+                    if (clubRepository.existsByClubMasterStudentId(studentId)) {
+                        return UserRole.CLUB_MASTER;
+                    }
+                    return UserRole.NORMAL;
+                })
+                .orElseGet(() -> {
+                    if (clubRepository.existsByClubMasterStudentId(studentId)) {
+                        return UserRole.CLUB_MASTER;
+                    }
+                    return UserRole.NORMAL;
+                });
     }
 
     @Transactional
@@ -98,7 +99,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public User findUser(final Long userId) {
         return userRepository.findById(userId)
-            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
     }
 
     @Transactional
@@ -109,23 +110,23 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserRoleResponse getUserRole(final Long userId) {
         final User user = userRepository.findById(userId)
-            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
 
         return UserRoleResponse.of(
-            user.getRole().toString()
+                user.getRole().toString()
         );
     }
 
     @Transactional
     public UserManageClubsResponse getUserManageClubs(final Long userId) {
         final User user = userRepository.findById(userId)
-            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
 
         String studentId = user.getStudentId();
 
         List<UserManageClubResponse> clubs = clubRepository.findByClubMasterStudentId(studentId).stream()
-            .map(club -> new UserManageClubResponse(club.getId(), club.getName()))
-            .toList();
+                .map(club -> new UserManageClubResponse(club.getId(), club.getName()))
+                .toList();
 
         return UserManageClubsResponse.of(clubs);
     }

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentImageRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentImageRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @Repository
 public interface RecruitmentImageRepository extends JpaRepository<RecruitmentImage, Long> {
-    List<RecruitmentImage> findByRecruitmentIdOrderByIdAsc(Long recruitmentId);
+    List<RecruitmentImage> findByRecruitmentIdOrderByCreatedAtAsc(Long recruitmentId);
 
     List<RecruitmentImage> findByRecruitmentId(Long recruitmentId);
 

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentImageRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentImageRepository.java
@@ -11,4 +11,6 @@ public interface RecruitmentImageRepository extends JpaRepository<RecruitmentIma
     List<RecruitmentImage> findByRecruitmentIdOrderByIdAsc(Long recruitmentId);
 
     List<RecruitmentImage> findByRecruitmentId(Long recruitmentId);
+
+    List<RecruitmentImage> findAllByImageIn(List<String> imageKeys);
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #247 

## 👷 **작업한 내용**
* S3 파일 경로 관리 개선
1) 모든 파일 주소를 백엔드에서 생성 및 반환하도록 변경
2) 파일 이름 중복 방지를 위해 UUID 적용
3) 게시글 이미지 생성 날짜 순(오름차순)으로 반환
4) 
게시글 수정할때
프론트 -> 삭제할 이미지의 Key리스트, 새로 추가할 사진의 수
백엔드 -> 특정 이미지 삭제 후, 새로 추가할 사진의 presignedURL 반환

* 파일 저장 구조
1) 클럽 로고: club-logo/{clubId}/이미지_UUID.jpg
2) 모집글 이미지: recruitment-image/{clubId}/{recruitmentId}/UUID.jpg

## 🚨 **참고 사항**
* 기존 프론트에서 직접 생성하던 S3 주소는 더 이상 사용하지 않음
* 파일 업로드 시 백엔드 응답의 URL을 그대로 활용하도록 수정 필요

-------------
근데 아직 프론트랑 자세한 논의 안 해봐서 .... 논의가 필요합니다.