### PR TITLE
Fix: Favorite 테스트 코드 수정 및 보완

### DIFF
--- a/src/main/java/com/greedy/mokkoji/db/recruitment/entity/Recruitment.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/entity/Recruitment.java
@@ -40,7 +40,7 @@ public class Recruitment extends BaseTime {
     @Column(name = "recruit_form", columnDefinition = "text")
     private String recruitForm;
 
-    @Column(name = "is_always_recruiting", columnDefinition = "tinyint(1)", nullable = false)
+    @Column(name = "is_always_recruiting", columnDefinition = "BOOLEAN", nullable = false)
     private boolean isAlwaysRecruiting;
 
     @Builder

--- a/src/main/java/com/greedy/mokkoji/db/user/entity/User.java
+++ b/src/main/java/com/greedy/mokkoji/db/user/entity/User.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "user")
+@Table(name = "`user`")
 public class User {
 
     @Id

--- a/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
+++ b/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
@@ -36,8 +36,8 @@ public class Fixture {
     public static Recruitment createRecruitment(Club club) {
         return Recruitment.builder()
             .club(club)
-            .recruitStart(LocalDateTime.of(2025, 1, 1, 12, 00, 00))
-            .recruitEnd(LocalDateTime.of(2025, 2, 2, 12, 00, 00))
+            .recruitStart(LocalDateTime.of(2025, 1, 1, 12, 0, 0))
+            .recruitEnd(LocalDateTime.of(2025, 2, 2, 12, 0, 0))
             .title("모집글 제목")
             .content("그리디 모집글")
             .isAlwaysRecruiting(false)
@@ -47,8 +47,8 @@ public class Fixture {
     public static Recruitment createRecruitmentOfAugust(Club club) {
         return Recruitment.builder()
             .club(club)
-            .recruitStart(LocalDateTime.of(2025, 8, 1, 12, 00, 00))
-            .recruitEnd(LocalDateTime.of(2025, 9, 2, 12, 00, 00))
+            .recruitStart(LocalDateTime.of(2025, 8, 1, 12, 0, 0))
+            .recruitEnd(LocalDateTime.of(2025, 9, 2, 12, 0, 0))
             .title("8월 모집글")
             .content("그리디 모집글")
             .isAlwaysRecruiting(false)

--- a/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
+++ b/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
@@ -38,7 +38,9 @@ public class Fixture {
                 .club(club)
                 .recruitStart(LocalDateTime.of(2025, 01, 01, 12, 00, 00))
                 .recruitEnd(LocalDateTime.of(2025, 02, 02, 12, 00, 00))
+                .title("모집글 제목")
                 .content("그리디 모집글")
+                .isAlwaysRecruiting(false)
                 .build();
     }
 

--- a/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
+++ b/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
@@ -6,49 +6,70 @@ import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
-
 import java.time.LocalDateTime;
 
 public class Fixture {
+
     public static final String FIXTURE_CLUB_LOGO = "그리디_로고";
 
     public static User createUser() {
         return User.builder()
-                .name("모꼬지")
-                .studentId("12341234")
-                .grade("4")
-                .department("컴퓨터공학과")
-                .email("모꼬지@test.com")
-                .build();
+            .name("모꼬지")
+            .studentId("12341234")
+            .grade("4")
+            .department("컴퓨터공학과")
+            .email("모꼬지@test.com")
+            .build();
     }
 
     public static Club createClub() {
         return Club.builder()
-                .name("그리디")
-                .clubCategory(ClubCategory.ACADEMIC_CULTURAL)
-                .clubAffiliation(ClubAffiliation.DEPARTMENT_CLUB)
-                .logo(FIXTURE_CLUB_LOGO)
-                .description("세종대 최고의 코딩 동아리")
-                .instagram("www.그리디.com")
-                .build();
+            .name("그리디")
+            .clubCategory(ClubCategory.ACADEMIC_CULTURAL)
+            .clubAffiliation(ClubAffiliation.DEPARTMENT_CLUB)
+            .logo(FIXTURE_CLUB_LOGO)
+            .description("세종대 최고의 코딩 동아리")
+            .instagram("www.그리디.com")
+            .build();
     }
 
     public static Recruitment createRecruitment(Club club) {
         return Recruitment.builder()
-                .club(club)
-                .recruitStart(LocalDateTime.of(2025, 01, 01, 12, 00, 00))
-                .recruitEnd(LocalDateTime.of(2025, 02, 02, 12, 00, 00))
-                .title("모집글 제목")
-                .content("그리디 모집글")
-                .isAlwaysRecruiting(false)
-                .build();
+            .club(club)
+            .recruitStart(LocalDateTime.of(2025, 1, 1, 12, 00, 00))
+            .recruitEnd(LocalDateTime.of(2025, 2, 2, 12, 00, 00))
+            .title("모집글 제목")
+            .content("그리디 모집글")
+            .isAlwaysRecruiting(false)
+            .build();
+    }
+
+    public static Recruitment createRecruitmentOfAugust(Club club) {
+        return Recruitment.builder()
+            .club(club)
+            .recruitStart(LocalDateTime.of(2025, 8, 1, 12, 00, 00))
+            .recruitEnd(LocalDateTime.of(2025, 9, 2, 12, 00, 00))
+            .title("8월 모집글")
+            .content("그리디 모집글")
+            .isAlwaysRecruiting(false)
+            .build();
+    }
+
+    public static Recruitment createLastedRecruitmentOfAugust(Club club) {
+        return Recruitment.builder()
+            .club(club)
+            .recruitStart(LocalDateTime.of(2025, 8, 1, 12, 0, 0))
+            .recruitEnd(LocalDateTime.of(2025, 9, 2, 12, 0, 0))
+            .title("8월 최신 모집글")
+            .content("그리디 모집글")
+            .isAlwaysRecruiting(false)
+            .build();
     }
 
     public static Favorite createFavorite(Club club, User user) {
         return Favorite.builder()
-                .club(club)
-                .user(user)
-                .build();
+            .club(club)
+            .user(user)
+            .build();
     }
 }
-

--- a/src/test/java/com/greedy/mokkoji/favorite/controller/FavoriteControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/favorite/controller/FavoriteControllerTest.java
@@ -198,7 +198,7 @@ public class FavoriteControllerTest extends ControllerTest {
 
         RecruitClubsResponse recruitClubResponse = recruitList.get(0);
 
-        assertThat(recruitClubResponse.clubId()).isEqualTo(1L);
+        assertThat(recruitClubResponse.clubId()).isEqualTo(favoriteClub.getId());
         assertThat(recruitClubResponse.clubName()).isEqualTo("그리디");
         assertThat(recruitClubResponse.recruitStart()).isEqualTo(LocalDateTime.of(2025, 1, 1, 12, 0, 0));
         assertThat(recruitClubResponse.recruitEnd()).isEqualTo(LocalDateTime.of(2025, 2, 2, 12, 0, 0));
@@ -228,7 +228,7 @@ public class FavoriteControllerTest extends ControllerTest {
 
         RecruitClubsResponse recruitClubResponse = recruitList.get(0);
 
-        assertThat(recruitClubResponse.clubId()).isEqualTo(1L);
+        assertThat(recruitClubResponse.clubId()).isEqualTo(favoriteClub.getId());
         assertThat(recruitClubResponse.clubName()).isEqualTo("그리디");
         assertThat(recruitClubResponse.recruitStart()).isEqualTo(LocalDateTime.of(2025, 8, 1, 12, 0, 0));
         assertThat(recruitClubResponse.recruitEnd()).isEqualTo(LocalDateTime.of(2025, 9, 2, 12, 0, 0));
@@ -258,7 +258,7 @@ public class FavoriteControllerTest extends ControllerTest {
 
         RecruitClubsResponse recruitClubResponse = recruitList.get(0);
 
-        assertThat(recruitClubResponse.clubId()).isEqualTo(1L);
+        assertThat(recruitClubResponse.clubId()).isEqualTo(favoriteClub.getId());
         assertThat(recruitClubResponse.clubName()).isEqualTo("그리디");
         assertThat(recruitClubResponse.recruitStart()).isEqualTo(LocalDateTime.of(2025, 8, 1, 12, 0, 0));
         assertThat(recruitClubResponse.recruitEnd()).isEqualTo(LocalDateTime.of(2025, 9, 2, 12, 0, 0));

--- a/src/test/java/com/greedy/mokkoji/favorite/controller/FavoriteControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/favorite/controller/FavoriteControllerTest.java
@@ -1,5 +1,8 @@
 package com.greedy.mokkoji.favorite.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.greedy.mokkoji.api.favorite.dto.response.RecruitClubsResponse;
 import com.greedy.mokkoji.common.ControllerTest;
 import com.greedy.mokkoji.common.fixture.Fixture;
 import com.greedy.mokkoji.common.response.APIErrorResponse;
@@ -9,13 +12,12 @@ import com.greedy.mokkoji.enums.message.FailMessage;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @SuppressWarnings("NonAsciiCharacters")
 public class FavoriteControllerTest extends ControllerTest {
@@ -37,19 +39,22 @@ public class FavoriteControllerTest extends ControllerTest {
         user = userRepository.save(Fixture.createUser());
         favoriteClub = clubRepository.save(Fixture.createClub());
         notFavoriteClub = clubRepository.save(Fixture.createClub());
-        recruitmentRepository.saveAll(List.of(Fixture.createRecruitment(favoriteClub), Fixture.createRecruitment(notFavoriteClub)));
+        recruitmentRepository.saveAll(
+            List.of(Fixture.createRecruitment(favoriteClub), Fixture.createRecruitment(notFavoriteClub))
+        );
         favoriteRepository.save(Fixture.createFavorite(favoriteClub, user));
     }
 
     @Test
-    void 즐겨찾기_성공_테스트() {
+    @DisplayName("즐겨찾기를 추가한다.")
+    void addFavorite() {
         // given & when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .header("Authorization", authorizationForBearerAccessToken(user))
-                .pathParam("clubId", notFavoriteClub.getId())
-                .when().post(prefixUrl + "/favorites/{clubId}")
-                .then().log().all()
-                .extract();
+            .header("Authorization", authorizationForBearerAccessToken(user))
+            .pathParam("clubId", notFavoriteClub.getId())
+            .when().post(prefixUrl + "/favorites/{clubId}")
+            .then().log().all()
+            .extract();
 
         // then
         final int actualStatusCode = response.statusCode();
@@ -58,35 +63,56 @@ public class FavoriteControllerTest extends ControllerTest {
     }
 
     @Test
-    void 즐겨찾기가_되어있는_곳에_즐겨찾기_요청시_409를_응답한다() {
+    @DisplayName("이미 즐겨찾기된 동아리에 즐겨찾기 요청을 보내면 409 Conflict 응답을 반환한다.")
+    void addFavorite_whenAlreadyFavorited_shouldReturn409() {
         // given & when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .header("Authorization", authorizationForBearerAccessToken(user))
-                .pathParam("clubId", favoriteClub.getId())
-                .when().post(prefixUrl + "/favorites/{clubId}")
-                .then().log().all()
-                .extract();
-
+            .header("Authorization", authorizationForBearerAccessToken(user))
+            .pathParam("clubId", favoriteClub.getId())
+            .when().post(prefixUrl + "/favorites/{clubId}")
+            .then().log().all()
+            .extract();
 
         // then
         final int actualStatusCode = response.statusCode();
         final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
-        final APIErrorResponse expectedResponse = new APIErrorResponse(FailMessage.CONFLICT_FAVORITE.getCode(), FailMessage.CONFLICT_FAVORITE.getMessage());
+        final APIErrorResponse expectedResponse = new APIErrorResponse(FailMessage.CONFLICT_FAVORITE.getCode(),
+            FailMessage.CONFLICT_FAVORITE.getMessage());
 
         assertThat(actualStatusCode).isEqualTo(HttpStatus.CONFLICT.value());
         assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
     }
 
-
     @Test
-    void 즐겨찾기_삭제_성공_테스트() {
+    @DisplayName("토큰 없이 즐겨찾기 추가 요청 시 401 Unauthorized 응답을 반환한다.")
+    void addFavorite_withoutToken_shouldReturn401() {
         // given & when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .header("Authorization", authorizationForBearerAccessToken(user))
-                .pathParam("clubId", favoriteClub.getId())
-                .when().delete(prefixUrl + "/favorites/{clubId}")
-                .then().log().all()
-                .extract();
+            .pathParam("clubId", notFavoriteClub.getId())
+            .when().post(prefixUrl + "/favorites/{clubId}")
+            .then().log().all()
+            .extract();
+
+        // then
+        final int actualStatusCode = response.statusCode();
+        final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
+        final APIErrorResponse expectedResponse = new APIErrorResponse(FailMessage.UNAUTHORIZED_EMPTY_HEADER.getCode(),
+            FailMessage.UNAUTHORIZED_EMPTY_HEADER.getMessage());
+
+        assertThat(actualStatusCode).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+    }
+
+    @Test
+    @DisplayName("즐겨찾기를 삭제한다.")
+    void deleteFavorite() {
+        // given & when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .header("Authorization", authorizationForBearerAccessToken(user))
+            .pathParam("clubId", favoriteClub.getId())
+            .when().delete(prefixUrl + "/favorites/{clubId}")
+            .then().log().all()
+            .extract();
 
         // then
         final int actualStatusCode = response.statusCode();
@@ -95,57 +121,171 @@ public class FavoriteControllerTest extends ControllerTest {
     }
 
     @Test
-    void 즐겨찾기_안_되어_있는곳에_즐겨찾기_삭제시_401을_응답한다() {
+    @DisplayName("즐겨찾기 되지 않은 동아리를 삭제하면 404 Not Found 응답을 반환한다.")
+    void deleteFavorite_whenNotFavorited_shouldReturn404() {
         // given & when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .header("Authorization", authorizationForBearerAccessToken(user))
-                .pathParam("clubId", notFavoriteClub.getId())
-                .when().delete(prefixUrl + "/favorites/{clubId}")
-                .then().log().all()
-                .extract();
+            .header("Authorization", authorizationForBearerAccessToken(user))
+            .pathParam("clubId", notFavoriteClub.getId())
+            .when().delete(prefixUrl + "/favorites/{clubId}")
+            .then().log().all()
+            .extract();
 
         // then
         final int actualStatusCode = response.statusCode();
         final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
-        final APIErrorResponse expectedResponse = new APIErrorResponse(FailMessage.NOT_FOUND_FAVORITE.getCode(), FailMessage.NOT_FOUND_FAVORITE.getMessage());
+        final APIErrorResponse expectedResponse = new APIErrorResponse(FailMessage.NOT_FOUND_FAVORITE.getCode(),
+            FailMessage.NOT_FOUND_FAVORITE.getMessage());
 
         assertThat(actualStatusCode).isEqualTo(HttpStatus.NOT_FOUND.value());
         assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
     }
 
     @Test
-    void 토큰없이_즐겨찾기_추가시_404에러를_응답한다() {
+    @DisplayName("토큰 없이 즐겨찾기 삭제 요청 시 401 Unauthorized 응답을 반환한다.")
+    void deleteFavorite_withoutToken_shouldReturn401() {
         // given & when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .pathParam("clubId", notFavoriteClub.getId())
-                .when().post(prefixUrl + "/favorites/{clubId}")
-                .then().log().all()
-                .extract();
+            .pathParam("clubId", notFavoriteClub.getId())
+            .when().delete(prefixUrl + "/favorites/{clubId}")
+            .then().log().all()
+            .extract();
 
         // then
         final int actualStatusCode = response.statusCode();
         final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
-        final APIErrorResponse expectedResponse = new APIErrorResponse(FailMessage.UNAUTHORIZED_EMPTY_HEADER.getCode(), FailMessage.UNAUTHORIZED_EMPTY_HEADER.getMessage());
+        final APIErrorResponse expectedResponse = new APIErrorResponse(FailMessage.UNAUTHORIZED_EMPTY_HEADER.getCode(),
+            FailMessage.UNAUTHORIZED_EMPTY_HEADER.getMessage());
 
         assertThat(actualStatusCode).isEqualTo(HttpStatus.UNAUTHORIZED.value());
         assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
     }
 
     @Test
-    void 토큰없이_즐겨찾기_삭제시_404에러를_응답한다() {
+    @DisplayName("즐겨찾기한 동아리를 조회한다.")
+    void getFavoriteClubs() {
         // given & when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .pathParam("clubId", notFavoriteClub.getId())
-                .when().delete(prefixUrl + "/favorites/{clubId}")
-                .then().log().all()
-                .extract();
+            .header("Authorization", authorizationForBearerAccessToken(user))
+            .param("page", 1)
+            .param("size", 5)
+            .when().get(prefixUrl + "/favorites")
+            .then().log().all()
+            .extract();
 
         // then
         final int actualStatusCode = response.statusCode();
-        final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
-        final APIErrorResponse expectedResponse = new APIErrorResponse(FailMessage.UNAUTHORIZED_EMPTY_HEADER.getCode(), FailMessage.UNAUTHORIZED_EMPTY_HEADER.getMessage());
 
-        assertThat(actualStatusCode).isEqualTo(HttpStatus.UNAUTHORIZED.value());
-        assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+        assertThat(actualStatusCode).isEqualTo(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("즐겨찾기 되어 있는 동아리 중, 해당 연월에 모집하는 동아리의 모집 정보를 조회한다.")
+    void getRecruitClubs() {
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .header("Authorization", authorizationForBearerAccessToken(user))
+            .param("yearMonth", "2025-01")
+            .when().get(prefixUrl + "/favorites/recruit")
+            .then().log().all()
+            .extract();
+
+        final int actualStatusCode = response.statusCode();
+
+        assertThat(actualStatusCode).isEqualTo(HttpStatus.OK.value());
+
+        List<RecruitClubsResponse> recruitList =
+            response.jsonPath().getList("data", RecruitClubsResponse.class);
+
+        RecruitClubsResponse recruitClubResponse = recruitList.get(0);
+
+        assertThat(recruitClubResponse.clubId()).isEqualTo(1L);
+        assertThat(recruitClubResponse.clubName()).isEqualTo("그리디");
+        assertThat(recruitClubResponse.recruitStart()).isEqualTo(LocalDateTime.of(2025, 1, 1, 12, 0, 0));
+        assertThat(recruitClubResponse.recruitEnd()).isEqualTo(LocalDateTime.of(2025, 2, 2, 12, 0, 0));
+    }
+
+    @DisplayName("특정 연월에 모집 중인 즐겨찾기 동아리의 최신 모집 정보를 조회한다. - 모집 시작일이 겹치는 경우를 검증한다.")
+    @Test
+    void getRecruitClubsWhenRecruitStartInYearMonth() {
+        recruitmentRepository.saveAll(
+            List.of(Fixture.createRecruitmentOfAugust(favoriteClub),
+                Fixture.createLastedRecruitmentOfAugust(favoriteClub))
+        );
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .header("Authorization", authorizationForBearerAccessToken(user))
+            .param("yearMonth", "2025-08")
+            .when().get(prefixUrl + "/favorites/recruit")
+            .then().log().all()
+            .extract();
+
+        final int actualStatusCode = response.statusCode();
+
+        assertThat(actualStatusCode).isEqualTo(HttpStatus.OK.value());
+
+        List<RecruitClubsResponse> recruitList =
+            response.jsonPath().getList("data", RecruitClubsResponse.class);
+
+        RecruitClubsResponse recruitClubResponse = recruitList.get(0);
+
+        assertThat(recruitClubResponse.clubId()).isEqualTo(1L);
+        assertThat(recruitClubResponse.clubName()).isEqualTo("그리디");
+        assertThat(recruitClubResponse.recruitStart()).isEqualTo(LocalDateTime.of(2025, 8, 1, 12, 0, 0));
+        assertThat(recruitClubResponse.recruitEnd()).isEqualTo(LocalDateTime.of(2025, 9, 2, 12, 0, 0));
+    }
+
+    @DisplayName("특정 연월에 모집 중인 즐겨찾기 동아리의 최신 모집 정보를 조회한다. - 모집 마감일이 겹치는 경우를 검증한다.")
+    @Test
+    void getRecruitClubsWhenRecruitEndInYearMonth() {
+        recruitmentRepository.saveAll(
+            List.of(Fixture.createRecruitmentOfAugust(favoriteClub),
+                Fixture.createLastedRecruitmentOfAugust(favoriteClub))
+        );
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .header("Authorization", authorizationForBearerAccessToken(user))
+            .param("yearMonth", "2025-09")
+            .when().get(prefixUrl + "/favorites/recruit")
+            .then().log().all()
+            .extract();
+
+        final int actualStatusCode = response.statusCode();
+
+        assertThat(actualStatusCode).isEqualTo(HttpStatus.OK.value());
+
+        List<RecruitClubsResponse> recruitList =
+            response.jsonPath().getList("data", RecruitClubsResponse.class);
+
+        RecruitClubsResponse recruitClubResponse = recruitList.get(0);
+
+        assertThat(recruitClubResponse.clubId()).isEqualTo(1L);
+        assertThat(recruitClubResponse.clubName()).isEqualTo("그리디");
+        assertThat(recruitClubResponse.recruitStart()).isEqualTo(LocalDateTime.of(2025, 8, 1, 12, 0, 0));
+        assertThat(recruitClubResponse.recruitEnd()).isEqualTo(LocalDateTime.of(2025, 9, 2, 12, 0, 0));
+    }
+
+    @DisplayName("특정 연월에 해당하는 즐겨찾기 동아리의 모집글이 없으면 빈 리스트를 반환한다.")
+    @Test
+    void getRecruitClubsWhenNoRecruitmentInYearMonth() {
+        recruitmentRepository.saveAll(
+            List.of(Fixture.createRecruitmentOfAugust(favoriteClub),
+                Fixture.createLastedRecruitmentOfAugust(favoriteClub))
+        );
+
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .header("Authorization", authorizationForBearerAccessToken(user))
+            .param("yearMonth", "2025-10")
+            .when().get(prefixUrl + "/favorites/recruit")
+            .then().log().all()
+            .extract();
+
+        final int actualStatusCode = response.statusCode();
+
+        assertThat(actualStatusCode).isEqualTo(HttpStatus.OK.value());
+
+        List<RecruitClubsResponse> recruitList =
+            response.jsonPath().getList("data", RecruitClubsResponse.class);
+
+        assertThat(recruitList).isEmpty();
     }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #263 

## 👷 **작업한 내용**
Favorite 관련하여 테스트 코드를 보완 및 수정하였습니다.
구체적인 작업 내용은 다음과 같습니다.

**1. Favorite Controller 테스트가 깨지는 문제를 해결했습니다.**
**2. 테스트 코드가 작성되지 않은 "/favorites/recruit" API에 대한 통합테스트를 추가하였습니다. 테스트 단에서는 h2 db를 사용하여 실제 db단까지 검증할 수 있도록 구현했습니다. 각 상황에 따른 객체를 생성 시에는 Fixture 클래스에 정의하여 해당 클래스 메서드를 활용하는 방식으로 간편하게 구현하고 의도를 명시했습니다.**

### 검증 화면
<img width="755" height="598" alt="스크린샷 2025-11-25 오후 12 58 00" src="https://github.com/user-attachments/assets/f2d2428e-bc0b-4743-b279-ce4fa5078286" />


## 🚨 **참고 사항**
이번 작업 과정에서 테스트 환경(h2 DB)에서 다음과 같은 문제가 확인되어 수정이 필요했습니다.

1. ### **User 엔티티의 테이블명이 user로 설정되어 있었던 문제**

h2에서는 user가 예약어이기 때문에
백틱을 사용하지 않으면 쿼리 실행 시 오류가 발생합니다.

이를 해결하기 위해 User 엔티티의 `@Table` 내의 테이블 명 user에 백틱을 감싸 충돌을 방지했습니다.

2. ### **Recruitment 엔티티의 isAlwaysRecruiting 컬럼 타입 문제**

해당 컬럼의 columnDefinition이 TINYINT로 지정되어 있었는데,
이는 h2에서 지원하지 않는 타입이었습니다.

실제 운영 DB(MySQL)에서는 TINYINT가 boolean 대용으로 사용되므로 문제가 없지만,
테스트 DB(h2)에서는 매핑 오류가 발생했습니다.

이를 해결하기 위해 MySQL과 H2 모두 호환 가능한 BOOLEAN 타입으로 변경했습니다.

---
더 보완할 점이 보이신다면 편하게 말씀해주세요!
