### PR TITLE
Fix: 특정 동아리의 모집글 최신 등록순으로 정렬하여 반환하도록 로직 수정

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -114,7 +114,7 @@ public class RecruitmentService {
         List<Recruitment> recruitments = recruitmentRepository.findAllByClubId(clubId);
 
         List<RecruitmentOfClubResponse> recruitmentList = recruitments.stream()
-                .sorted(Comparator.comparing(Recruitment::getRecruitEnd).reversed())
+                .sorted(Comparator.comparing(Recruitment::getId).reversed())
                 .map(recruitment -> RecruitmentOfClubResponse.builder()
                         .id(recruitment.getId())
                         .title(recruitment.getTitle())


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #294 

## 👷 **작업한 내용**
특정 동아리의 모집글 리스트 반환 시, 최신 등록순으로 정렬하여 반환하도록 수정했습니다.

**[기존 로직]**
기존에는 모집글들을 모집마감일 기준으로 정렬했었습니다. 

> ex) 3기 모집글 - 2기 모집글 - 1기 모집글 순

하지만 같은 모집 기수에서 모집글을 여러번 등록했을 경우, 모집마감일이 모두 동일하기 때문에 id가 오름차순으로 응답이 내려집니다.
이와 같은 상황에서는 최신순으로 정렬되지 않게 됩니다.

**[수정 로직]**
기존에는 모집글을 정렬할 때 모집 마감일(`recruitEnd`) 기준으로 정렬하고 있었습니다.
모집글이 생성될 때 createdAt 필드가 자동으로 저장되기 때문에, 모집 마감일보다 생성 시점을 기준으로 정렬하는 것이 더 자연스럽다고 판단하였습니다. 하지만, 정렬 기준을 생성 시각(`createdAt`) 기준으로 변경하려는 로직 수정 중 문제가 발생했습니다.

저희 프로젝트의 초기 단계에서는 모집글 API가 없었기 때문에 일부 데이터를 수동으로 DB에 넣어주었습니다.
이 과정에서 createdAt 필드가 null인 데이터가 다수 존재하게 되었습니다. 이에 따라 정렬 과정에서 다음과 같은 오류가 발생했습니다.

> Cannot invoke "java.lang.Comparable.compareTo(Object)" because the return value of "java.util.function.Function.apply(Object)" is null

## 문제 해결
createdAt이 null인 경우를 고려하여 정렬 기준을 id 필드로 대체하였습니다.
id는 모집글이 등록될수록 증가하므로, 이를 통해 최근 등록된 모집글을 판별하는 기준으로 사용할 수 있습니다.
따라서 createdAt이 null일 수 있는 상황에서도 안정적으로 정렬이 가능해졌습니다.

혹시 이 방법에 대해 어떻게 생각하시나요? 

## 논의 사항
1. 같은 기수의 모집들 중 제일 최신 모집글만 반환하도록 작업한다.
2. 기수 상관없이 최신 등록순대로 정렬하여 특정 동아리에 등록된 모든 모집글 반환한다.

전체 회의 때 위 두가지 내용에 대해 논의해보면 좋을 것 같아요.
우선 현재까지 의견 말씀해 주신분들의 의견에 공감하여 2번으로 진행했습니다!

## 🚨 **참고 사항**
현재 전체적인 테스트 커버리지는 거의 마무리되고 있어서 안정성이 확보되고 있는 것 같아요! 
다만, recruitment 도메인은 서비스 내에서 club만큼 핵심적인 기능을 담당하고 있기 때문에, 이 부분의 테스트 코드도 빠르게 보완해두면 좋을 것 같습니다~!!

[검증]
현재 recruitment 도메인에 대한 테스트 코드가 없어서 포스트맨으로 검증 완료했습니당