### PR TITLE
Fix: 메일 전송 시 중복 동아리 제거 및 최신 모집 공고 선택

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/notification/service/EmailNotificationChannel.java
+++ b/src/main/java/com/greedy/mokkoji/api/notification/service/EmailNotificationChannel.java
@@ -24,8 +24,11 @@ public class EmailNotificationChannel implements NotificationChannel {
     private static final String SUBJECT = "동아리 모집 시작";
     private static final String SENDER_NAME = "모꼬지";
     private final JavaMailSender mailSender;
+
     @Value("${spring.mail.username}")
     private String senderMail;
+    @Value("${mokkoji.base-url}")
+    private String baseUrl;
 
     private String generateHtmlText(
             final Long clubId,
@@ -47,7 +50,8 @@ public class EmailNotificationChannel implements NotificationChannel {
                 "<p>모꼬지에서 즐겨찾기하신 <strong>" + clubName + "</strong> 동아리가 신규 회원을 모집합니다.</p>" +
                 "<p>📅 <strong>모집 기간:</strong> " + recruitStart.format(formatter) + " ~ " + recruitEnd.format(formatter) + "</p>" +
                 "<p>지금 바로 지원하여 기회를 놓치지 마세요!</p>" +
-                "<a href='https://mokkoji.vercel.app/clubs/" + clubId + "' style='display: inline-block; padding: 10px 20px; margin-top: 20px; font-size: 16px; color: white; background-color: #2E86C1; text-decoration: none; border-radius: 5px;'>신청하러 가기</a>" +
+                "<a href='" + baseUrl + "/club/" + clubId + "' " +
+                "style='display: inline-block; padding: 10px 20px; margin-top: 20px; font-size: 16px; color: white; background-color: #2E86C1; text-decoration: none; border-radius: 5px;'>신청하러 가기</a>" +
                 "<p>감사합니다!<br>모꼬지 팀 드림</p>" +
                 "</body>" +
                 "</html>";

--- a/src/main/java/com/greedy/mokkoji/api/scheduler/service/RecruitmentNotificationScheduler.java
+++ b/src/main/java/com/greedy/mokkoji/api/scheduler/service/RecruitmentNotificationScheduler.java
@@ -5,13 +5,15 @@ import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.db.recruitment.repository.RecruitmentRepository;
 import jakarta.transaction.Transactional;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @Slf4j
 @Service
@@ -31,6 +33,37 @@ public class RecruitmentNotificationScheduler {
 
         recruitments.addAll(recruitmentRepository.findAllByRecruitEndToday(today));
         recruitments.addAll(recruitmentRepository.findAllByRecruitEndInThreeDays(threeDaysLater));
+
+        // 1. Club을 키로, Recruitment를 값으로 하는 Map을 생성 (중복 제거 및 최신 선택)
+        Map<Club, Recruitment> latestRecruitmentsByClub = new HashMap<>();
+
+        for (Recruitment recruitment : recruitments) {
+            Club club = recruitment.getClub();
+
+            // 이미 해당 Club에 대한 Recruitment가 Map에 있다면
+            if (latestRecruitmentsByClub.containsKey(club)) {
+                Recruitment existingRecruitment = latestRecruitmentsByClub.get(club);
+
+                // 현재 것이 더 최신이면 Map의 값을 업데이트
+                if (recruitment.getCreatedAt().isAfter(existingRecruitment.getCreatedAt())) {
+                    latestRecruitmentsByClub.put(club, recruitment);
+                }
+            } else {
+                // Map에 없으면 새로운 항목으로 추가
+                latestRecruitmentsByClub.put(club, recruitment);
+            }
+        }
+
+        // 2. Map의 값(가장 최신 Recruitment들)만 추출하여 List로 다시 구성
+        List<Recruitment> uniqueAndLatestRecruitments = new ArrayList<>(latestRecruitmentsByClub.values());
+
+        // 3. 원래의 recruitments 변수에 새 List를 대입하여 forEach문의 입력으로 사용
+        recruitments = uniqueAndLatestRecruitments;
+
+        recruitments.forEach(recruitment -> {
+            Club club = recruitment.getClub();
+            notificationService.sendNotification(club, recruitment);
+        });
 
         recruitments.stream()
                 .filter(recruitment -> !recruitment.isAlwaysRecruiting())

--- a/src/main/java/com/greedy/mokkoji/api/scheduler/service/RecruitmentNotificationScheduler.java
+++ b/src/main/java/com/greedy/mokkoji/api/scheduler/service/RecruitmentNotificationScheduler.java
@@ -5,15 +5,14 @@ import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.db.recruitment.repository.RecruitmentRepository;
 import jakarta.transaction.Transactional;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -34,43 +33,24 @@ public class RecruitmentNotificationScheduler {
         recruitments.addAll(recruitmentRepository.findAllByRecruitEndToday(today));
         recruitments.addAll(recruitmentRepository.findAllByRecruitEndInThreeDays(threeDaysLater));
 
-        // 1. Club을 키로, Recruitment를 값으로 하는 Map을 생성 (중복 제거 및 최신 선택)
-        Map<Club, Recruitment> latestRecruitmentsByClub = new HashMap<>();
+        List<Recruitment> uniqueAndLatestRecruitments = recruitments.stream()
+                .filter(recruitment -> !recruitment.isAlwaysRecruiting())
+                .collect(Collectors.toMap(
+                        Recruitment::getClub,
+                        recruitment -> recruitment,
+                        (recruitment1, recruitment2) ->
+                                recruitment1.getCreatedAt().isAfter(recruitment2.getCreatedAt())
+                                        ? recruitment1
+                                        : recruitment2
+                ))
+                .values()
+                .stream()
+                .toList();
 
-        for (Recruitment recruitment : recruitments) {
-            Club club = recruitment.getClub();
-
-            // 이미 해당 Club에 대한 Recruitment가 Map에 있다면
-            if (latestRecruitmentsByClub.containsKey(club)) {
-                Recruitment existingRecruitment = latestRecruitmentsByClub.get(club);
-
-                // 현재 것이 더 최신이면 Map의 값을 업데이트
-                if (recruitment.getCreatedAt().isAfter(existingRecruitment.getCreatedAt())) {
-                    latestRecruitmentsByClub.put(club, recruitment);
-                }
-            } else {
-                // Map에 없으면 새로운 항목으로 추가
-                latestRecruitmentsByClub.put(club, recruitment);
-            }
-        }
-
-        // 2. Map의 값(가장 최신 Recruitment들)만 추출하여 List로 다시 구성
-        List<Recruitment> uniqueAndLatestRecruitments = new ArrayList<>(latestRecruitmentsByClub.values());
-
-        // 3. 원래의 recruitments 변수에 새 List를 대입하여 forEach문의 입력으로 사용
-        recruitments = uniqueAndLatestRecruitments;
-
-        recruitments.forEach(recruitment -> {
+        uniqueAndLatestRecruitments.forEach(recruitment -> {
             Club club = recruitment.getClub();
             notificationService.sendNotification(club, recruitment);
         });
-
-        recruitments.stream()
-                .filter(recruitment -> !recruitment.isAlwaysRecruiting())
-                .forEach(recruitment -> {
-                    Club club = recruitment.getClub();
-                    notificationService.sendNotification(club, recruitment);
-                });
     }
 }
 

--- a/src/main/java/com/greedy/mokkoji/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/greedy/mokkoji/config/swagger/SwaggerConfig.java
@@ -2,7 +2,6 @@ package com.greedy.mokkoji.config.swagger;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
-import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;

--- a/src/main/java/com/greedy/mokkoji/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/greedy/mokkoji/config/swagger/SwaggerConfig.java
@@ -2,6 +2,7 @@ package com.greedy.mokkoji.config.swagger;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #283 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
* 메일이 전송될 때 중복되어 전송되는 이슈를 해결했습니다.

[원인]
```java
        List<Recruitment> recruitments = recruitmentRepository.findAllByRecruitStartToday(today);

        recruitments.addAll(recruitmentRepository.findAllByRecruitEndToday(today));
        recruitments.addAll(recruitmentRepository.findAllByRecruitEndInThreeDays(threeDaysLater));
```
- 해당 부분에서는 오늘 등록, 오늘 마감, 3일뒤 마감인 공고가 불려옵니다.
- 이 때 `3일뒤 마감이거나 당일 마감인 모집공고`를 등록하게 된다면 2개의 중복된 Recruiment가 전송되게 됩니다.
- 또한, 하나의 동아리에서 여러 개의 모집 공고를 올린 경우 모든 모집 공고를 가져오는 문제가 있었습니다.

[해결]
- HashMap을 이용하여 중복을 제거했습니다.
    - 먼저 쿼리를 통해 중복을 제거하는 방법을 생각하긴 했으나 이 때 여러가지 조건을 붙이게 되면 더 성능이 낮아질 것을 우려하여 우선은 Service 로직에서 이를 해결하고자 했습니다.
    - 이후 더 좋은 성능을 낼 수 있는 방향이 있는지 확인하고 개선하면 좋을 듯 싶습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
