### PR TITLE
Fix: Club 관련 테스트 코드 수정 및 구현

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -227,7 +227,7 @@ public class ClubService {
 
     @Nullable
     private String extractLogoKey(Long clubId, String logo) {
-        if (logo == null && logo.isBlank()) {
+        if (logo == null || logo.isBlank()) {
             return null;
         }
 

--- a/src/test/java/com/greedy/mokkoji/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/club/controller/ClubControllerTest.java
@@ -1,15 +1,24 @@
 package com.greedy.mokkoji.club.controller;
 
+import com.greedy.mokkoji.api.club.dto.request.ClubCreateRequest;
+import com.greedy.mokkoji.api.club.dto.request.ClubUpdateRequest;
 import com.greedy.mokkoji.api.club.dto.response.ClubDetailResponse;
+import com.greedy.mokkoji.api.club.dto.response.ClubManageDetailResponse;
 import com.greedy.mokkoji.api.club.dto.response.ClubResponse;
+import com.greedy.mokkoji.api.club.dto.response.ClubUpdateResponse;
 import com.greedy.mokkoji.api.club.dto.response.ClubsPaginationResponse;
 import com.greedy.mokkoji.api.pagination.dto.PageResponse;
 import com.greedy.mokkoji.common.ControllerTest;
 import com.greedy.mokkoji.common.fixture.Fixture;
+import com.greedy.mokkoji.common.response.APIErrorResponse;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.favorite.entity.Favorite;
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.db.user.entity.User;
+import com.greedy.mokkoji.enums.club.ClubAffiliation;
+import com.greedy.mokkoji.enums.club.ClubCategory;
+import com.greedy.mokkoji.enums.message.FailMessage;
+import com.greedy.mokkoji.enums.user.UserRole;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,6 +26,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -61,7 +71,7 @@ public class ClubControllerTest extends ControllerTest {
         final ExtractableResponse<Response> response = given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", authorizationForBearer)
-                .when().get(prefixUrl + "/clubs/{clubId}", 1L)
+                .when().get(prefixUrl + "/clubs/{clubId}", club.getId())
                 .then().log().all()
                 .extract();
 
@@ -76,7 +86,7 @@ public class ClubControllerTest extends ControllerTest {
                 club.getDescription(),
                 recruitment.getRecruitStart(),
                 recruitment.getRecruitEnd(),
-                club.getLogo(),
+                Fixture.FIXTURE_CLUB_LOGO,
                 true,
                 club.getInstagram(),
                 recruitment.getContent()
@@ -131,5 +141,319 @@ public class ClubControllerTest extends ControllerTest {
 
         assertThat(statusCode).isEqualTo(HttpStatus.OK.value());
         assertThat(expected).usingRecursiveComparison().isEqualTo(actual);
+    }
+
+    @Test
+    @DisplayName("동아리를 생성할 수 있다.")
+    void createClub() {
+        //given
+        final User adminUser = User.builder()
+                .name("관리자")
+                .email("admin@test.com")
+                .studentId("12345678")
+                .grade("4")
+                .department("컴퓨터공학과")
+                .role(UserRole.CLUB_ADMIN)
+                .build();
+        userRepository.save(adminUser);
+        String authorizationForBearer = authorizationForBearerAccessToken(adminUser);
+
+        final ClubCreateRequest request = new ClubCreateRequest(
+                "새로운 동아리",
+                ClubCategory.ACADEMIC_CULTURAL,
+                ClubAffiliation.DEPARTMENT_CLUB,
+                adminUser.getStudentId()
+        );
+
+        //when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .body(request)
+                .when().post(prefixUrl + "/clubs")
+                .then().log().all()
+                .extract();
+
+        //then
+        final int statusCode = response.statusCode();
+        Club createdClub = clubRepository.findByClubMasterStudentId(adminUser.getStudentId()).get(0);
+        assertThat(statusCode).isEqualTo(HttpStatus.CREATED.value());
+        assertThat(createdClub.getName()).isEqualTo(request.name());
+        assertThat(createdClub.getClubAffiliation()).isEqualTo(request.affiliation());
+        assertThat(createdClub.getClubCategory()).isEqualTo(request.category());
+        assertThat(createdClub.getClubMasterStudentId()).isEqualTo(request.clubMasterStudentId());
+    }
+
+    @Test
+    @DisplayName("동아리 관리 상세 정보 조회를 할 수 있다.")
+    void getClubManageDetail() {
+        //given
+        final User adminUser = User.builder()
+                .name("관리자")
+                .email("admin@test.com")
+                .studentId("12345678")
+                .grade("4")
+                .department("컴퓨터공학과")
+                .role(UserRole.CLUB_ADMIN)
+                .build();
+        userRepository.save(adminUser);
+
+        final Club managedClub = Club.builder()
+                .name("관리할 동아리")
+                .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
+                .clubCategory(ClubCategory.SPORTS)
+                .clubMasterStudentId(adminUser.getStudentId())
+                .description("동아리 설명")
+                .instagram("instagram.com")
+                .build();
+        clubRepository.save(managedClub);
+        String authorizationForBearer = authorizationForBearerAccessToken(adminUser);
+        when(appDataS3Client.getPresignedUrl(null)).thenReturn(null);
+
+        //when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .when().get(prefixUrl + "/clubs/manage/{clubId}", managedClub.getId())
+                .then().log().all()
+                .extract();
+
+        //then
+        final int statusCode = response.statusCode();
+        final ClubManageDetailResponse actual = getDataFromResponse(response, ClubManageDetailResponse.class);
+        final ClubManageDetailResponse expected = ClubManageDetailResponse.of(
+                managedClub.getName(),
+                managedClub.getClubCategory().name(),
+                managedClub.getClubAffiliation().name(),
+                managedClub.getDescription(),
+                managedClub.getLogo(),
+                managedClub.getInstagram()
+        );
+
+        assertThat(statusCode).isEqualTo(HttpStatus.OK.value());
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("동아리 정보를 수정할 수 있다.")
+    void updateClub() {
+        //given
+        final User clubMasterUser = User.builder()
+                .name("동아리장")
+                .email("master@test.com")
+                .grade("3")
+                .studentId("21123456")
+                .role(UserRole.CLUB_MASTER)
+                .build();
+        userRepository.save(clubMasterUser);
+        String authorizationForBearer = authorizationForBearerAccessToken(clubMasterUser);
+
+        final Club managedClub = Club.builder()
+                .name("수정할 동아리")
+                .clubCategory(ClubCategory.SPORTS)
+                .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
+                .clubMasterStudentId(clubMasterUser.getStudentId())
+                .build();
+        ReflectionTestUtils.setField(managedClub, "logo", "logo.jpg");
+        clubRepository.save(managedClub);
+
+        final ClubUpdateRequest request = new ClubUpdateRequest(
+                "수정된 동아리",
+                ClubCategory.CULTURAL_ART,
+                ClubAffiliation.DEPARTMENT_CLUB,
+                "동아리 수정 완료",
+                "12345678",
+                "new-logo.jpg",
+                "new-instagram.com"
+        );
+
+        when(appDataS3Client.getPresignedPutUrl(any())).thenReturn("presignedPutUrl");
+        when(appDataS3Client.getPresignedDeleteUrl(any())).thenReturn("presignedDeleteUrl");
+
+        //when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .body(request)
+                .when().patch(prefixUrl + "/clubs/manage/{clubId}", managedClub.getId())
+                .then().log().all()
+                .extract();
+
+        //then
+        final int statusCode = response.statusCode();
+        ClubUpdateResponse actual = getDataFromResponse(response, ClubUpdateResponse.class);
+
+        assertThat(statusCode).isEqualTo(HttpStatus.OK.value());
+        assertThat(actual.updateLogo()).isEqualTo("presignedPutUrl");
+        assertThat(actual.deleteLogo()).isEqualTo("presignedDeleteUrl");
+
+        final Club updatedClub = clubRepository.findById(managedClub.getId()).orElseThrow();
+        assertThat(updatedClub.getName()).isEqualTo(request.name());
+        assertThat(updatedClub.getClubCategory()).isEqualTo(request.category());
+        assertThat(updatedClub.getClubMasterStudentId()).isEqualTo(request.clubMasterStudentId());
+        assertThat(updatedClub.getClubAffiliation()).isEqualTo(request.affiliation());
+        assertThat(updatedClub.getLogo()).contains("new-logo_");
+        assertThat(updatedClub.getInstagram()).isEqualTo(request.instagram());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 동아리를 조회하면 404를 반환한다")
+    void getClubNotFound() {
+        //given
+        Long nonExistentClubId = 99999L;
+        String authorizationForBearer = authorizationForBearerAccessToken(user);
+
+        //when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .when().get(prefixUrl + "/clubs/{clubId}", nonExistentClubId)
+                .then().log().all()
+                .extract();
+
+        //then
+        final int actualStatusCode = response.statusCode();
+        final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
+        final APIErrorResponse expectedResponse = new APIErrorResponse(
+                FailMessage.NOT_FOUND_CLUB.getCode(),
+                FailMessage.NOT_FOUND_CLUB.getMessage()
+        );
+
+        assertThat(actualStatusCode).isEqualTo(HttpStatus.NOT_FOUND.value());
+        assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+    }
+
+    @Test
+    @DisplayName("권한 없는 사용자가 동아리를 생성하면 403을 반환한다")
+    void createClubForbidden() {
+        //given
+        final User normalUser = User.builder()
+                .name("일반사용자")
+                .email("normal@test.com")
+                .studentId("11112222")
+                .grade("2")
+                .department("소프트웨어학과")
+                .role(UserRole.NORMAL)
+                .build();
+        userRepository.save(normalUser);
+        String authorizationForBearer = authorizationForBearerAccessToken(normalUser);
+
+        final ClubCreateRequest request = new ClubCreateRequest(
+                "새로운 동아리",
+                ClubCategory.ACADEMIC_CULTURAL,
+                ClubAffiliation.DEPARTMENT_CLUB,
+                null
+        );
+
+        //when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .body(request)
+                .when().post(prefixUrl + "/clubs")
+                .then().log().all()
+                .extract();
+
+        //then
+        final int actualStatusCode = response.statusCode();
+        final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
+        final APIErrorResponse expectedResponse = new APIErrorResponse(
+                FailMessage.FORBIDDEN_REGISTER_CLUB.getCode(),
+                FailMessage.FORBIDDEN_REGISTER_CLUB.getMessage()
+        );
+
+        assertThat(actualStatusCode).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+    }
+
+    @Test
+    @DisplayName("권한 없는 사용자가 동아리를 수정하면 403을 반환한다")
+    void updateClubForbidden() {
+        //given
+        final User normalUser = User.builder()
+                .name("일반사용자")
+                .email("normal2@test.com")
+                .studentId("22223333")
+                .grade("2")
+                .department("소프트웨어학과")
+                .role(UserRole.NORMAL)
+                .build();
+        userRepository.save(normalUser);
+        String authorizationForBearer = authorizationForBearerAccessToken(normalUser);
+
+        final ClubUpdateRequest request = new ClubUpdateRequest(
+                "수정된 동아리",
+                ClubCategory.CULTURAL_ART,
+                ClubAffiliation.DEPARTMENT_CLUB,
+                "동아리 수정",
+                null,
+                null,
+                null
+        );
+
+        //when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .body(request)
+                .when().patch(prefixUrl + "/clubs/manage/{clubId}", club.getId())
+                .then().log().all()
+                .extract();
+
+        //then
+        final int actualStatusCode = response.statusCode();
+        final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
+        final APIErrorResponse expectedResponse = new APIErrorResponse(
+                FailMessage.FORBIDDEN_MANAGE_CLUB.getCode(),
+                FailMessage.FORBIDDEN_MANAGE_CLUB.getMessage()
+        );
+
+        assertThat(actualStatusCode).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 동아리장 학번으로 동아리를 생성하면 404를 반환한다")
+    void createClubWithNonExistentClubMaster() {
+        //given
+        final String nonExistentStudentId = "99999999";
+
+        final User adminUser = User.builder()
+                .name("관리자")
+                .email("admin2@test.com")
+                .studentId("99998888")
+                .grade("4")
+                .department("컴퓨터공학과")
+                .role(UserRole.CLUB_ADMIN)
+                .build();
+        userRepository.save(adminUser);
+        String authorizationForBearer = authorizationForBearerAccessToken(adminUser);
+
+        final ClubCreateRequest request = new ClubCreateRequest(
+                "새로운 동아리",
+                ClubCategory.ACADEMIC_CULTURAL,
+                ClubAffiliation.DEPARTMENT_CLUB,
+                nonExistentStudentId
+        );
+
+        //when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .body(request)
+                .when().post(prefixUrl + "/clubs")
+                .then().log().all()
+                .extract();
+
+        //then
+        final int actualStatusCode = response.statusCode();
+        final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
+        final APIErrorResponse expectedResponse = new APIErrorResponse(
+                FailMessage.NOT_FOUND_USER.getCode(),
+                FailMessage.NOT_FOUND_USER.getMessage()
+        );
+
+        assertThat(actualStatusCode).isEqualTo(HttpStatus.NOT_FOUND.value());
+        assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
     }
 }

--- a/src/test/java/com/greedy/mokkoji/club/service/ClubServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/club/service/ClubServiceTest.java
@@ -1,16 +1,23 @@
 package com.greedy.mokkoji.club.service;
 
 import com.greedy.mokkoji.api.club.dto.response.ClubDetailResponse;
+import com.greedy.mokkoji.api.club.dto.response.ClubManageDetailResponse;
+import com.greedy.mokkoji.api.club.dto.response.ClubUpdateResponse;
 import com.greedy.mokkoji.api.club.dto.response.ClubsPaginationResponse;
 import com.greedy.mokkoji.api.club.service.ClubService;
 import com.greedy.mokkoji.api.external.AppDataS3Client;
+import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.club.repository.ClubRepository;
 import com.greedy.mokkoji.db.favorite.repository.FavoriteRepository;
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.db.recruitment.repository.RecruitmentRepository;
+import com.greedy.mokkoji.db.user.entity.User;
+import com.greedy.mokkoji.db.user.repository.UserRepository;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
+import com.greedy.mokkoji.enums.message.FailMessage;
+import com.greedy.mokkoji.enums.user.UserRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +37,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -48,6 +56,9 @@ class ClubServiceTest {
 
     @Mock
     private FavoriteRepository favoriteRepository;
+
+    @Mock
+    private UserRepository userRepository;
 
     @Mock
     private AppDataS3Client appDataS3Client;
@@ -175,5 +186,355 @@ class ClubServiceTest {
         verify(clubRepository, times(1)).findById(anyLong());
         verify(recruitmentRepository, times(1)).findTopByClubIdOrderByUpdatedAtDesc(anyLong());
         verify(favoriteRepository, times(1)).existsByUserIdAndClubId(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 클럽을 조회하면 예외를 던진다")
+    void getClubShouldThrowExceptionWhenNotExists() {
+        //given
+        final Long userId = 1L;
+        final Long nonExistentClubId = 99999L;
+
+        BDDMockito.given(clubRepository.findById(nonExistentClubId)).willReturn(Optional.empty());
+
+        //then
+        assertThatThrownBy(() -> clubService.findClub(userId, nonExistentClubId))
+                .isInstanceOf(MokkojiException.class)
+                .hasMessage(FailMessage.NOT_FOUND_CLUB.getMessage());
+    }
+
+    @Test
+    @DisplayName("모집이 존재하지 않는 경우 null 값을 가진 응답을 반환한다")
+    void findClubDetailWhenRecruitmentNotExists() {
+        //given
+        final Long userId = 1L;
+        final Club clubWithoutRecruitment = Club.builder()
+                .name("testClub3")
+                .clubCategory(ClubCategory.SPORTS)
+                .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
+                .description("testDescription3")
+                .logo("testLogo3")
+                .instagram("testInstagramURL3")
+                .build();
+        ReflectionTestUtils.setField(clubWithoutRecruitment, "id", 3L);
+        final Long clubId = clubWithoutRecruitment.getId();
+
+        BDDMockito.given(clubRepository.findById(clubId)).willReturn(Optional.of(clubWithoutRecruitment));
+        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByUpdatedAtDesc(clubId)).willReturn(Optional.empty());
+        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, clubId)).willReturn(false);
+        BDDMockito.given(appDataS3Client.getPresignedUrl(clubWithoutRecruitment.getLogo())).willReturn("testLogo3");
+
+        //when
+        ClubDetailResponse response = clubService.findClub(userId, clubId);
+
+        //then
+        assertThat(response).isNotNull();
+        assertThat(response.name()).isEqualTo("testClub3");
+        assertThat(response.category()).isEqualTo("체육");
+        assertThat(response.recruitStartDate()).isNull();
+        assertThat(response.recruitEndDate()).isNull();
+        assertThat(response.recruitPost()).isNull();
+
+        verify(clubRepository, times(1)).findById(clubId);
+        verify(recruitmentRepository, times(1)).findTopByClubIdOrderByUpdatedAtDesc(clubId);
+        verify(favoriteRepository, times(1)).existsByUserIdAndClubId(userId, clubId);
+    }
+
+    @Test
+    @DisplayName("동아리를 생성한다")
+    void createClub() {
+        //given
+        final Long userId = 1L;
+        final String name = "새로운 동아리";
+        final ClubCategory category = ClubCategory.ACADEMIC_CULTURAL;
+        final ClubAffiliation affiliation = ClubAffiliation.CENTRAL_CLUB;
+        final String clubMasterStudentId = "20201234";
+
+        final User adminUser = User.builder()
+                .name("관리자")
+                .email("admin@test.com")
+                .studentId("12345678")
+                .grade("4")
+                .department("컴퓨터공학과")
+                .build();
+        ReflectionTestUtils.setField(adminUser, "id", userId);
+        ReflectionTestUtils.setField(adminUser, "role", UserRole.CLUB_ADMIN);
+
+        final User masterUser = User.builder()
+                .name("동아리장")
+                .email("master@test.com")
+                .studentId(clubMasterStudentId)
+                .grade("3")
+                .department("컴퓨터공학과")
+                .build();
+        ReflectionTestUtils.setField(masterUser, "id", 2L);
+        ReflectionTestUtils.setField(masterUser, "role", UserRole.NORMAL);
+
+        BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(adminUser));
+        BDDMockito.given(userRepository.findByStudentId(clubMasterStudentId)).willReturn(Optional.of(masterUser));
+        BDDMockito.given(clubRepository.save(any(Club.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        //when
+        clubService.createClub(userId, name, category, affiliation, clubMasterStudentId);
+
+        //then
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(1)).findByStudentId(clubMasterStudentId);
+        verify(clubRepository, times(1)).save(any(Club.class));
+    }
+
+    @Test
+    @DisplayName("동아리 생성 권한이 없으면 예외를 던진다")
+    void createClubShouldThrowExceptionWhenNoPermission() {
+        //given
+        final Long userId = 1L;
+        final String name = "새로운 동아리";
+        final ClubCategory category = ClubCategory.ACADEMIC_CULTURAL;
+        final ClubAffiliation affiliation = ClubAffiliation.CENTRAL_CLUB;
+
+        final User normalUser = User.builder()
+                .name("일반 사용자")
+                .email("user@test.com")
+                .studentId("12345678")
+                .grade("4")
+                .department("컴퓨터공학과")
+                .build();
+        ReflectionTestUtils.setField(normalUser, "id", userId);
+        ReflectionTestUtils.setField(normalUser, "role", UserRole.NORMAL);
+
+        BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(normalUser));
+
+        //when & then
+        assertThatThrownBy(() -> clubService.createClub(userId, name, category, affiliation, null))
+                .isInstanceOf(MokkojiException.class)
+                .hasMessage(FailMessage.FORBIDDEN_REGISTER_CLUB.getMessage());
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(clubRepository, never()).save(any(Club.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 동아리장 학번으로 동아리를 생성하면 예외를 던진다")
+    void createClubShouldThrowExceptionWhenClubMasterNotFound() {
+        //given
+        final Long userId = 1L;
+        final String name = "새로운 동아리";
+        final ClubCategory category = ClubCategory.ACADEMIC_CULTURAL;
+        final ClubAffiliation affiliation = ClubAffiliation.CENTRAL_CLUB;
+        final String clubMasterStudentId = "99999999";
+
+        final User adminUser = User.builder()
+                .name("관리자")
+                .email("admin@test.com")
+                .studentId("12345678")
+                .grade("4")
+                .department("컴퓨터공학과")
+                .build();
+        ReflectionTestUtils.setField(adminUser, "id", userId);
+        ReflectionTestUtils.setField(adminUser, "role", UserRole.CLUB_ADMIN);
+
+        BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(adminUser));
+        BDDMockito.given(userRepository.findByStudentId(clubMasterStudentId)).willReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> clubService.createClub(userId, name, category, affiliation, clubMasterStudentId))
+                .isInstanceOf(MokkojiException.class)
+                .hasMessage(FailMessage.NOT_FOUND_USER.getMessage());
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(userRepository, times(1)).findByStudentId(clubMasterStudentId);
+        verify(clubRepository, never()).save(any(Club.class));
+    }
+
+    @Test
+    @DisplayName("동아리 관리 상세 정보를 조회한다")
+    void getClubManageDetail() {
+        //given
+        final Long userId = 1L;
+        final Long clubId = club1.getId();
+
+        final User clubMasterUser = User.builder()
+                .name("동아리장")
+                .email("master@test.com")
+                .studentId("20201234")
+                .grade("3")
+                .department("컴퓨터공학과")
+                .build();
+        ReflectionTestUtils.setField(clubMasterUser, "id", userId);
+        ReflectionTestUtils.setField(clubMasterUser, "role", UserRole.CLUB_MASTER);
+        ReflectionTestUtils.setField(club1, "clubMasterStudentId", clubMasterUser.getStudentId());
+
+        BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(clubMasterUser));
+        BDDMockito.given(clubRepository.findById(clubId)).willReturn(Optional.of(club1));
+        BDDMockito.given(appDataS3Client.getPresignedUrl(club1.getLogo())).willReturn("testLogo1");
+
+        //when
+        ClubManageDetailResponse response = clubService.getClubManageDetail(userId, clubId);
+
+        //then
+        assertThat(response).isNotNull();
+        assertThat(response.name()).isEqualTo("testClub1");
+        assertThat(response.category()).isEqualTo(ClubCategory.ACADEMIC_CULTURAL.name());
+        assertThat(response.affiliation()).isEqualTo(ClubAffiliation.CENTRAL_CLUB.name());
+        assertThat(response.description()).isEqualTo("testDescription1");
+        assertThat(response.logo()).isEqualTo("testLogo1");
+        assertThat(response.instagram()).isEqualTo("testInstagramURL1");
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(clubRepository, times(1)).findById(clubId);
+    }
+
+    @Test
+    @DisplayName("동아리 관리 권한이 없으면 예외를 던진다")
+    void getClubManageDetailShouldThrowExceptionWhenNoPermission() {
+        //given
+        final Long userId = 1L;
+        final Long clubId = club1.getId();
+
+        final User normalUser = User.builder()
+                .name("일반 사용자")
+                .email("user@test.com")
+                .studentId("12345678")
+                .grade("4")
+                .department("컴퓨터공학과")
+                .build();
+        ReflectionTestUtils.setField(normalUser, "id", userId);
+        ReflectionTestUtils.setField(normalUser, "role", UserRole.NORMAL);
+
+        BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(normalUser));
+        BDDMockito.given(clubRepository.findById(clubId)).willReturn(Optional.of(club1));
+
+        //when & then
+        assertThatThrownBy(() -> clubService.getClubManageDetail(userId, clubId))
+                .isInstanceOf(MokkojiException.class)
+                .hasMessage(FailMessage.FORBIDDEN_MANAGE_CLUB.getMessage());
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(clubRepository, times(1)).findById(clubId);
+    }
+
+    @Test
+    @DisplayName("동아리 정보를 수정한다")
+    void updateClub() {
+        //given
+        final Long userId = 1L;
+        final Long clubId = club1.getId();
+        final String updatedName = "수정된 동아리명";
+        final ClubCategory updatedCategory = ClubCategory.SPORTS;
+        final ClubAffiliation updatedAffiliation = ClubAffiliation.DEPARTMENT_CLUB;
+        final String updatedDescription = "수정된 설명";
+        final String updatedLogo = "updatedLogo.jpg";
+        final String updatedInstagram = "updatedInstagram";
+
+        final User clubMasterUser = User.builder()
+                .name("동아리장")
+                .email("master@test.com")
+                .studentId("20201234")
+                .grade("3")
+                .department("컴퓨터공학과")
+                .build();
+        ReflectionTestUtils.setField(clubMasterUser, "id", userId);
+        ReflectionTestUtils.setField(clubMasterUser, "role", UserRole.CLUB_MASTER);
+        ReflectionTestUtils.setField(club1, "clubMasterStudentId", clubMasterUser.getStudentId());
+
+        BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(clubMasterUser));
+        BDDMockito.given(clubRepository.findById(clubId)).willReturn(Optional.of(club1));
+        BDDMockito.given(appDataS3Client.getPresignedPutUrl(any())).willReturn("presignedPutUrl");
+        BDDMockito.given(appDataS3Client.getPresignedDeleteUrl(any())).willReturn("presignedDeleteUrl");
+
+        //when
+        ClubUpdateResponse response = clubService.updateClub(userId, clubId, updatedName, updatedCategory,
+                updatedAffiliation, updatedDescription, null, updatedLogo, updatedInstagram);
+
+        //then
+        assertThat(response).isNotNull();
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(clubRepository, times(1)).findById(clubId);
+    }
+
+    @Test
+    @DisplayName("동아리장을 변경하면 역할이 업데이트된다")
+    void updateClubWithNewClubMaster() {
+        //given
+        final Long userId = 1L;
+        final Long clubId = club1.getId();
+        final String previousMasterStudentId = "20201234";
+        final String newMasterStudentId = "20205678";
+
+        final User clubAdminUser = User.builder()
+                .name("동아리 관리자")
+                .email("admin@test.com")
+                .studentId("12345678")
+                .grade("4")
+                .department("컴퓨터공학과")
+                .build();
+        ReflectionTestUtils.setField(clubAdminUser, "id", userId);
+        ReflectionTestUtils.setField(clubAdminUser, "role", UserRole.CLUB_ADMIN);
+
+        final User previousMaster = User.builder()
+                .name("이전 동아리장")
+                .email("previous@test.com")
+                .studentId(previousMasterStudentId)
+                .grade("4")
+                .department("컴퓨터공학과")
+                .build();
+        ReflectionTestUtils.setField(previousMaster, "id", 2L);
+        ReflectionTestUtils.setField(previousMaster, "role", UserRole.CLUB_MASTER);
+        ReflectionTestUtils.setField(club1, "clubMasterStudentId", previousMasterStudentId);
+
+        final User newMaster = User.builder()
+                .name("새 동아리장")
+                .email("new@test.com")
+                .studentId(newMasterStudentId)
+                .grade("3")
+                .department("컴퓨터공학과")
+                .build();
+        ReflectionTestUtils.setField(newMaster, "id", 3L);
+        ReflectionTestUtils.setField(newMaster, "role", UserRole.NORMAL);
+
+        BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(clubAdminUser));
+        BDDMockito.given(clubRepository.findById(clubId)).willReturn(Optional.of(club1));
+        BDDMockito.given(userRepository.findByStudentId(previousMasterStudentId)).willReturn(Optional.of(previousMaster));
+        BDDMockito.given(userRepository.findByStudentId(newMasterStudentId)).willReturn(Optional.of(newMaster));
+
+        //when
+        clubService.updateClub(userId, clubId, null, null, null, null, newMasterStudentId, null, null);
+
+        //then
+        verify(userRepository, times(1)).findById(userId);
+        verify(clubRepository, times(1)).findById(clubId);
+        verify(userRepository, times(1)).findByStudentId(previousMasterStudentId);
+        verify(userRepository, times(1)).findByStudentId(newMasterStudentId);
+    }
+
+    @Test
+    @DisplayName("즐겨찾기한 동아리가 목록 상단에 표시된다")
+    void findClubsSortedByFavorite() {
+        //given
+        final Long userId = 1L;
+        final Long clubId1 = club1.getId();
+        final Long clubId2 = club2.getId();
+        final Pageable pageable = PageRequest.of(0, 10);
+        final List<Club> clubs = List.of(club1, club2);
+        final Page<Club> clubPage = new PageImpl<>(clubs, pageable, clubs.size());
+
+        BDDMockito.given(clubRepository.findClubs(any(), any(), any(), any(), any())).willReturn(clubPage);
+        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByUpdatedAtDesc(clubId1)).willReturn(Optional.ofNullable(recruitment1));
+        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByUpdatedAtDesc(clubId2)).willReturn(Optional.ofNullable(recruitment2));
+        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, clubId1)).willReturn(false);
+        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, clubId2)).willReturn(true);
+        BDDMockito.given(appDataS3Client.getPresignedUrl(club1.getLogo())).willReturn("testLogo1");
+        BDDMockito.given(appDataS3Client.getPresignedUrl(club2.getLogo())).willReturn("testLogo2");
+
+        //when
+        final ClubsPaginationResponse response = clubService.findClubsByConditions(userId, null, null, null, null, pageable);
+
+        //then
+        assertThat(response.clubs()).hasSize(2);
+        assertThat(response.clubs().get(0).name()).isEqualTo("testClub2");
+        assertThat(response.clubs().get(0).isFavorite()).isTrue();
+        assertThat(response.clubs().get(1).name()).isEqualTo("testClub1");
+        assertThat(response.clubs().get(1).isFavorite()).isFalse();
     }
 }

--- a/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
+++ b/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
@@ -36,6 +36,7 @@ public class Fixture {
     public static Recruitment createRecruitment(Club club) {
         return Recruitment.builder()
                 .club(club)
+                .title("제목")
                 .recruitStart(LocalDateTime.of(2025, 01, 01, 12, 00, 00))
                 .recruitEnd(LocalDateTime.of(2025, 02, 02, 12, 00, 00))
                 .content("그리디 모집글")


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #271 

## 👷 **작업한 내용** #27 

 - [x] ClubControllerTest 신규 작성
 - [x] ClubServiceTest 신규 작성 
 - [x] Fixture 개선 - Recruitment 엔티티에 title 필드 추가
 - [x] Service 로고 변경 로직 수정 - 로고 업데이트 시 새 로고 키 생성 및 기존 로고 삭제 URL 생성 로직 개선
  

## 🚨 **참고 사항**
- 혹시 수정해야 할 코드나 추가 테스트가 필요하면 편하게 말씀해주세요!
