### PR TITLE
Fix: Club 테스트 코드 수정

### DIFF
--- a/src/test/java/com/greedy/mokkoji/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/club/controller/ClubControllerTest.java
@@ -208,7 +208,7 @@ public class ClubControllerTest extends ControllerTest {
                 .build();
         clubRepository.save(managedClub);
         String authorizationForBearer = authorizationForBearerAccessToken(adminUser);
-        when(appDataS3Client.getPresignedUrl(null)).thenReturn(null);
+        when(appDataS3Client.getPublicUrl(null)).thenReturn(null);
 
         //when
         final ExtractableResponse<Response> response = given().log().all()

--- a/src/test/java/com/greedy/mokkoji/club/service/ClubServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/club/service/ClubServiceTest.java
@@ -222,7 +222,7 @@ class ClubServiceTest {
         BDDMockito.given(clubRepository.findById(clubId)).willReturn(Optional.of(clubWithoutRecruitment));
         BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByUpdatedAtDesc(clubId)).willReturn(Optional.empty());
         BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, clubId)).willReturn(false);
-        BDDMockito.given(appDataS3Client.getPresignedUrl(clubWithoutRecruitment.getLogo())).willReturn("testLogo3");
+        BDDMockito.given(appDataS3Client.getPublicUrl(clubWithoutRecruitment.getLogo())).willReturn("testLogo3");
 
         //when
         ClubDetailResponse response = clubService.findClub(userId, clubId);
@@ -366,7 +366,7 @@ class ClubServiceTest {
 
         BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(clubMasterUser));
         BDDMockito.given(clubRepository.findById(clubId)).willReturn(Optional.of(club1));
-        BDDMockito.given(appDataS3Client.getPresignedUrl(club1.getLogo())).willReturn("testLogo1");
+        BDDMockito.given(appDataS3Client.getPublicUrl(club1.getLogo())).willReturn("testLogo1");
 
         //when
         ClubManageDetailResponse response = clubService.getClubManageDetail(userId, clubId);
@@ -524,8 +524,8 @@ class ClubServiceTest {
         BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByUpdatedAtDesc(clubId2)).willReturn(Optional.ofNullable(recruitment2));
         BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, clubId1)).willReturn(false);
         BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, clubId2)).willReturn(true);
-        BDDMockito.given(appDataS3Client.getPresignedUrl(club1.getLogo())).willReturn("testLogo1");
-        BDDMockito.given(appDataS3Client.getPresignedUrl(club2.getLogo())).willReturn("testLogo2");
+        BDDMockito.given(appDataS3Client.getPublicUrl(club1.getLogo())).willReturn("testLogo1");
+        BDDMockito.given(appDataS3Client.getPublicUrl(club2.getLogo())).willReturn("testLogo2");
 
         //when
         final ClubsPaginationResponse response = clubService.findClubsByConditions(userId, null, null, null, null, pageable);


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #292 

## 👷 **작업한 내용**
AppDataS3Client의 getPresignedUrl 메서드가 getPublicUrl로 변경되었으나 Club 테스트 코드에서는 여전히 기존 메서드를 사용하고 있어 테스트가 실패했습니다. 테스트가 현재 동작 방식에 맞게 실행되도록 getPublicUrl 사용으로 수정했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
