### PR TITLE
Fix: 수신자 이메일 노출 방지를 위해 To → Bcc로 변경

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/notification/service/EmailNotificationChannel.java
+++ b/src/main/java/com/greedy/mokkoji/api/notification/service/EmailNotificationChannel.java
@@ -23,6 +23,7 @@ import java.util.List;
 public class EmailNotificationChannel implements NotificationChannel {
     private static final String SUBJECT = "동아리 모집 시작";
     private static final String SENDER_NAME = "모꼬지";
+    private static final String OFFICIAL_EMAIL = "noreply@mokkoji.com";
     private final JavaMailSender mailSender;
 
     @Value("${spring.mail.username}")
@@ -69,6 +70,7 @@ public class EmailNotificationChannel implements NotificationChannel {
             final MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
 
             helper.setFrom(senderMail, SENDER_NAME);
+            helper.setTo(OFFICIAL_EMAIL);
 
             final String[] receiverMailsS = receiverMails.toArray(String[]::new);
             helper.setBcc(receiverMailsS);

--- a/src/main/java/com/greedy/mokkoji/api/notification/service/EmailNotificationChannel.java
+++ b/src/main/java/com/greedy/mokkoji/api/notification/service/EmailNotificationChannel.java
@@ -71,7 +71,7 @@ public class EmailNotificationChannel implements NotificationChannel {
             helper.setFrom(senderMail, SENDER_NAME);
 
             final String[] receiverMailsS = receiverMails.toArray(String[]::new);
-            helper.setTo(receiverMailsS);
+            helper.setBcc(receiverMailsS);
 
             helper.setSubject(SUBJECT);
 

--- a/src/test/java/com/greedy/mokkoji/notification/EmailNotificationRealTest.java
+++ b/src/test/java/com/greedy/mokkoji/notification/EmailNotificationRealTest.java
@@ -1,0 +1,43 @@
+package com.greedy.mokkoji.notification;
+
+import com.greedy.mokkoji.api.notification.service.EmailNotificationChannel;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+@SpringBootTest
+@DisplayName("실제 이메일 발송 테스트")
+@Disabled("이메일 테스트 시 해제를 하고 사용")
+public class EmailNotificationRealTest {
+
+    @Value("${test.mail.receivers}")
+    private String receivers;
+
+    @Autowired
+    private EmailNotificationChannel emailNotificationChannel;
+
+    @Test
+    @DisplayName("수신자 이메일 노출 확인")
+    void checkEmailExposure() {
+
+        List<String> receiverMails = Arrays.stream(receivers.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isBlank())
+                .toList();
+
+        emailNotificationChannel.sendNotification(
+                receiverMails,
+                1L,
+                "수신자 노출 테스트",
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(7)
+        );
+    }
+}


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #298 

## 👷 **작업한 내용**
문제점
- 메일을 보냈을 때 수신자들의 메일이 모두 함께 노출되는 문제가 있었습니다.

해결
- setTo 함수를 setBcc 로 변경해서 수신자들의 메일이 노출되는 것을 방지했습니다.
<img width="426" height="80" alt="image" src="https://github.com/user-attachments/assets/c7c076f1-8c1e-4e07-9ba3-f7b706298de1" />

## 🚨 **참고 사항**
각 수신자의 메일 주소를 To에 표시하면서 보내려면 수신자별로 1통씩 개별 발송해야 합니다.
다만 개별 발송은 호출 횟수 증가로 비효율적일 수 있어 이번 PR에서는 BCC 단체 발송 방식으로 처리했습니다.
