### PR TITLE
Feat: Comment 관련 테스트 코드 작성

### DIFF
--- a/src/test/java/com/greedy/mokkoji/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/comment/controller/CommentControllerTest.java
@@ -1,0 +1,281 @@
+package com.greedy.mokkoji.comment.controller;
+
+import com.greedy.mokkoji.api.comment.dto.request.CommentCreateRequest;
+import com.greedy.mokkoji.api.comment.dto.request.CommentUpdateRequest;
+import com.greedy.mokkoji.api.comment.dto.response.CommentListResponse;
+import com.greedy.mokkoji.common.ControllerTest;
+import com.greedy.mokkoji.common.fixture.Fixture;
+import com.greedy.mokkoji.common.response.APIErrorResponse;
+import com.greedy.mokkoji.db.club.entity.Club;
+import com.greedy.mokkoji.db.comment.entity.Comment;
+import com.greedy.mokkoji.db.user.entity.User;
+import com.greedy.mokkoji.enums.message.FailMessage;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CommentControllerTest extends ControllerTest {
+
+    private User user;
+    private User anotherUser;
+    private Club club;
+
+    @BeforeEach
+    void setUp() {
+        commentRepository.deleteAll();
+        favoriteRepository.deleteAll();
+        recruitmentRepository.deleteAll();
+        clubRepository.deleteAll();
+        userRepository.deleteAll();
+        prepareData();
+    }
+
+    private void prepareData() {
+        user = userRepository.save(Fixture.createUser());
+        anotherUser = userRepository.save(Fixture.createAnotherUser());
+        club = clubRepository.save(Fixture.createClub());
+    }
+
+    @Test
+    @DisplayName("댓글을 생성할 수 있다.")
+    void createComment() {
+        //given
+        String authorizationForBearer = authorizationForBearerAccessToken(user);
+        final CommentCreateRequest request = new CommentCreateRequest(5.0, "최고의 동아리입니다!");
+
+        //when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .body(request)
+                .when().post(prefixUrl + "/comments/{clubId}", club.getId())
+                .then().log().all()
+                .extract();
+
+        //then
+        final int statusCode = response.statusCode();
+        assertThat(statusCode).isEqualTo(HttpStatus.CREATED.value());
+
+        final Comment createdComment = commentRepository.findAll().get(0);
+        assertThat(createdComment.getUser().getId()).isEqualTo(user.getId());
+        assertThat(createdComment.getClub().getId()).isEqualTo(club.getId());
+        assertThat(createdComment.getRate()).isEqualTo(5.0);
+        assertThat(createdComment.getContent()).isEqualTo("최고의 동아리입니다!");
+    }
+
+    @Test
+    @DisplayName("이미 댓글이 존재하면 403를 반환한다.")
+    void createComment_WhenAlreadyExists() {
+        //given
+        final Comment existingComment = Comment.builder()
+                .user(user)
+                .club(club)
+                .rate(4.0)
+                .content("기존 댓글")
+                .build();
+        commentRepository.save(existingComment);
+
+        String authorizationForBearer = authorizationForBearerAccessToken(user);
+        final CommentCreateRequest request = new CommentCreateRequest(5.0, "새로운 댓글");
+
+        //when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .body(request)
+                .when().post(prefixUrl + "/comments/{clubId}", club.getId())
+                .then().log().all()
+                .extract();
+
+        //then
+        final int actualStatusCode = response.statusCode();
+        final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
+        final APIErrorResponse expectedResponse = new APIErrorResponse(
+                FailMessage.FORBIDDEN_ALREADY_EXIST_COMMENT.getCode(),
+                FailMessage.FORBIDDEN_ALREADY_EXIST_COMMENT.getMessage()
+        );
+
+        assertThat(actualStatusCode).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+    }
+
+    @Test
+    @DisplayName("동아리의 댓글 목록을 조회할 수 있다.")
+    void getComments() {
+        //given
+        final Comment comment1 = Comment.builder()
+                .user(user)
+                .club(club)
+                .rate(5.0)
+                .content("좋은 동아리입니다")
+                .build();
+        final Comment comment2 = Comment.builder()
+                .user(anotherUser)
+                .club(club)
+                .rate(4.0)
+                .content("추천합니다")
+                .build();
+        commentRepository.save(comment1);
+        commentRepository.save(comment2);
+
+        String authorizationForBearer = authorizationForBearerAccessToken(user);
+
+        //when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .when().get(prefixUrl + "/comments/{clubId}", club.getId())
+                .then().log().all()
+                .extract();
+
+        //then
+        final int statusCode = response.statusCode();
+        final CommentListResponse actual = getDataFromResponse(response, CommentListResponse.class);
+
+        assertThat(statusCode).isEqualTo(HttpStatus.OK.value());
+        assertThat(actual.comments()).hasSize(2);
+        assertThat(actual.comments().get(0).content()).isEqualTo("좋은 동아리입니다");
+        assertThat(actual.comments().get(0).rate()).isEqualTo(5.0);
+        assertThat(actual.comments().get(0).isWriter()).isTrue();
+        assertThat(actual.comments().get(1).content()).isEqualTo("추천합니다");
+        assertThat(actual.comments().get(1).isWriter()).isFalse();
+    }
+
+    @Test
+    @DisplayName("댓글을 수정할 수 있다.")
+    void updateComment() {
+        //given
+        final Comment comment = Comment.builder()
+                .user(user)
+                .club(club)
+                .rate(5.0)
+                .content("원래 댓글")
+                .build();
+        commentRepository.save(comment);
+
+        String authorizationForBearer = authorizationForBearerAccessToken(user);
+        final CommentUpdateRequest request = new CommentUpdateRequest(4.0, "수정된 댓글");
+
+        //when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .body(request)
+                .when().patch(prefixUrl + "/comments/{commentId}", comment.getId())
+                .then().log().all()
+                .extract();
+
+        //then
+        final int statusCode = response.statusCode();
+        assertThat(statusCode).isEqualTo(HttpStatus.OK.value());
+
+        final Comment updatedComment = commentRepository.findById(comment.getId()).orElseThrow();
+        assertThat(updatedComment.getRate()).isEqualTo(4.0);
+        assertThat(updatedComment.getContent()).isEqualTo("수정된 댓글");
+    }
+
+    @Test
+    @DisplayName("작성자가 아니면 댓글 수정 시 403을 반환한다.")
+    void updateComment_WhenNotWriter() {
+        //given
+        final Comment comment = Comment.builder()
+                .user(anotherUser)
+                .club(club)
+                .rate(5.0)
+                .content("다른 사람의 댓글")
+                .build();
+        commentRepository.save(comment);
+
+        String authorizationForBearer = authorizationForBearerAccessToken(user);
+        final CommentUpdateRequest request = new CommentUpdateRequest(4.0, "수정 시도");
+
+        //when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .body(request)
+                .when().patch(prefixUrl + "/comments/{commentId}", comment.getId())
+                .then().log().all()
+                .extract();
+
+        //then
+        final int actualStatusCode = response.statusCode();
+        final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
+        final APIErrorResponse expectedResponse = new APIErrorResponse(
+                FailMessage.FORBIDDEN_NOT_COMMENT_WRITER.getCode(),
+                FailMessage.FORBIDDEN_NOT_COMMENT_WRITER.getMessage()
+        );
+
+        assertThat(actualStatusCode).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+    }
+
+    @Test
+    @DisplayName("댓글을 삭제할 수 있다.")
+    void deleteComment() {
+        //given
+        final Comment comment = Comment.builder()
+                .user(user)
+                .club(club)
+                .rate(5.0)
+                .content("삭제할 댓글")
+                .build();
+        commentRepository.save(comment);
+
+        String authorizationForBearer = authorizationForBearerAccessToken(user);
+
+        //when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .when().delete(prefixUrl + "/comments/{commentId}", comment.getId())
+                .then().log().all()
+                .extract();
+
+        //then
+        final int statusCode = response.statusCode();
+        assertThat(statusCode).isEqualTo(HttpStatus.OK.value());
+        assertThat(commentRepository.findById(comment.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("작성자가 아니면 댓글 삭제 시 403을 반환한다.")
+    void deleteComment_WhenNotWriter() {
+        //given
+        final Comment comment = Comment.builder()
+                .user(anotherUser)
+                .club(club)
+                .rate(5.0)
+                .content("다른 사람의 댓글")
+                .build();
+        commentRepository.save(comment);
+
+        String authorizationForBearer = authorizationForBearerAccessToken(user);
+
+        //when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .when().delete(prefixUrl + "/comments/{commentId}", comment.getId())
+                .then().log().all()
+                .extract();
+
+        //then
+        final int actualStatusCode = response.statusCode();
+        final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
+        final APIErrorResponse expectedResponse = new APIErrorResponse(
+                FailMessage.FORBIDDEN_NOT_COMMENT_WRITER.getCode(),
+                FailMessage.FORBIDDEN_NOT_COMMENT_WRITER.getMessage()
+        );
+
+        assertThat(actualStatusCode).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+    }
+}

--- a/src/test/java/com/greedy/mokkoji/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/comment/controller/CommentControllerTest.java
@@ -3,6 +3,7 @@ package com.greedy.mokkoji.comment.controller;
 import com.greedy.mokkoji.api.comment.dto.request.CommentCreateRequest;
 import com.greedy.mokkoji.api.comment.dto.request.CommentUpdateRequest;
 import com.greedy.mokkoji.api.comment.dto.response.CommentListResponse;
+import com.greedy.mokkoji.api.comment.dto.response.CommentResponse;
 import com.greedy.mokkoji.common.ControllerTest;
 import com.greedy.mokkoji.common.fixture.Fixture;
 import com.greedy.mokkoji.common.response.APIErrorResponse;
@@ -12,11 +13,14 @@ import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.enums.message.FailMessage;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+
+import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,11 +67,11 @@ public class CommentControllerTest extends ControllerTest {
         final int statusCode = response.statusCode();
         assertThat(statusCode).isEqualTo(HttpStatus.CREATED.value());
 
-        final Comment createdComment = commentRepository.findAll().get(0);
-        assertThat(createdComment.getUser().getId()).isEqualTo(user.getId());
-        assertThat(createdComment.getClub().getId()).isEqualTo(club.getId());
-        assertThat(createdComment.getRate()).isEqualTo(5.0);
-        assertThat(createdComment.getContent()).isEqualTo("최고의 동아리입니다!");
+        List<Comment> createdComments = commentRepository.findAll();
+        assertThat(createdComments).hasSize(1);
+        assertThat(createdComments)
+                .extracting("rate", "content")
+                .containsExactlyInAnyOrder(Tuple.tuple(5.0, "최고의 동아리입니다!"));
     }
 
     @Test
@@ -141,11 +145,16 @@ public class CommentControllerTest extends ControllerTest {
 
         assertThat(statusCode).isEqualTo(HttpStatus.OK.value());
         assertThat(actual.comments()).hasSize(2);
-        assertThat(actual.comments().get(0).content()).isEqualTo("좋은 동아리입니다");
-        assertThat(actual.comments().get(0).rate()).isEqualTo(5.0);
-        assertThat(actual.comments().get(0).isWriter()).isTrue();
-        assertThat(actual.comments().get(1).content()).isEqualTo("추천합니다");
-        assertThat(actual.comments().get(1).isWriter()).isFalse();
+        assertThat(actual.comments())
+                .extracting(
+                        CommentResponse::content,
+                        CommentResponse::rate,
+                        CommentResponse::isWriter
+                )
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple("좋은 동아리입니다", 5.0, true),
+                        Tuple.tuple("추천합니다", 4.0, false)
+                );
     }
 
     @Test

--- a/src/test/java/com/greedy/mokkoji/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/comment/service/CommentServiceTest.java
@@ -10,6 +10,7 @@ import com.greedy.mokkoji.db.comment.repository.CommentRepository;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.db.user.repository.UserRepository;
 import com.greedy.mokkoji.enums.message.FailMessage;
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -150,11 +151,12 @@ public class CommentServiceTest {
 
         //then
         assertThat(response.comments()).hasSize(2);
-        assertThat(response.comments().get(0).id()).isEqualTo(1L);
-        assertThat(response.comments().get(0).content()).isEqualTo("좋은 동아리입니다");
-        assertThat(response.comments().get(0).rate()).isEqualTo(5.0);
-        assertThat(response.comments().get(0).isWriter()).isTrue();
-        assertThat(response.comments().get(1).id()).isEqualTo(2L);
+        assertThat(response.comments())
+                .extracting("id", "content", "rate", "isWriter")
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple(1L, "좋은 동아리입니다", 5.0, true),
+                        Tuple.tuple(2L, "추천합니다", 4.0, false)
+                );
 
         BDDMockito.verify(clubRepository, times(1)).findById(clubId);
         BDDMockito.verify(commentRepository, times(1)).findAllByClub(club);

--- a/src/test/java/com/greedy/mokkoji/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/comment/service/CommentServiceTest.java
@@ -109,17 +109,21 @@ public class CommentServiceTest {
     @DisplayName("동아리의 댓글 목록을 조회한다")
     void getComments() {
         //given
-        final Long userId = 1L;
+        final Long userId1 = 1L;
+        final Long userId2 = 2L;
         final Long clubId = 1L;
 
-        final User user = User.builder().build();
-        ReflectionTestUtils.setField(user, "id", userId);
+        final User user1 = User.builder().build();
+        ReflectionTestUtils.setField(user1, "id", userId1);
+
+        final User user2 = User.builder().build();
+        ReflectionTestUtils.setField(user2, "id", userId2);
 
         final Club club = Club.builder().build();
         ReflectionTestUtils.setField(club, "id", clubId);
 
         final Comment comment1 = Comment.builder()
-                .user(user)
+                .user(user1)
                 .club(club)
                 .rate(5.0)
                 .content("좋은 동아리입니다")
@@ -129,7 +133,7 @@ public class CommentServiceTest {
         ReflectionTestUtils.setField(comment1, "updatedAt", LocalDateTime.of(2025, 11, 1, 10, 0));
 
         final Comment comment2 = Comment.builder()
-                .user(user)
+                .user(user2)
                 .club(club)
                 .rate(4.0)
                 .content("추천합니다")
@@ -142,7 +146,7 @@ public class CommentServiceTest {
         BDDMockito.given(commentRepository.findAllByClub(club)).willReturn(List.of(comment1, comment2));
 
         //when
-        CommentListResponse response = commentService.getComments(userId, clubId);
+        CommentListResponse response = commentService.getComments(userId1, clubId);
 
         //then
         assertThat(response.comments()).hasSize(2);

--- a/src/test/java/com/greedy/mokkoji/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/comment/service/CommentServiceTest.java
@@ -1,0 +1,291 @@
+package com.greedy.mokkoji.comment.service;
+
+import com.greedy.mokkoji.api.comment.dto.response.CommentListResponse;
+import com.greedy.mokkoji.api.comment.service.CommentService;
+import com.greedy.mokkoji.common.exception.MokkojiException;
+import com.greedy.mokkoji.db.club.entity.Club;
+import com.greedy.mokkoji.db.club.repository.ClubRepository;
+import com.greedy.mokkoji.db.comment.entity.Comment;
+import com.greedy.mokkoji.db.comment.repository.CommentRepository;
+import com.greedy.mokkoji.db.user.entity.User;
+import com.greedy.mokkoji.db.user.repository.UserRepository;
+import com.greedy.mokkoji.enums.message.FailMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@DisplayName("댓글 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+public class CommentServiceTest {
+
+    @InjectMocks
+    private CommentService commentService;
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private ClubRepository clubRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("댓글을 생성한다")
+    void createComment() {
+        //given
+        final Long userId = 1L;
+        final Long clubId = 1L;
+        final Double rate = 5.0;
+        final String content = "최고의 동아리입니다!";
+
+        final User user = User.builder().build();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        final Club club = Club.builder().build();
+        ReflectionTestUtils.setField(club, "id", clubId);
+
+        BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        BDDMockito.given(clubRepository.findById(clubId)).willReturn(Optional.of(club));
+        BDDMockito.given(commentRepository.existsByClubAndUser(club, user)).willReturn(false);
+
+        //when
+        commentService.createComment(userId, clubId, rate, content);
+
+        //then
+        ArgumentCaptor<Comment> commentCaptor = ArgumentCaptor.forClass(Comment.class);
+        BDDMockito.verify(commentRepository, times(1)).save(commentCaptor.capture());
+
+        Comment savedComment = commentCaptor.getValue();
+        assertThat(savedComment.getUser()).isEqualTo(user);
+        assertThat(savedComment.getClub()).isEqualTo(club);
+        assertThat(savedComment.getRate()).isEqualTo(rate);
+        assertThat(savedComment.getContent()).isEqualTo(content);
+    }
+
+    @Test
+    @DisplayName("이미 댓글이 존재하면 FORBIDDEN_ALREADY_EXIST_COMMENT 예외가 발생한다")
+    void createComment_WhenCommentAlreadyExists_ThrowsException() {
+        //given
+        final Long userId = 1L;
+        final Long clubId = 1L;
+        final Double rate = 5.0;
+        final String content = "댓글 내용";
+
+        final User user = User.builder().build();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        final Club club = Club.builder().build();
+        ReflectionTestUtils.setField(club, "id", clubId);
+
+        BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        BDDMockito.given(clubRepository.findById(clubId)).willReturn(Optional.of(club));
+        BDDMockito.given(commentRepository.existsByClubAndUser(club, user)).willReturn(true);
+
+        //when & then
+        assertThatThrownBy(() -> commentService.createComment(userId, clubId, rate, content))
+                .isInstanceOf(MokkojiException.class)
+                .hasMessage(FailMessage.FORBIDDEN_ALREADY_EXIST_COMMENT.getMessage());
+
+        BDDMockito.verify(commentRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("동아리의 댓글 목록을 조회한다")
+    void getComments() {
+        //given
+        final Long userId = 1L;
+        final Long clubId = 1L;
+
+        final User user = User.builder().build();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        final Club club = Club.builder().build();
+        ReflectionTestUtils.setField(club, "id", clubId);
+
+        final Comment comment1 = Comment.builder()
+                .user(user)
+                .club(club)
+                .rate(5.0)
+                .content("좋은 동아리입니다")
+                .build();
+        ReflectionTestUtils.setField(comment1, "id", 1L);
+        ReflectionTestUtils.setField(comment1, "createdAt", LocalDateTime.of(2025, 11, 1, 10, 0));
+        ReflectionTestUtils.setField(comment1, "updatedAt", LocalDateTime.of(2025, 11, 1, 10, 0));
+
+        final Comment comment2 = Comment.builder()
+                .user(user)
+                .club(club)
+                .rate(4.0)
+                .content("추천합니다")
+                .build();
+        ReflectionTestUtils.setField(comment2, "id", 2L);
+        ReflectionTestUtils.setField(comment2, "createdAt", LocalDateTime.of(2025, 11, 2, 10, 0));
+        ReflectionTestUtils.setField(comment2, "updatedAt", LocalDateTime.of(2025, 11, 2, 10, 0));
+
+        BDDMockito.given(clubRepository.findById(clubId)).willReturn(Optional.of(club));
+        BDDMockito.given(commentRepository.findAllByClub(club)).willReturn(List.of(comment1, comment2));
+
+        //when
+        CommentListResponse response = commentService.getComments(userId, clubId);
+
+        //then
+        assertThat(response.comments()).hasSize(2);
+        assertThat(response.comments().get(0).id()).isEqualTo(1L);
+        assertThat(response.comments().get(0).content()).isEqualTo("좋은 동아리입니다");
+        assertThat(response.comments().get(0).rate()).isEqualTo(5.0);
+        assertThat(response.comments().get(0).isWriter()).isTrue();
+        assertThat(response.comments().get(1).id()).isEqualTo(2L);
+
+        BDDMockito.verify(clubRepository, times(1)).findById(clubId);
+        BDDMockito.verify(commentRepository, times(1)).findAllByClub(club);
+    }
+
+    @Test
+    @DisplayName("댓글을 수정한다")
+    void updateComment() {
+        //given
+        final Long userId = 1L;
+        final Long commentId = 1L;
+        final Double newRate = 4.0;
+        final String newContent = "수정된 댓글";
+
+        final User user = User.builder().build();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        final Club club = Club.builder().build();
+        ReflectionTestUtils.setField(club, "id", 1L);
+
+        final Comment comment = Comment.builder()
+                .user(user)
+                .club(club)
+                .rate(5.0)
+                .content("원래 댓글")
+                .build();
+        ReflectionTestUtils.setField(comment, "id", commentId);
+
+        BDDMockito.given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+        BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        //when
+        commentService.updateComment(userId, commentId, newRate, newContent);
+
+        //then
+        assertThat(comment.getRate()).isEqualTo(newRate);
+        assertThat(comment.getContent()).isEqualTo(newContent);
+    }
+
+    @Test
+    @DisplayName("댓글 수정 시 작성자가 아니면 FORBIDDEN_NOT_COMMENT_WRITER 예외가 발생한다")
+    void updateComment_WithNotWriter_ThrowsException() {
+        //given
+        final Long userId = 1L;
+        final Long commentId = 1L;
+        final Double newRate = 4.0;
+        final String newContent = "수정된 댓글";
+
+        final User user = User.builder().build();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        final User anotherUser = User.builder().build();
+        ReflectionTestUtils.setField(anotherUser, "id", 2L);
+
+        final Club club = Club.builder().build();
+        ReflectionTestUtils.setField(club, "id", 1L);
+
+        final Comment comment = Comment.builder()
+                .user(anotherUser)
+                .club(club)
+                .rate(5.0)
+                .content("원래 댓글")
+                .build();
+
+        BDDMockito.given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+        BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        //when & then
+        assertThatThrownBy(() -> commentService.updateComment(userId, commentId, newRate, newContent))
+                .isInstanceOf(MokkojiException.class)
+                .hasMessage(FailMessage.FORBIDDEN_NOT_COMMENT_WRITER.getMessage());
+    }
+
+    @Test
+    @DisplayName("댓글을 삭제한다")
+    void deleteComment() {
+        //given
+        final Long userId = 1L;
+        final Long commentId = 1L;
+
+        final User user = User.builder().build();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        final Club club = Club.builder().build();
+        ReflectionTestUtils.setField(club, "id", 1L);
+
+        final Comment comment = Comment.builder()
+                .user(user)
+                .club(club)
+                .rate(5.0)
+                .content("댓글 내용")
+                .build();
+        ReflectionTestUtils.setField(comment, "id", commentId);
+
+        BDDMockito.given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+        BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        //when
+        commentService.deleteComment(userId, commentId);
+
+        //then
+        BDDMockito.verify(commentRepository, times(1)).deleteById(commentId);
+    }
+
+    @Test
+    @DisplayName("댓글 삭제 시 작성자가 아니면 FORBIDDEN_NOT_COMMENT_WRITER 예외가 발생한다")
+    void deleteComment_WithNotWriter_ThrowsException() {
+        //given
+        final Long userId = 1L;
+        final Long commentId = 1L;
+
+        final User user = User.builder().build();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        final User anotherUser = User.builder().build();
+        ReflectionTestUtils.setField(anotherUser, "id", 2L);
+
+        final Club club = Club.builder().build();
+        ReflectionTestUtils.setField(club, "id", 1L);
+
+        final Comment comment = Comment.builder()
+                .user(anotherUser)
+                .club(club)
+                .rate(5.0)
+                .content("댓글 내용")
+                .build();
+
+        BDDMockito.given(commentRepository.findById(commentId)).willReturn(Optional.of(comment));
+        BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        //when & then
+        assertThatThrownBy(() -> commentService.deleteComment(userId, commentId))
+                .isInstanceOf(MokkojiException.class)
+                .hasMessage(FailMessage.FORBIDDEN_NOT_COMMENT_WRITER.getMessage());
+
+        BDDMockito.verify(commentRepository, never()).deleteById(any());
+    }
+}

--- a/src/test/java/com/greedy/mokkoji/common/AbstractTest.java
+++ b/src/test/java/com/greedy/mokkoji/common/AbstractTest.java
@@ -1,6 +1,7 @@
 package com.greedy.mokkoji.common;
 
 import com.greedy.mokkoji.db.club.repository.ClubRepository;
+import com.greedy.mokkoji.db.comment.repository.CommentRepository;
 import com.greedy.mokkoji.db.favorite.repository.FavoriteRepository;
 import com.greedy.mokkoji.db.recruitment.repository.RecruitmentRepository;
 import com.greedy.mokkoji.db.user.repository.UserRepository;
@@ -20,4 +21,7 @@ public class AbstractTest {
 
     @Autowired
     protected RecruitmentRepository recruitmentRepository;
+
+    @Autowired
+    protected CommentRepository commentRepository;
 }

--- a/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
+++ b/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
@@ -22,6 +22,16 @@ public class Fixture {
             .build();
     }
 
+    public static User createAnotherUser() {
+        return User.builder()
+            .name("다른사용자")
+            .studentId("87654321")
+            .grade("3")
+            .department("소프트웨어학과")
+            .email("another@test.com")
+            .build();
+    }
+
     public static Club createClub() {
         return Club.builder()
             .name("그리디")


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #291

## 👷 **작업한 내용**
  - AbstractTest에 CommentRepository 추가했습니다.
  - Fixture에 createAnotherUser() 메서드 추가해서 댓글 작성자가 아닌 사용자를 생성하는 메서드를 추가했습니다.
  - 서비스 단위 테스트 시 객체 생성에서 검증에 필수적인 필드만 명시적으로 설정하고 그 외 불필요한 필드의 생성을 최소화했습니다. 이를 통해 테스트 코드의 가독성을 높이고 향후 불필요한 필드 변경으로 인한 유지보수 비용을 줄이고자 했습니다

<img width="779" height="449" alt="image" src="https://github.com/user-attachments/assets/ff8c4502-7aae-47a4-8fbd-12d7fec8ea46" />


## 🚨 **참고 사항**
누락된 테스트 코드 있으면 편하게 말씀해주세요!