### PR TITLE
 Fix: 이메일 발송 비동기 처리로 수정

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/notification/service/DiscordNotifier.java
+++ b/src/main/java/com/greedy/mokkoji/api/notification/service/DiscordNotifier.java
@@ -1,0 +1,70 @@
+package com.greedy.mokkoji.api.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DiscordNotifier {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    @Value("${discord.webhook.url}")
+    private String webhookUrl;
+
+    @Value("${discord.webhook.enabled}")
+    private boolean enabled;
+
+    private final RestTemplate restTemplate;
+
+
+    @Async
+    public void notifyEmailFailure(Long clubId, String clubName, int receiverCount, String errorMessage) {
+        if (!enabled || webhookUrl == null || webhookUrl.isEmpty()) {
+            return;
+        }
+
+        String timestamp = LocalDateTime.now().format(FORMATTER);
+
+        String content = String.format(
+                "🚨 **이메일 발송 실패 알림**\n" +
+                        "```text\n" +
+                        "동아리 ID   : %d\n" +
+                        "동아리명    : %s\n" +
+                        "수신자 수  : %d명\n" +
+                        "에러 내용  : %s\n" +
+                        "발생 시간  : %s\n" +
+                        "```",
+                clubId, clubName, receiverCount, errorMessage, timestamp
+        );
+        sendToDiscord(content);
+    }
+
+    private void sendToDiscord(String content) {
+        try {
+            Map<String, String> payload = new HashMap<>();
+            payload.put("content", content);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            HttpEntity<Map<String, String>> request = new HttpEntity<>(payload, headers);
+            restTemplate.postForEntity(webhookUrl, request, String.class);
+        } catch (Exception e) {
+            log.error("[DISCORD WEBHOOK FAILED] message={}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/greedy/mokkoji/api/notification/service/EmailNotificationChannel.java
+++ b/src/main/java/com/greedy/mokkoji/api/notification/service/EmailNotificationChannel.java
@@ -82,7 +82,6 @@ public class EmailNotificationChannel implements NotificationChannel {
             final String text = generateHtmlText(clubId, clubName, recruitStartTime, recruitEndTime);
             helper.setText(text, true);
             mailSender.send(mimeMessage);
-            throw new MessagingException();
         } catch (MessagingException | UnsupportedEncodingException e) {
             log.error("[MAIL GENERATING ERROR] clubId={} clubName={} receivers={} message={}",
                     clubId,

--- a/src/main/java/com/greedy/mokkoji/api/notification/service/EmailNotificationChannel.java
+++ b/src/main/java/com/greedy/mokkoji/api/notification/service/EmailNotificationChannel.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 import java.io.UnsupportedEncodingException;
@@ -88,6 +89,7 @@ public class EmailNotificationChannel implements NotificationChannel {
         }
     }
 
+    @Async
     @Override
     public void sendNotification(
             final List<String> receiverMails,
@@ -98,7 +100,6 @@ public class EmailNotificationChannel implements NotificationChannel {
     ) {
         try {
             final MimeMessage mimeMessage = generateNotification(receiverMails, clubId, clubName, recruitStartTime, recruitEndTime);
-
             mailSender.send(mimeMessage);
         } catch (MailException e) {
             log.error("[MAIL SEND FAILED] : {}", e.getMessage());

--- a/src/main/java/com/greedy/mokkoji/api/notification/service/EmailNotificationChannel.java
+++ b/src/main/java/com/greedy/mokkoji/api/notification/service/EmailNotificationChannel.java
@@ -1,7 +1,5 @@
 package com.greedy.mokkoji.api.notification.service;
 
-import com.greedy.mokkoji.common.exception.MokkojiException;
-import com.greedy.mokkoji.enums.message.FailMessage;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -10,13 +8,16 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 import java.io.UnsupportedEncodingException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+
+import static com.greedy.mokkoji.enums.message.FailMessage.INTERNAL_SERVER_ERROR;
+import static com.greedy.mokkoji.enums.message.FailMessage.INTERNAL_SERVER_ERROR_SMTP;
+import static com.greedy.mokkoji.enums.message.FailMessage.INTERNAL_SERVER_ERROR_SMTP_MAIL;
 
 @Slf4j
 @Component
@@ -25,6 +26,7 @@ public class EmailNotificationChannel implements NotificationChannel {
     private static final String SUBJECT = "동아리 모집 시작";
     private static final String SENDER_NAME = "모꼬지";
     private final JavaMailSender mailSender;
+    private final DiscordNotifier discordNotifier;
 
     @Value("${spring.mail.username}")
     private String senderMail;
@@ -58,7 +60,8 @@ public class EmailNotificationChannel implements NotificationChannel {
                 "</html>";
     }
 
-    private MimeMessage generateNotification(
+    @Override
+    public void sendNotification(
             final List<String> receiverMails,
             final Long clubId,
             final String clubName,
@@ -78,32 +81,30 @@ public class EmailNotificationChannel implements NotificationChannel {
 
             final String text = generateHtmlText(clubId, clubName, recruitStartTime, recruitEndTime);
             helper.setText(text, true);
-
-            return mimeMessage;
-        } catch (MessagingException e) {
-            log.error("[MAIL GENERATING ERROR]: {}", e.getMessage());
-            throw new MokkojiException(FailMessage.INTERNAL_SERVER_ERROR_SMTP_MAIL);
-        } catch (UnsupportedEncodingException e) {
-            log.error("[Mail GENERATING ERROR FROM SENDER INFORMATION]: {}", e.getMessage());
-            throw new MokkojiException(FailMessage.INTERNAL_SERVER_ERROR_SMTP_MAIL);
-        }
-    }
-
-    @Async
-    @Override
-    public void sendNotification(
-            final List<String> receiverMails,
-            final Long clubId,
-            final String clubName,
-            final LocalDateTime recruitStartTime,
-            final LocalDateTime recruitEndTime
-    ) {
-        try {
-            final MimeMessage mimeMessage = generateNotification(receiverMails, clubId, clubName, recruitStartTime, recruitEndTime);
             mailSender.send(mimeMessage);
+            throw new MessagingException();
+        } catch (MessagingException | UnsupportedEncodingException e) {
+            log.error("[MAIL GENERATING ERROR] clubId={} clubName={} receivers={} message={}",
+                    clubId,
+                    clubName,
+                    receiverMails,
+                    e.getMessage());
+            discordNotifier.notifyEmailFailure(clubId, clubName, receiverMails.size(), INTERNAL_SERVER_ERROR_SMTP_MAIL.getMessage());
         } catch (MailException e) {
-            log.error("[MAIL SEND FAILED] : {}", e.getMessage());
-            throw new MokkojiException(FailMessage.INTERNAL_SERVER_ERROR_SMTP);
+            log.error("[MAIL SEND FAILED] clubId={} clubName={} receivers={} message={}",
+                    clubId,
+                    clubName,
+                    receiverMails,
+                    e.getMessage());
+            discordNotifier.notifyEmailFailure(clubId, clubName, receiverMails.size(), INTERNAL_SERVER_ERROR_SMTP.getMessage());
+        } catch (Exception e) {
+            log.error("[EMAIL UNEXPECTED ERROR] clubId={}, clubName={} receivers={}",
+                    clubId,
+                    clubName,
+                    receiverMails,
+                    e);
+            discordNotifier.notifyEmailFailure(clubId, clubName, receiverMails.size(), INTERNAL_SERVER_ERROR.getMessage());
         }
     }
 }
+

--- a/src/main/java/com/greedy/mokkoji/api/notification/service/NotificationService.java
+++ b/src/main/java/com/greedy/mokkoji/api/notification/service/NotificationService.java
@@ -6,6 +6,7 @@ import com.greedy.mokkoji.db.favorite.repository.FavoriteRepository;
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -16,6 +17,7 @@ public class NotificationService {
     private final NotificationChannel notificationChannel;
     private final FavoriteRepository favoriteRepository;
 
+    @Async
     @Transactional
     public void sendNotification(final Club club, final Recruitment recruitment) {
         List<Favorite> favorites = favoriteRepository.findByClubIdWithFetchJoin(club.getId());
@@ -33,5 +35,4 @@ public class NotificationService {
                 userEmail, club.getId(), club.getName(), recruitment.getRecruitStart(), recruitment.getRecruitEnd()
         );
     }
-
 }

--- a/src/main/java/com/greedy/mokkoji/api/scheduler/service/RecruitmentNotificationScheduler.java
+++ b/src/main/java/com/greedy/mokkoji/api/scheduler/service/RecruitmentNotificationScheduler.java
@@ -49,7 +49,12 @@ public class RecruitmentNotificationScheduler {
 
         uniqueAndLatestRecruitments.forEach(recruitment -> {
             Club club = recruitment.getClub();
-            notificationService.sendNotification(club, recruitment);
+            try {
+                notificationService.sendNotification(club, recruitment);
+            } catch (Exception e) {
+                log.error("[RECRUITMENT NOTI SUBMIT FAILED] clubId={} recruitmentId={} msg={}",
+                        club.getId(), recruitment.getId(), e.getMessage(), e);
+            }
         });
     }
 }

--- a/src/main/java/com/greedy/mokkoji/config/AsyncConfig.java
+++ b/src/main/java/com/greedy/mokkoji/config/AsyncConfig.java
@@ -8,6 +8,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 
 @Slf4j
 @Configuration
@@ -23,6 +24,7 @@ public class AsyncConfig implements AsyncConfigurer {
         executor.setThreadNamePrefix("email-async-");
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(60);
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/greedy/mokkoji/config/AsyncConfig.java
+++ b/src/main/java/com/greedy/mokkoji/config/AsyncConfig.java
@@ -12,7 +12,7 @@ import java.util.concurrent.Executor;
 @Slf4j
 @Configuration
 @EnableAsync
-public class AsyncConfiguration implements AsyncConfigurer {
+public class AsyncConfig implements AsyncConfigurer {
 
     @Override
     public Executor getAsyncExecutor() {

--- a/src/main/java/com/greedy/mokkoji/config/AsyncConfig.java
+++ b/src/main/java/com/greedy/mokkoji/config/AsyncConfig.java
@@ -19,7 +19,7 @@ public class AsyncConfig implements AsyncConfigurer {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(5);
         executor.setMaxPoolSize(10);
-        executor.setQueueCapacity(100);
+        executor.setQueueCapacity(300);
         executor.setThreadNamePrefix("email-async-");
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(60);

--- a/src/main/java/com/greedy/mokkoji/config/AsyncConfiguration.java
+++ b/src/main/java/com/greedy/mokkoji/config/AsyncConfiguration.java
@@ -1,0 +1,36 @@
+package com.greedy.mokkoji.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Slf4j
+@Configuration
+@EnableAsync
+public class AsyncConfiguration implements AsyncConfigurer {
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("email-async-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) -> {
+            log.error("[ASYNC UNEXPECTED ERROR]: Method: {}, Exception: {}", method.getName(), ex.getMessage(), ex);
+        };
+    }
+}


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #299

## 👷 **작업한 내용**
  - @Async 어노테이션을 적용하여 이메일 발송을 비동기로 처리하도록 수정했습니다.
  - 스레드 풀(Executor)을 생성하여 Configuration으로 등록해 스레드 재사용을 통한 자원 낭비를 방지했습니다.
  - 비동기로 처리를 할 경우 예외가 호출자 스레드까지 전달이 되지 않습니다. 그래서 getAsyncUncaughtExceptionHandler 메서드를 구현해서 예상치 못한 예외의 로그를 남겼습니다. 
  - 로그를 통해서 별도의 스레드로 실행이 되는 것을 확인했습니다.
<img width="560" height="62" alt="image" src="https://github.com/user-attachments/assets/30e001b3-560f-45b4-8b76-3aec3ae148c5" />


## 🚨 **참고 사항**
 - 스레드 풀 설정: Core 5개, Max 10개, Queue 100개
