### PR TITLE
Fix: 특정 동아리의 모집글 최신 등록순으로 정렬하여 반환하도록 로직 최종 수정

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -45,7 +45,7 @@ public class ClubService {
         final Club club = clubRepository.findById(clubId)
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB));
         final Recruitment recruitment = recruitmentRepository
-                .findTopByClubIdOrderByUpdatedAtDesc(club.getId())
+                .findTopByClubIdOrderByCreatedAtDesc(club.getId())
                 .orElse(null);
         final Boolean isFavorite = getIsFavorite(userId, clubId);
 
@@ -157,7 +157,7 @@ public class ClubService {
     private List<ClubResponse> mapToClubResponses(final Long userId, final List<Club> clubs) {
         return clubs.stream()
                 .map(club -> {
-                    Recruitment recruitment = recruitmentRepository.findTopByClubIdOrderByUpdatedAtDesc(club.getId())
+                    Recruitment recruitment = recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(club.getId())
                             .orElse(null);
                     boolean isFavorite = getIsFavorite(userId, club.getId());
                     return ClubResponse.of(club.getId(),

--- a/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
+++ b/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
@@ -61,7 +61,7 @@ public class FavoriteService {
         List<ClubResponse> clubResponses = favorites.stream()
                 .map(favorite -> {
                     final Club club = favorite.getClub();
-                    Recruitment recruitment = recruitmentRepository.findTopByClubIdOrderByUpdatedAtDesc(club.getId())
+                    Recruitment recruitment = recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(club.getId())
                             .orElse(null);
 
                     return ClubResponse.of(

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -114,14 +114,20 @@ public class RecruitmentService {
         List<Recruitment> recruitments = recruitmentRepository.findAllByClubId(clubId);
 
         List<RecruitmentOfClubResponse> recruitmentList = recruitments.stream()
-                .sorted(Comparator.comparing(Recruitment::getRecruitEnd).reversed())
+                .sorted(clubRecruitmentsOrderByNewestFirstComparator())
                 .map(recruitment -> RecruitmentOfClubResponse.builder()
                         .id(recruitment.getId())
                         .title(recruitment.getTitle())
                         .content(recruitment.getContent())
                         .recruitStart(recruitment.getRecruitStart())
                         .recruitEnd(recruitment.getRecruitEnd())
-                        .status(RecruitStatus.from(recruitment.getRecruitStart(), recruitment.getRecruitEnd()))
+                        .status(
+                            RecruitStatus.from(
+                                recruitment.isAlwaysRecruiting(),
+                                recruitment.getRecruitStart(),
+                                recruitment.getRecruitEnd()
+                            )
+                        )
                         .createdAt(recruitment.getCreatedAt())
                         .firstImage(getFirstImageUrl(recruitment.getId()))
                         .isAlwaysRecruiting(recruitment.isAlwaysRecruiting())
@@ -162,7 +168,7 @@ public class RecruitmentService {
                 recruitment.getContent(),
                 recruitment.getRecruitStart(),
                 recruitment.getRecruitEnd(),
-                RecruitStatus.from(recruitment.getRecruitStart(), recruitment.getRecruitEnd()),
+                RecruitStatus.from(recruitment.isAlwaysRecruiting(), recruitment.getRecruitStart(), recruitment.getRecruitEnd()),
                 recruitment.getCreatedAt(),
                 imageUrls,
                 recruitment.getRecruitForm(),
@@ -197,7 +203,7 @@ public class RecruitmentService {
                 recruitment.getContent(),
                 recruitment.getRecruitStart(),
                 recruitment.getRecruitEnd(),
-                RecruitStatus.from(recruitment.getRecruitStart(), recruitment.getRecruitEnd()),
+                RecruitStatus.from(recruitment.isAlwaysRecruiting(), recruitment.getRecruitStart(), recruitment.getRecruitEnd()),
                 recruitment.getCreatedAt(),
                 imageUrls,
                 recruitment.getRecruitForm(),
@@ -350,7 +356,7 @@ public class RecruitmentService {
                 recruitment.getTitle(),
                 recruitment.getRecruitStart(),
                 recruitment.getRecruitEnd(),
-                RecruitStatus.from(recruitment.getRecruitStart(), recruitment.getRecruitEnd()),
+                RecruitStatus.from(recruitment.isAlwaysRecruiting(), recruitment.getRecruitStart(), recruitment.getRecruitEnd()),
                 isFavorite,
                 recruitment.isAlwaysRecruiting()
         );
@@ -359,16 +365,22 @@ public class RecruitmentService {
     // 즐겨찾기 여부 → 모집 상태 → 마감일 순으로 정렬하는 Comparator 생성
     private Comparator<RecruitmentPreviewResponse> getFinalComparator(Long userId) {
         Comparator<RecruitmentPreviewResponse> comparator =
-                Comparator.comparing(
-                        (RecruitmentPreviewResponse r) ->
-                                RecruitStatus.from(r.recruitStart(), r.recruitEnd()).getPriority()
-                ).thenComparing(RecruitmentPreviewResponse::recruitEnd);
+            Comparator.comparing(
+                    (RecruitmentPreviewResponse response) ->
+                        RecruitStatus.from(response.isAlwaysRecruiting(), response.recruitStart(), response.recruitEnd()).getPriority()
+                )
+                .thenComparing(RecruitmentPreviewResponse::recruitEnd);
 
         if (userId != null) {
             comparator = Comparator.comparing(RecruitmentPreviewResponse::isFavorite).reversed()
-                    .thenComparing(comparator);
+                .thenComparing(comparator);
         }
 
         return comparator;
+    }
+
+    private Comparator<Recruitment> clubRecruitmentsOrderByNewestFirstComparator() {
+        return Comparator.comparing(Recruitment::getCreatedAt).reversed()
+            .thenComparing(Recruitment::getId, Comparator.reverseOrder());
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -30,7 +30,6 @@ import com.greedy.mokkoji.enums.user.UserRole;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -222,25 +221,9 @@ public class RecruitmentService {
         Page<Recruitment> recruitmentPage = recruitmentRepository.findRecruitments(affiliation, category, pageable);
         List<Recruitment> filteredRecruitments = recruitmentPage.getContent();
 
-        // 페이징 처리
-        int start = (int) pageable.getOffset();
-        int end = Math.min(start + pageable.getPageSize(), filteredRecruitments.size());
-        List<Recruitment> pagedRecruitments = filteredRecruitments.subList(start, end);
-        Page<Recruitment> paged = new PageImpl<>(pagedRecruitments, pageable, filteredRecruitments.size());
+        List<RecruitmentPreviewResponse> recruitmentResponses = mapToRecruitmentResponses(userId, filteredRecruitments);
 
-        // DTO 변환 및 정렬
-        List<RecruitmentPreviewResponse> recruitmentResponses = paged.stream()
-                .map(recruitment -> mapToRecruitmentPreviewResponse(userId, recruitment))
-                .sorted(getFinalComparator(userId))
-                .toList();
-
-        // 페이징 정보 생성
-        PageResponse pageResponse = PageResponse.of(
-                paged.getNumber() + 1,
-                paged.getSize(),
-                paged.getTotalPages(),
-                (int) paged.getTotalElements()
-        );
+        PageResponse pageResponse = createPageResponse(recruitmentPage);
 
         return new AllRecruitmentResponse(recruitmentResponses, pageResponse);
     }
@@ -336,6 +319,22 @@ public class RecruitmentService {
             return false;
         }
         return favoriteRepository.existsByUserIdAndClubId(userId, clubId);
+    }
+
+    private List<RecruitmentPreviewResponse> mapToRecruitmentResponses(Long userId, List<Recruitment> filteredRecruitments) {
+        return filteredRecruitments.stream()
+            .map(recruitment -> mapToRecruitmentPreviewResponse(userId, recruitment))
+            .sorted(getFinalComparator(userId))
+            .toList();
+    }
+
+    private static PageResponse createPageResponse(Page<Recruitment> recruitmentPage) {
+        return PageResponse.of(
+            recruitmentPage.getNumber() + 1,
+            recruitmentPage.getSize(),
+            recruitmentPage.getTotalPages(),
+            (int) recruitmentPage.getTotalElements()
+        );
     }
 
     private RecruitmentPreviewResponse mapToRecruitmentPreviewResponse(Long userId, Recruitment recruitment) {

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -113,7 +113,7 @@ public class RecruitmentService {
         List<Recruitment> recruitments = recruitmentRepository.findAllByClubId(clubId);
 
         List<RecruitmentOfClubResponse> recruitmentList = recruitments.stream()
-                .sorted(clubRecruitmentsOrderByNewestFirstComparator())
+                .sorted(newestFirstRecruitmentComparator())
                 .map(recruitment -> RecruitmentOfClubResponse.builder()
                         .id(recruitment.getId())
                         .title(recruitment.getTitle())
@@ -324,7 +324,7 @@ public class RecruitmentService {
     private List<RecruitmentPreviewResponse> mapToRecruitmentResponses(Long userId, List<Recruitment> filteredRecruitments) {
         return filteredRecruitments.stream()
             .map(recruitment -> mapToRecruitmentPreviewResponse(userId, recruitment))
-            .sorted(getFinalComparator(userId))
+            .sorted(recruitmentPriorityComparator(userId))
             .toList();
     }
 
@@ -362,7 +362,7 @@ public class RecruitmentService {
     }
 
     // 즐겨찾기 여부 → 모집 상태 → 마감일 순으로 정렬하는 Comparator 생성
-    private Comparator<RecruitmentPreviewResponse> getFinalComparator(Long userId) {
+    private Comparator<RecruitmentPreviewResponse> recruitmentPriorityComparator(Long userId) {
         Comparator<RecruitmentPreviewResponse> comparator =
             Comparator.comparing(
                     (RecruitmentPreviewResponse response) ->
@@ -378,7 +378,7 @@ public class RecruitmentService {
         return comparator;
     }
 
-    private Comparator<Recruitment> clubRecruitmentsOrderByNewestFirstComparator() {
+    private Comparator<Recruitment> newestFirstRecruitmentComparator() {
         return Comparator.comparing(Recruitment::getCreatedAt).reversed()
             .thenComparing(Recruitment::getId, Comparator.reverseOrder());
     }

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -140,10 +140,10 @@ public class RecruitmentService {
     @Transactional
     public RecentRecruitmentOfClubResponse getRecentRecruitmentOfClub(final Long clubId, final Long userId) {
 
-        Optional<Recruitment> recentRecruitment = recruitmentRepository.findTopByClubIdOrderByUpdatedAtDesc(clubId);
+        Optional<Recruitment> recentRecruitment = recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(clubId);
 
         Recruitment recruitment = recentRecruitment.orElseGet(() ->
-                recruitmentRepository.findTopByClubIdAndIsAlwaysRecruitingOrderByUpdatedAtDesc(clubId, true)
+                recruitmentRepository.findTopByClubIdAndIsAlwaysRecruitingOrderByCreatedAtDesc(clubId, true)
                         .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUNT_RECRUITMENT))
         );
 

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepository.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long>, RecruitmentRepositoryCustom {
+
     @Query("SELECT r FROM Recruitment r WHERE FUNCTION('DATE', r.recruitStart) = :currentDate")
     List<Recruitment> findAllByRecruitStartToday(LocalDate currentDate);
 
@@ -28,9 +29,8 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long>,
 
     List<Recruitment> findAllByClubId(final Long id);
 
-    Optional<Recruitment> findTopByClubIdOrderByUpdatedAtDesc(Long clubId);
+    Optional<Recruitment> findTopByClubIdOrderByCreatedAtDesc(Long clubId);
 
     //상시모집 중인 모집글 중 최신 updatedAt 공고 반환
-    Optional<Recruitment> findTopByClubIdAndIsAlwaysRecruitingOrderByUpdatedAtDesc(Long clubId, boolean isAlwaysRecruiting);
-
+    Optional<Recruitment> findTopByClubIdAndIsAlwaysRecruitingOrderByCreatedAtDesc(Long clubId, boolean isAlwaysRecruiting);
 }

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepository.java
@@ -31,6 +31,5 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long>,
 
     Optional<Recruitment> findTopByClubIdOrderByCreatedAtDesc(Long clubId);
 
-    //상시모집 중인 모집글 중 최신 updatedAt 공고 반환
     Optional<Recruitment> findTopByClubIdAndIsAlwaysRecruitingOrderByCreatedAtDesc(Long clubId, boolean isAlwaysRecruiting);
 }

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryImpl.java
@@ -35,14 +35,14 @@ public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom {
             .where(
                 equalAffiliation(affiliation),
                 equalCategory(category),
-                recruitment.updatedAt.eq(
+                recruitment.createdAt.eq(
                     JPAExpressions
-                        .select(subRecruitment.updatedAt.max())
+                        .select(subRecruitment.createdAt.max())
                         .from(subRecruitment)
                         .where(subRecruitment.club.id.eq(recruitment.club.id))
                 )
             )
-            .orderBy(recruitment.updatedAt.desc())
+            .orderBy(recruitment.createdAt.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();
@@ -53,9 +53,10 @@ public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom {
             .join(recruitment.club, club)
             .where(
                 equalAffiliation(affiliation),
-                recruitment.updatedAt.eq(
+                equalCategory(category),
+                recruitment.createdAt.eq(
                     JPAExpressions
-                        .select(subRecruitment.updatedAt.max())
+                        .select(subRecruitment.createdAt.max())
                         .from(subRecruitment)
                         .where(subRecruitment.club.id.eq(recruitment.club.id))
                 )
@@ -74,14 +75,14 @@ public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom {
             .join(recruitment.club, club).fetchJoin()
             .where(
                 club.id.in(favoriteClubIds),
-                recruitment.updatedAt.eq(
+                recruitment.createdAt.eq(
                     JPAExpressions
-                        .select(subRecruitment.updatedAt.max())
+                        .select(subRecruitment.createdAt.max())
                         .from(subRecruitment)
                         .where(subRecruitment.club.id.eq(recruitment.club.id))
                 )
             )
-            .orderBy(recruitment.updatedAt.desc())
+            .orderBy(recruitment.createdAt.desc())
             .fetch();
     }
 

--- a/src/main/java/com/greedy/mokkoji/enums/recruitment/RecruitStatus.java
+++ b/src/main/java/com/greedy/mokkoji/enums/recruitment/RecruitStatus.java
@@ -8,25 +8,35 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 public enum RecruitStatus {
-    IMMINENT(0),
-    OPEN(1),
-    BEFORE(2),
-    CLOSED(3);
+    ALWAYS(0),
+    IMMINENT(1),
+    OPEN(2),
+    BEFORE(3),
+    CLOSED(4);
 
     private final int priority;
 
-    public static RecruitStatus from(LocalDateTime start, LocalDateTime end) {
+    public static RecruitStatus from(boolean isAlwaysRecruiting, LocalDateTime recruitStart, LocalDateTime recruitEnd) {
+        if (isAlwaysRecruiting) {
+            return ALWAYS;
+        }
+
         LocalDateTime now = LocalDateTime.now();
 
-        if (now.isBefore(start)) {
+        if (now.isBefore(recruitStart)) {
             return BEFORE;
-        } else if (now.isAfter(end)) {
-            return CLOSED;
-        } else if (now.isAfter(end.minusDays(7))) {
-            return IMMINENT;
-        } else {
-            return OPEN;
         }
+        if (now.isAfter(recruitEnd)) {
+            return CLOSED;
+        }
+        if (now.isAfter(recruitEnd.minusDays(7))) {
+            return IMMINENT;
+        }
+        return OPEN;
+    }
+
+    public static RecruitStatus from(LocalDateTime start, LocalDateTime end) {
+        return from(false, start, end);
     }
 }
 

--- a/src/main/java/com/greedy/mokkoji/enums/recruitment/RecruitStatus.java
+++ b/src/main/java/com/greedy/mokkoji/enums/recruitment/RecruitStatus.java
@@ -8,9 +8,9 @@ import java.time.LocalDateTime;
 @Getter
 @AllArgsConstructor
 public enum RecruitStatus {
-    ALWAYS(0),
-    IMMINENT(1),
-    OPEN(2),
+    IMMINENT(0),
+    OPEN(1),
+    ALWAYS(2),
     BEFORE(3),
     CLOSED(4);
 

--- a/src/test/java/com/greedy/mokkoji/club/service/ClubServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/club/service/ClubServiceTest.java
@@ -117,8 +117,8 @@ class ClubServiceTest {
         final Page<Club> clubPage = new PageImpl<>(clubs, pageable, clubs.size());
 
         BDDMockito.given(clubRepository.findClubs(any(), any(), any(), any(), any())).willReturn(clubPage);
-        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByUpdatedAtDesc(clubId1)).willReturn(Optional.ofNullable(recruitment1));
-        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByUpdatedAtDesc(clubId2)).willReturn(Optional.ofNullable(recruitment2));
+        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(clubId1)).willReturn(Optional.ofNullable(recruitment1));
+        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(clubId2)).willReturn(Optional.ofNullable(recruitment2));
         BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, clubId1)).willReturn(true);
         BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, clubId2)).willReturn(false);
         BDDMockito.given(appDataS3Client.getPublicUrl(club1.getLogo())).willReturn("testLogo1");
@@ -151,7 +151,7 @@ class ClubServiceTest {
         assertThat(response.pagination().totalElements()).isEqualTo(2);
 
         BDDMockito.verify(clubRepository, times(1)).findClubs(any(), any(), any(), any(), any(Pageable.class));
-        BDDMockito.verify(recruitmentRepository, times(2)).findTopByClubIdOrderByUpdatedAtDesc(anyLong());
+        BDDMockito.verify(recruitmentRepository, times(2)).findTopByClubIdOrderByCreatedAtDesc(anyLong());
         BDDMockito.verify(favoriteRepository, times(2)).existsByUserIdAndClubId(anyLong(), anyLong());
     }
 
@@ -163,7 +163,7 @@ class ClubServiceTest {
         final Long clubId = club1.getId();
 
         BDDMockito.given(clubRepository.findById(clubId)).willReturn(Optional.ofNullable(club1));
-        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByUpdatedAtDesc(clubId)).willReturn(Optional.ofNullable(recruitment1));
+        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(clubId)).willReturn(Optional.ofNullable(recruitment1));
         BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, clubId)).willReturn(true);
         BDDMockito.given(appDataS3Client.getPublicUrl(club1.getLogo())).willReturn("testLogo1");
 
@@ -184,7 +184,7 @@ class ClubServiceTest {
         assertThat(response.recruitPost()).isEqualTo("testContent1");
 
         verify(clubRepository, times(1)).findById(anyLong());
-        verify(recruitmentRepository, times(1)).findTopByClubIdOrderByUpdatedAtDesc(anyLong());
+        verify(recruitmentRepository, times(1)).findTopByClubIdOrderByCreatedAtDesc(anyLong());
         verify(favoriteRepository, times(1)).existsByUserIdAndClubId(anyLong(), anyLong());
     }
 
@@ -220,7 +220,7 @@ class ClubServiceTest {
         final Long clubId = clubWithoutRecruitment.getId();
 
         BDDMockito.given(clubRepository.findById(clubId)).willReturn(Optional.of(clubWithoutRecruitment));
-        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByUpdatedAtDesc(clubId)).willReturn(Optional.empty());
+        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(clubId)).willReturn(Optional.empty());
         BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, clubId)).willReturn(false);
         BDDMockito.given(appDataS3Client.getPublicUrl(clubWithoutRecruitment.getLogo())).willReturn("testLogo3");
 
@@ -236,7 +236,7 @@ class ClubServiceTest {
         assertThat(response.recruitPost()).isNull();
 
         verify(clubRepository, times(1)).findById(clubId);
-        verify(recruitmentRepository, times(1)).findTopByClubIdOrderByUpdatedAtDesc(clubId);
+        verify(recruitmentRepository, times(1)).findTopByClubIdOrderByCreatedAtDesc(clubId);
         verify(favoriteRepository, times(1)).existsByUserIdAndClubId(userId, clubId);
     }
 
@@ -520,8 +520,8 @@ class ClubServiceTest {
         final Page<Club> clubPage = new PageImpl<>(clubs, pageable, clubs.size());
 
         BDDMockito.given(clubRepository.findClubs(any(), any(), any(), any(), any())).willReturn(clubPage);
-        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByUpdatedAtDesc(clubId1)).willReturn(Optional.ofNullable(recruitment1));
-        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByUpdatedAtDesc(clubId2)).willReturn(Optional.ofNullable(recruitment2));
+        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(clubId1)).willReturn(Optional.ofNullable(recruitment1));
+        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(clubId2)).willReturn(Optional.ofNullable(recruitment2));
         BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, clubId1)).willReturn(false);
         BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, clubId2)).willReturn(true);
         BDDMockito.given(appDataS3Client.getPublicUrl(club1.getLogo())).willReturn("testLogo1");

--- a/src/test/java/com/greedy/mokkoji/common/AbstractTest.java
+++ b/src/test/java/com/greedy/mokkoji/common/AbstractTest.java
@@ -2,6 +2,7 @@ package com.greedy.mokkoji.common;
 
 import com.greedy.mokkoji.db.club.repository.ClubRepository;
 import com.greedy.mokkoji.db.favorite.repository.FavoriteRepository;
+import com.greedy.mokkoji.db.recruitment.repository.RecruitmentImageRepository;
 import com.greedy.mokkoji.db.recruitment.repository.RecruitmentRepository;
 import com.greedy.mokkoji.db.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,4 +21,7 @@ public class AbstractTest {
 
     @Autowired
     protected RecruitmentRepository recruitmentRepository;
+
+    @Autowired
+    protected RecruitmentImageRepository recruitmentImageRepository;
 }

--- a/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
+++ b/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
@@ -6,11 +6,14 @@ import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
+import com.greedy.mokkoji.enums.user.UserRole;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class Fixture {
 
     public static final String FIXTURE_CLUB_LOGO = "그리디_로고";
+    public static final List<String> FIXTURE_RECRUITMENT_IMAGE_NAME = List.of("모집글_이미지_이름.png");
 
     public static User createUser() {
         return User.builder()
@@ -19,6 +22,17 @@ public class Fixture {
             .grade("4")
             .department("컴퓨터공학과")
             .email("모꼬지@test.com")
+            .build();
+    }
+
+    public static User createUserWithRole(UserRole role) {
+        return User.builder()
+            .name("모꼬지")
+            .studentId("22222222")
+            .grade("4")
+            .department("컴퓨터공학과")
+            .email("모꼬지@test.com")
+            .role(role)
             .build();
     }
 
@@ -33,6 +47,17 @@ public class Fixture {
             .build();
     }
 
+    public static Club createClubWithCategoryAndAffiliation(ClubCategory category, ClubAffiliation affiliation) {
+        return Club.builder()
+            .name("그리디")
+            .clubCategory(category)
+            .clubAffiliation(affiliation)
+            .logo(FIXTURE_CLUB_LOGO)
+            .description("세종대 최고의 코딩 동아리")
+            .instagram("www.그리디.com")
+            .build();
+    }
+
     public static Recruitment createRecruitment(Club club) {
         return Recruitment.builder()
             .club(club)
@@ -40,6 +65,31 @@ public class Fixture {
             .recruitEnd(LocalDateTime.of(2025, 2, 2, 12, 0, 0))
             .title("모집글 제목")
             .content("그리디 모집글")
+            .recruitForm("그리디 모집 링크")
+            .isAlwaysRecruiting(false)
+            .build();
+    }
+
+    public static Recruitment createOrderRecruitment(Club club) {
+        return Recruitment.builder()
+            .club(club)
+            .recruitStart(LocalDateTime.of(2024, 1, 1, 12, 0, 0))
+            .recruitEnd(LocalDateTime.of(2024, 2, 2, 12, 0, 0))
+            .title("오래된 모집글 제목")
+            .content("오래된 모집글")
+            .recruitForm("오래된 모집 링크")
+            .isAlwaysRecruiting(false)
+            .build();
+    }
+
+    public static Recruitment createNewerRecruitment(Club club) {
+        return Recruitment.builder()
+            .club(club)
+            .recruitStart(LocalDateTime.of(2025, 1, 1, 12, 0, 0))
+            .recruitEnd(LocalDateTime.of(2025, 2, 2, 12, 0, 0))
+            .title("최신 모집글 제목")
+            .content("최신 모집글")
+            .recruitForm("최신 모집 링크")
             .isAlwaysRecruiting(false)
             .build();
     }
@@ -63,6 +113,22 @@ public class Fixture {
             .title("8월 최신 모집글")
             .content("그리디 모집글")
             .isAlwaysRecruiting(false)
+            .build();
+    }
+
+    public static Recruitment createRecruitmentWithTimes(
+        Club club,
+        LocalDateTime recruitStart,
+        LocalDateTime recruitEnd,
+        boolean isAlwaysRecruiting
+    ) {
+        return Recruitment.builder()
+            .club(club)
+            .recruitStart(recruitStart)
+            .recruitEnd(recruitEnd)
+            .title("8월 모집글")
+            .content("그리디 모집글")
+            .isAlwaysRecruiting(isAlwaysRecruiting)
             .build();
     }
 

--- a/src/test/java/com/greedy/mokkoji/favorite/servcie/FavoriteServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/favorite/servcie/FavoriteServiceTest.java
@@ -240,7 +240,7 @@ public class FavoriteServiceTest {
         final Page<Favorite> favoritePage = new PageImpl<>(List.of(favorite));
 
         BDDMockito.given(favoriteRepository.findByUserId(any(), any())).willReturn(favoritePage);
-        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByUpdatedAtDesc(any())).willReturn(Optional.of(recruitment));
+        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(any())).willReturn(Optional.of(recruitment));
         BDDMockito.given(appDataS3Client.getPublicUrl(any())).willReturn("testLogo1");
 
         //when
@@ -258,7 +258,7 @@ public class FavoriteServiceTest {
         assertThat(favoriteClubs.clubs().get(0).isFavorite()).isEqualTo(true);
 
         BDDMockito.verify(favoriteRepository, times(1)).findByUserId(user.getId(), PageRequest.of(0, 10));
-        BDDMockito.verify(recruitmentRepository, times(1)).findTopByClubIdOrderByUpdatedAtDesc(club.getId());
+        BDDMockito.verify(recruitmentRepository, times(1)).findTopByClubIdOrderByCreatedAtDesc(club.getId());
     }
 
     @DisplayName("특정 연월에 모집 중인 즐겨찾기 동아리의 최신 모집 정보를 조회한다. - 모집 시작일이 겹치는 경우")

--- a/src/test/java/com/greedy/mokkoji/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/recruitment/controller/RecruitmentControllerTest.java
@@ -1,0 +1,628 @@
+package com.greedy.mokkoji.recruitment.controller;
+
+import static com.greedy.mokkoji.common.fixture.Fixture.FIXTURE_RECRUITMENT_IMAGE_NAME;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.greedy.mokkoji.api.recruitment.dto.request.CreateRecruitmentRequest;
+import com.greedy.mokkoji.api.recruitment.dto.request.UpdateRecruitmentRequest;
+import com.greedy.mokkoji.api.recruitment.dto.response.allRecruitment.AllRecruitmentResponse;
+import com.greedy.mokkoji.api.recruitment.dto.response.allRecruitment.RecruitmentPreviewResponse;
+import com.greedy.mokkoji.api.recruitment.dto.response.allRecruitmentOfClub.RecruitmentOfClubResponse;
+import com.greedy.mokkoji.api.recruitment.dto.response.recentRecruitment.RecentRecruitmentOfClubResponse;
+import com.greedy.mokkoji.common.ControllerTest;
+import com.greedy.mokkoji.common.fixture.Fixture;
+import com.greedy.mokkoji.common.response.APIErrorResponse;
+import com.greedy.mokkoji.db.club.entity.Club;
+import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
+import com.greedy.mokkoji.db.user.entity.User;
+import com.greedy.mokkoji.enums.club.ClubAffiliation;
+import com.greedy.mokkoji.enums.club.ClubCategory;
+import com.greedy.mokkoji.enums.message.FailMessage;
+import com.greedy.mokkoji.enums.user.UserRole;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+public class RecruitmentControllerTest extends ControllerTest {
+
+    private Club club;
+    private Recruitment recruitment;
+
+    @BeforeEach
+    void setUp() {
+        recruitmentImageRepository.deleteAll();
+        recruitmentRepository.deleteAll();
+        favoriteRepository.deleteAll();
+        clubRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @ParameterizedTest
+    @MethodSource("allowedRoles")
+    @DisplayName("권한을 가진 관리자는 모집글을 생성할 수 있다.")
+    void createRecruitment_allowedRoles_success(UserRole role) {
+        //given
+        club = clubRepository.save(Fixture.createClub());
+        recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
+        User adminUser = userRepository.save(Fixture.createUserWithRole(role));
+        String authorizationForBearer = authorizationForBearerAccessToken(adminUser);
+
+        final CreateRecruitmentRequest request = new CreateRecruitmentRequest(
+            recruitment.getTitle(),
+            FIXTURE_RECRUITMENT_IMAGE_NAME,
+            recruitment.getContent(),
+            recruitment.getRecruitStart(),
+            recruitment.getRecruitEnd(),
+            recruitment.getRecruitForm(),
+            recruitment.isAlwaysRecruiting()
+        );
+
+        //when
+        final ExtractableResponse<Response> response = given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .body(request)
+            .when().post(prefixUrl + "/recruitments/{clubId}", club.getId())
+            .then().log().all()
+            .extract();
+
+        //then
+        final int statusCode = response.statusCode();
+        Recruitment createRecruitment = recruitmentRepository.findAllByClubId(club.getId()).get(0);
+        assertThat(statusCode).isEqualTo(HttpStatus.CREATED.value());
+        assertThat(createRecruitment.getTitle()).isEqualTo(request.title());
+        assertThat(createRecruitment.getContent()).isEqualTo(request.content());
+        assertThat(createRecruitment.getRecruitStart()).isEqualTo(request.recruitStart());
+        assertThat(createRecruitment.getRecruitEnd()).isEqualTo(request.recruitEnd());
+        assertThat(createRecruitment.isAlwaysRecruiting()).isEqualTo(request.isAlwaysRecruiting());
+    }
+
+    @ParameterizedTest
+    @MethodSource("forbiddenRoles")
+    @DisplayName("허용되지 않은 권한을 가진 일반 사용자가 모집글 생성 시 403을 반환한다.")
+    void createRecruitment_forbiddenRoles_403(UserRole role) {
+        // given
+        club = clubRepository.save(Fixture.createClub());
+        recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
+        User normalUser = userRepository.save(Fixture.createUserWithRole(role));
+        String authorizationForBearer = authorizationForBearerAccessToken(normalUser);
+
+        final CreateRecruitmentRequest request = new CreateRecruitmentRequest(
+            recruitment.getTitle(),
+            FIXTURE_RECRUITMENT_IMAGE_NAME,
+            recruitment.getContent(),
+            recruitment.getRecruitStart(),
+            recruitment.getRecruitEnd(),
+            recruitment.getRecruitForm(),
+            recruitment.isAlwaysRecruiting()
+        );
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .body(request)
+            .when().post(prefixUrl + "/recruitments/{clubId}", club.getId())
+            .then().log().all()
+            .extract();
+
+        // then
+        final int actualStatusCode = response.statusCode();
+        final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
+        final APIErrorResponse expectedResponse = new APIErrorResponse(
+            FailMessage.FORBIDDEN.getCode(),
+            FailMessage.FORBIDDEN.getMessage()
+        );
+
+        assertThat(actualStatusCode).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+    }
+
+    @Test
+    @DisplayName("토큰 없이 모집글 생성 요청 시 401을 반환한다.")
+    void createRecruitment_withoutToken_shouldReturn401() {
+        // given
+        club = clubRepository.save(Fixture.createClub());
+        recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
+
+        final CreateRecruitmentRequest request = new CreateRecruitmentRequest(
+            recruitment.getTitle(),
+            FIXTURE_RECRUITMENT_IMAGE_NAME,
+            recruitment.getContent(),
+            recruitment.getRecruitStart(),
+            recruitment.getRecruitEnd(),
+            recruitment.getRecruitForm(),
+            recruitment.isAlwaysRecruiting()
+        );
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(request)
+            .when().post(prefixUrl + "/recruitments/{clubId}", club.getId())
+            .then().log().all()
+            .extract();
+
+        // then
+        final int actualStatusCode = response.statusCode();
+        final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
+        final APIErrorResponse expectedResponse = new APIErrorResponse(
+            FailMessage.UNAUTHORIZED.getCode(),
+            FailMessage.UNAUTHORIZED.getMessage()
+        );
+
+        assertThat(actualStatusCode).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+    }
+
+    @ParameterizedTest
+    @MethodSource("allowedRoles")
+    @DisplayName("권한을 가진 관리자는 모집글을 수정할 수 있다.")
+    void updateRecruitment_allowedRoles_success(UserRole role) {
+        // given
+        club = clubRepository.save(Fixture.createClub());
+        recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
+        User adminUser = userRepository.save(Fixture.createUserWithRole(role));
+        String authorizationForBearer = authorizationForBearerAccessToken(adminUser);
+
+        final UpdateRecruitmentRequest request = new UpdateRecruitmentRequest(
+            "수정된 모집글 제목",
+            List.of("수정된 모집글 이미지.png"),
+            "수정된 모집글 내용",
+            recruitment.getRecruitStart().plusDays(1),
+            recruitment.getRecruitEnd().plusDays(1),
+            "수정된 모집글 링크",
+            false
+        );
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .body(request)
+            .when().patch(prefixUrl + "/recruitments/{recruitmentId}", recruitment.getId())
+            .then().log().all()
+            .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        Recruitment updatedRecruitment = recruitmentRepository.findById(recruitment.getId()).orElseThrow();
+        assertThat(updatedRecruitment.getTitle()).isEqualTo("수정된 모집글 제목");
+        assertThat(updatedRecruitment.getContent()).isEqualTo("수정된 모집글 내용");
+        assertThat(updatedRecruitment.getRecruitStart()).isEqualTo(recruitment.getRecruitStart().plusDays(1));
+        assertThat(updatedRecruitment.getRecruitEnd()).isEqualTo(recruitment.getRecruitEnd().plusDays(1));
+        assertThat(updatedRecruitment.getRecruitForm()).isEqualTo("수정된 모집글 링크");
+    }
+
+    @ParameterizedTest
+    @MethodSource("forbiddenRoles")
+    @DisplayName("허용되지 않은 권한을 가진 일반 사용자가 모집글 수정 시 403을 반환한다.")
+    void updateRecruitment_forbiddenRoles_403(UserRole role) {
+        // given
+        club = clubRepository.save(Fixture.createClub());
+        recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
+        User normalUser = userRepository.save(Fixture.createUserWithRole(role));
+        String authorizationForBearer = authorizationForBearerAccessToken(normalUser);
+
+        final UpdateRecruitmentRequest request = new UpdateRecruitmentRequest(
+            "수정된 모집글 제목",
+            List.of("수정된 모집글 이미지.png"),
+            "수정된 모집글 내용",
+            recruitment.getRecruitStart().plusDays(1),
+            recruitment.getRecruitEnd().plusDays(1),
+            "수정된 모집글 링크",
+            false
+        );
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .body(request)
+            .when().patch(prefixUrl + "/recruitments/{recruitmentId}", recruitment.getId())
+            .then().log().all()
+            .extract();
+
+        // then
+        final int actualStatusCode = response.statusCode();
+        final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
+        final APIErrorResponse expectedResponse = new APIErrorResponse(
+            FailMessage.FORBIDDEN.getCode(),
+            FailMessage.FORBIDDEN.getMessage()
+        );
+
+        assertThat(actualStatusCode).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+    }
+
+    @ParameterizedTest
+    @MethodSource("allowedRoles")
+    @DisplayName("권한을 가진 관리자는 모집글을 삭제할 수 있다.")
+    void deleteRecruitment_allowedRoles_success(UserRole role) {
+        // given
+        club = clubRepository.save(Fixture.createClub());
+        recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
+        User adminUser = userRepository.save(Fixture.createUserWithRole(role));
+        String authorizationForBearer = authorizationForBearerAccessToken(adminUser);
+
+        //when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .header("Authorization", authorizationForBearer)
+            .when().delete(prefixUrl + "/recruitments/{recruitmentId}", recruitment.getId())
+            .then().log().all()
+            .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(recruitmentRepository.findById(recruitment.getId())).isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("forbiddenRoles")
+    @DisplayName("허용되지 않은 권한을 가진 일반 사용자가 모집글 삭제 시 403을 반환한다.")
+    void deleteRecruitment_forbiddenRoles_403(UserRole role) {
+        // given
+        club = clubRepository.save(Fixture.createClub());
+        recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
+        User normalUser = userRepository.save(Fixture.createUserWithRole(role));
+        String authorizationForBearer = authorizationForBearerAccessToken(normalUser);
+
+        //when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .header("Authorization", authorizationForBearer)
+            .when().delete(prefixUrl + "/recruitments/{recruitmentId}", recruitment.getId())
+            .then().log().all()
+            .extract();
+
+        // then
+        final int actualStatusCode = response.statusCode();
+        final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
+        final APIErrorResponse expectedResponse = new APIErrorResponse(
+            FailMessage.FORBIDDEN.getCode(),
+            FailMessage.FORBIDDEN.getMessage()
+        );
+
+        assertThat(actualStatusCode).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(actualResponse).usingRecursiveComparison().isEqualTo(expectedResponse);
+    }
+
+    @Test
+    @DisplayName("특정 동아리의 모든 모집글을 최신순으로 조회한다.")
+    void getAllRecruitmentOfClub_shouldReturnNewestFirst() {
+        // given
+        club = clubRepository.save(Fixture.createClub());
+        recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
+        Recruitment olderRecruitment = recruitmentRepository.save(Fixture.createOrderRecruitment(club));
+        Recruitment newerRecruitment = recruitmentRepository.save(Fixture.createNewerRecruitment(club));
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .when().get(prefixUrl + "/recruitments/club/{clubId}", club.getId())
+            .then().log().all()
+            .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        List<RecruitmentOfClubResponse> recruitments =
+            response.jsonPath().getList("data.recruitments", RecruitmentOfClubResponse.class);
+
+        assertThat(recruitments).isNotEmpty();
+
+        RecruitmentOfClubResponse first = recruitments.get(0);
+        assertThat(first.id()).isEqualTo(newerRecruitment.getId());
+        assertThat(first.isAlwaysRecruiting()).isFalse();
+
+        assertThat(recruitments.stream().anyMatch(
+            recruitmentOfClubResponse -> recruitmentOfClubResponse.id().equals(recruitment.getId()))).isTrue();
+        assertThat(recruitments.stream().anyMatch(
+            recruitmentOfClubResponse -> recruitmentOfClubResponse.id().equals(olderRecruitment.getId()))).isTrue();
+    }
+
+    @Test
+    @DisplayName("동아리의 최신 모집글을 조회한다.")
+    void getRecentRecruitmentOfClub() {
+        // given
+        club = clubRepository.save(Fixture.createClub());
+        recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
+        User normalUser = userRepository.save(Fixture.createUserWithRole(UserRole.NORMAL));
+        String authorizationForBearer = authorizationForBearerAccessToken(normalUser);
+
+        Recruitment newerRecruitment = recruitmentRepository.save(Fixture.createNewerRecruitment(club));
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .when().get(prefixUrl + "/recruitments/club/recent/{clubId}", club.getId())
+            .then().log().all()
+            .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        RecentRecruitmentOfClubResponse recruitmentOfClubResponse = getDataFromResponse(response,
+            RecentRecruitmentOfClubResponse.class);
+
+        assertThat(recruitmentOfClubResponse.id()).isEqualTo(newerRecruitment.getId());
+    }
+
+    @Test
+    @DisplayName("특정 모집글을 상세 조회한다.")
+    void getSpecificRecruitment() {
+        // given
+        club = clubRepository.save(Fixture.createClub());
+        recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
+        User user = userRepository.save(Fixture.createUserWithRole(UserRole.NORMAL));
+        String authorizationForBearer = authorizationForBearerAccessToken(user);
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .pathParam("recruitmentId", recruitment.getId())
+            .when().get(prefixUrl + "/recruitments/{recruitmentId}")
+            .then().log().all()
+            .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        Long id = response.jsonPath().getLong("data.id");
+        assertThat(id).isEqualTo(recruitment.getId());
+    }
+
+    @Test
+    @DisplayName("전체 모집글 조회한다. - 소속 및 카테고리 필터링 동작을 검증한다.")
+    void getAllRecruitment_filtersByAffiliationAndCategory() {
+        // given
+        User normaluser = userRepository.save(Fixture.createUserWithRole(UserRole.NORMAL));
+        String authorizationForBearer = authorizationForBearerAccessToken(normaluser);
+
+        //필터링에 포함될 동아리 데이터
+        Club club1 = clubRepository.save(Fixture.createClubWithCategoryAndAffiliation(ClubCategory.ACADEMIC_CULTURAL,
+            ClubAffiliation.DEPARTMENT_CLUB));
+        Club club2 = clubRepository.save(Fixture.createClubWithCategoryAndAffiliation(ClubCategory.ACADEMIC_CULTURAL,
+            ClubAffiliation.DEPARTMENT_CLUB));
+        recruitmentRepository.save(Fixture.createRecruitment(club1));
+        recruitmentRepository.save(Fixture.createRecruitment(club2));
+
+        // 필터링에서 걸러질 동아리 데이터
+        Club otherClub1 = clubRepository.save(
+            Fixture.createClubWithCategoryAndAffiliation(ClubCategory.CULTURAL_ART, ClubAffiliation.CENTRAL_CLUB));
+        Club otherClub2 = clubRepository.save(
+            Fixture.createClubWithCategoryAndAffiliation(ClubCategory.CULTURAL_ART, ClubAffiliation.CENTRAL_CLUB));
+        recruitmentRepository.save(Fixture.createRecruitment(otherClub1));
+        recruitmentRepository.save(Fixture.createRecruitment(otherClub2));
+
+        ClubAffiliation filteringByAffiliation = ClubAffiliation.DEPARTMENT_CLUB;
+        ClubCategory filteringByCategory = ClubCategory.ACADEMIC_CULTURAL;
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .queryParam("affiliation", ClubAffiliation.DEPARTMENT_CLUB.name())
+            .queryParam("category", ClubCategory.ACADEMIC_CULTURAL.name())
+            .when().get(prefixUrl + "/recruitments")
+            .then().log().all()
+            .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        AllRecruitmentResponse data = getDataFromResponse(response, AllRecruitmentResponse.class);
+
+        assertThat(data.recruitments()).hasSize(2);
+
+        assertThat(data.recruitments()).allSatisfy(recruitmentPreviewResponse -> {
+            assertThat(recruitmentPreviewResponse.club()).isNotNull();
+            assertThat(recruitmentPreviewResponse.club().clubAffiliation()).isEqualTo(filteringByAffiliation);
+            assertThat(recruitmentPreviewResponse.club().clubCategory()).isEqualTo(filteringByCategory);
+            assertThat(recruitmentPreviewResponse.id()).isNotNull();
+            assertThat(recruitmentPreviewResponse.title()).isNotBlank();
+        });
+    }
+
+    @Test
+    @DisplayName("전체 모집글 조회한다. - 동아리 당 최신 모집글 1개만 반환되는 것을 검증한다.")
+    void getAllRecruitment_returnsOnlyLatestRecruitmentPerClub() {
+        // given
+        User normalUser = userRepository.save(Fixture.createUserWithRole(UserRole.NORMAL));
+        String authorizationForBearer = authorizationForBearerAccessToken(normalUser);
+
+        Club targetClub = clubRepository.save(Fixture.createClub());
+
+        Recruitment olderRecruitment = recruitmentRepository.save(Fixture.createOrderRecruitment(targetClub));
+        Recruitment newerRecruitment = recruitmentRepository.save(Fixture.createNewerRecruitment(targetClub));
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .queryParam("affiliation", targetClub.getClubAffiliation().name())
+            .queryParam("category", targetClub.getClubCategory().name())
+            .when().get(prefixUrl + "/recruitments")
+            .then().log().all()
+            .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        AllRecruitmentResponse data = getDataFromResponse(response, AllRecruitmentResponse.class);
+        assertThat(data.recruitments()).hasSize(1);
+
+        RecruitmentPreviewResponse recruitmentPreviewResponse = data.recruitments().get(0);
+        assertThat(recruitmentPreviewResponse.id()).isEqualTo(newerRecruitment.getId());
+
+        assertThat(newerRecruitment.getClub().getId()).isEqualTo(targetClub.getId());
+    }
+
+    @Test
+    @DisplayName("전체 모집글 조회 - 페이징이 정삭적으로 동작하는지 검증한다.")
+    void getAllRecruitment_pagingWorks() {
+        // given
+        User normalUser = userRepository.save(Fixture.createUserWithRole(UserRole.NORMAL));
+        String authorizationForBearer = authorizationForBearerAccessToken(normalUser);
+
+        ClubAffiliation filteringByAffiliation = ClubAffiliation.DEPARTMENT_CLUB;
+        ClubCategory filteringByCategory = ClubCategory.ACADEMIC_CULTURAL;
+
+        for (int i = 0; i < 11; i++) {
+            Club club = clubRepository.save(
+                Fixture.createClubWithCategoryAndAffiliation(filteringByCategory, filteringByAffiliation));
+            recruitmentRepository.save(Fixture.createNewerRecruitment(club));
+        }
+
+        // when: page=1, size= 10 일 경우
+        ExtractableResponse<Response> response1 = RestAssured.given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .queryParam("affiliation", filteringByAffiliation)
+            .queryParam("category", filteringByCategory)
+            .when().get(prefixUrl + "/recruitments")
+            .then().log().all()
+            .extract();
+        AllRecruitmentResponse allRecruitmentResponse1 = getDataFromResponse(response1, AllRecruitmentResponse.class);
+
+        // then
+        assertThat(allRecruitmentResponse1.recruitments()).hasSize(10);
+        assertThat(allRecruitmentResponse1.page().page()).isEqualTo(1);
+        assertThat(allRecruitmentResponse1.page().size()).isEqualTo(10);
+        assertThat(allRecruitmentResponse1.page().totalElements()).isEqualTo(11);
+        assertThat(allRecruitmentResponse1.page().totalPages()).isEqualTo(2);
+
+        // when: page=2, size= 10 일 경우
+        ExtractableResponse<Response> response2 = RestAssured.given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .queryParam("page", 2)
+            .queryParam("size", 10)
+            .queryParam("affiliation", filteringByAffiliation)
+            .queryParam("category", filteringByCategory)
+            .when().get(prefixUrl + "/recruitments")
+            .then().log().all()
+            .extract();
+        AllRecruitmentResponse allRecruitmentResponse2 = getDataFromResponse(response2, AllRecruitmentResponse.class);
+
+        // then
+        assertThat(allRecruitmentResponse2.recruitments()).hasSize(1);
+        assertThat(allRecruitmentResponse2.page().page()).isEqualTo(2);
+        assertThat(allRecruitmentResponse2.page().totalElements()).isEqualTo(11);
+        assertThat(allRecruitmentResponse2.page().totalPages()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("전체 모집글 조회 - 정렬 정책(즐겨 찾기, 마감 임박, 모집 중, 상시 모집, 모집 전, 모집 마감)대로 정렬되는지 검증한다.")
+    void getAllRecruitment_sortedByPolicy() {
+        // given
+        User normalUser = userRepository.save(Fixture.createUserWithRole(UserRole.NORMAL));
+        String token = authorizationForBearerAccessToken(normalUser);
+
+        ClubAffiliation filteringByAffiliation = ClubAffiliation.DEPARTMENT_CLUB;
+        ClubCategory filteringByCategory = ClubCategory.ACADEMIC_CULTURAL;
+
+        Club favoriteClub = clubRepository.save(
+            Fixture.createClubWithCategoryAndAffiliation(filteringByCategory, filteringByAffiliation));
+        Club imminetClub = clubRepository.save(
+            Fixture.createClubWithCategoryAndAffiliation(filteringByCategory, filteringByAffiliation));
+        Club openClub = clubRepository.save(
+            Fixture.createClubWithCategoryAndAffiliation(filteringByCategory, filteringByAffiliation));
+        Club alwaysClub = clubRepository.save(
+            Fixture.createClubWithCategoryAndAffiliation(filteringByCategory, filteringByAffiliation));
+        Club beforeClub = clubRepository.save(
+            Fixture.createClubWithCategoryAndAffiliation(filteringByCategory, filteringByAffiliation));
+        Club closedClub = clubRepository.save(
+            Fixture.createClubWithCategoryAndAffiliation(filteringByCategory, filteringByAffiliation));
+
+        LocalDateTime now = LocalDateTime.now();
+
+        // 즐겨찾기
+        Recruitment favoriteRecruitment = recruitmentRepository.save(
+            Fixture.createRecruitmentWithTimes(favoriteClub, now.minusDays(2), now.plusDays(10), false)
+        );
+        favoriteRepository.save(Fixture.createFavorite(favoriteClub, normalUser));
+
+        //모집 마감 임박
+        Recruitment imminetRecruitment = recruitmentRepository.save(
+            Fixture.createRecruitmentWithTimes(imminetClub, now.minusDays(1), now.plusMinutes(30), false)
+        );
+
+        //모집 중
+        Recruitment openRecruitment = recruitmentRepository.save(
+            Fixture.createRecruitmentWithTimes(openClub, now.minusDays(1), now.plusDays(30), false)
+        );
+
+        //상시 모집
+        Recruitment alwaysRecruitment = recruitmentRepository.save(
+            Fixture.createRecruitmentWithTimes(alwaysClub, now.minusDays(100), now.plusDays(1000), true)
+        );
+
+        //모집 전
+        Recruitment beforeRecruitment = recruitmentRepository.save(
+            Fixture.createRecruitmentWithTimes(beforeClub, now.plusDays(3), now.plusDays(10), false)
+        );
+
+        //모집 마감
+        Recruitment closedRecruitment = recruitmentRepository.save(
+            Fixture.createRecruitmentWithTimes(closedClub, now.minusDays(10), now.minusDays(1), false)
+        );
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", token)
+            .queryParam("page", 1)
+            .queryParam("size", 10)
+            .queryParam("affiliation", filteringByAffiliation)
+            .queryParam("category", filteringByCategory)
+            .when().get(prefixUrl + "/recruitments")
+            .then().log().all()
+            .extract();
+
+        AllRecruitmentResponse data = getDataFromResponse(response, AllRecruitmentResponse.class);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(data.recruitments()).hasSize(6);
+
+        List<Long> ids = data.recruitments().stream()
+            .map(RecruitmentPreviewResponse::id)
+            .toList();
+
+        assertThat(ids).containsExactly(
+            favoriteRecruitment.getId(),
+            imminetRecruitment.getId(),
+            openRecruitment.getId(),
+            alwaysRecruitment.getId(),
+            beforeRecruitment.getId(),
+            closedRecruitment.getId()
+        );
+    }
+
+    static Stream<UserRole> allowedRoles() {
+        return Stream.of(UserRole.CLUB_MASTER, UserRole.GREEDY_ADMIN, UserRole.CLUB_ADMIN);
+    }
+
+    static Stream<UserRole> forbiddenRoles() {
+        return Stream.of(UserRole.NORMAL);
+    }
+}

--- a/src/test/java/com/greedy/mokkoji/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/recruitment/service/RecruitmentServiceTest.java
@@ -1,0 +1,643 @@
+package com.greedy.mokkoji.recruitment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+
+import com.greedy.mokkoji.api.external.AppDataS3Client;
+import com.greedy.mokkoji.api.recruitment.dto.response.allRecruitment.AllRecruitmentResponse;
+import com.greedy.mokkoji.api.recruitment.dto.response.allRecruitment.RecruitmentPreviewResponse;
+import com.greedy.mokkoji.api.recruitment.dto.response.allRecruitmentOfClub.AllRecruitmentOfClubResponse;
+import com.greedy.mokkoji.api.recruitment.dto.response.allRecruitmentOfClub.RecruitmentOfClubResponse;
+import com.greedy.mokkoji.api.recruitment.dto.response.createRecruitment.CreateRecruitmentResponse;
+import com.greedy.mokkoji.api.recruitment.dto.response.deleteRecruitment.DeleteRecruitmentResponse;
+import com.greedy.mokkoji.api.recruitment.dto.response.recentRecruitment.RecentRecruitmentOfClubResponse;
+import com.greedy.mokkoji.api.recruitment.dto.response.specificRecruitment.SpecificRecruitmentResponse;
+import com.greedy.mokkoji.api.recruitment.dto.response.updateRecruitment.UpdateRecruitmentResponse;
+import com.greedy.mokkoji.api.recruitment.service.RecruitmentService;
+import com.greedy.mokkoji.common.exception.MokkojiException;
+import com.greedy.mokkoji.db.club.entity.Club;
+import com.greedy.mokkoji.db.club.repository.ClubRepository;
+import com.greedy.mokkoji.db.favorite.repository.FavoriteRepository;
+import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
+import com.greedy.mokkoji.db.recruitment.entity.RecruitmentImage;
+import com.greedy.mokkoji.db.recruitment.repository.RecruitmentImageRepository;
+import com.greedy.mokkoji.db.recruitment.repository.RecruitmentRepository;
+import com.greedy.mokkoji.db.user.entity.User;
+import com.greedy.mokkoji.db.user.repository.UserRepository;
+import com.greedy.mokkoji.enums.club.ClubAffiliation;
+import com.greedy.mokkoji.enums.club.ClubCategory;
+import com.greedy.mokkoji.enums.message.FailMessage;
+import com.greedy.mokkoji.enums.user.UserRole;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("모집글 서비스 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class RecruitmentServiceTest {
+
+    @InjectMocks
+    RecruitmentService recruitmentService;
+
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    ClubRepository clubRepository;
+
+    @Mock
+    RecruitmentRepository recruitmentRepository;
+
+    @Mock
+    RecruitmentImageRepository recruitmentImageRepository;
+
+    @Mock
+    AppDataS3Client appDataS3Client;
+
+    @Mock
+    FavoriteRepository favoriteRepository;
+
+    @Test
+    @DisplayName("권한을 가진 관리자는 모집글을 생성할 수 있다.")
+    void createRecruitment() {
+        // given
+        User adminUser = User.builder().build();
+        ReflectionTestUtils.setField(adminUser, "id", 1L);
+        ReflectionTestUtils.setField(adminUser, "role", UserRole.CLUB_MASTER);
+
+        Club club = Club.builder()
+            .name("그리디")
+            .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
+            .clubCategory(ClubCategory.ACADEMIC_CULTURAL)
+            .logo("greedy-logo.png")
+            .instagram("https://greedy-instagram.com")
+            .description("그리디 소개글")
+            .build();
+        ReflectionTestUtils.setField(club, "id", 1L);
+
+        BDDMockito.given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
+        BDDMockito.given(clubRepository.findById(1L)).willReturn(Optional.of(club));
+        BDDMockito.given(recruitmentRepository.save(any(Recruitment.class)))
+            .willAnswer(inv -> {
+                Recruitment recruitment = inv.getArgument(0);
+                ReflectionTestUtils.setField(recruitment, "id", 1L);
+                return recruitment;
+            });
+
+        BDDMockito.given(appDataS3Client.getPresignedPutUrl(any())).willReturn("putUrl");
+
+        // when
+        CreateRecruitmentResponse createRecruitmentResponse = recruitmentService.createRecruitment(
+            1L,
+            1L,
+            "그리디 모집글 제목",
+            "그리디 모집글 내용",
+            LocalDateTime.of(2025, 1, 1, 0, 0),
+            LocalDateTime.of(2025, 1, 31, 23, 59),
+            List.of("그리디 모집글 이미지1.jpg", "그리디 모집글 이미지2.png"),
+            "그리디 모집 링크",
+            false
+        );
+
+        // then
+        assertThat(createRecruitmentResponse.id()).isEqualTo(1L);
+        assertThat(createRecruitmentResponse.uploadImageUrls()).hasSize(2);
+        assertThat(createRecruitmentResponse.uploadImageUrls()).allMatch(url -> url.equals("putUrl"));
+
+        BDDMockito.verify(recruitmentRepository, times(1)).save(any(Recruitment.class));
+        BDDMockito.verify(appDataS3Client, times(2)).getPresignedPutUrl(any());
+        BDDMockito.verify(recruitmentImageRepository, times(1)).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("일반 사용자는 모집글을 생성할 수 없다.")
+    void createRecruitment_forbidden() {
+        // given
+        User normalUser = User.builder().build();
+        ReflectionTestUtils.setField(normalUser, "id", 1L);
+        ReflectionTestUtils.setField(normalUser, "role", UserRole.NORMAL);
+
+        BDDMockito.given(userRepository.findById(1L)).willReturn(Optional.of(normalUser));
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> recruitmentService.createRecruitment(
+                1L, 1L, "그리디 모집글 제목", "그리디 모집글 내용", LocalDateTime.now(), LocalDateTime.now().plusDays(1),
+                List.of("그리디 모집글 이미지.jpgg"), "그리디 모집 링크", false
+            ))
+            .isInstanceOf(MokkojiException.class)
+            .hasMessageContaining(FailMessage.FORBIDDEN.getMessage());
+    }
+
+    @Test
+    @DisplayName("모집글 생성 시 동아리가 존재하지 않으면 예외가 발생한다.")
+    void createRecruitment_notFoundClub() {
+        // given
+        User adminUser = User.builder().build();
+        ReflectionTestUtils.setField(adminUser, "id", 1L);
+        ReflectionTestUtils.setField(adminUser, "role", UserRole.CLUB_MASTER);
+
+        BDDMockito.given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
+        BDDMockito.given(clubRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> recruitmentService.createRecruitment(
+                1L, 999L, "그리디 모집글 제목", "그리디 모집글 내용", LocalDateTime.now(), LocalDateTime.now().plusDays(1),
+                List.of("그리디 모집글 이미지.jpgg"), "그리디 모집 링크", false
+            ))
+            .isInstanceOf(MokkojiException.class)
+            .hasMessageContaining(FailMessage.NOT_FOUND_CLUB.getMessage());
+    }
+
+    @Test
+    @DisplayName("권한을 가진 관리자는 모집글을 수정할 수 있다.")
+    void updateRecruitment() {
+        // given
+        User adminUser = User.builder().build();
+        ReflectionTestUtils.setField(adminUser, "id", 1L);
+        ReflectionTestUtils.setField(adminUser, "role", UserRole.CLUB_MASTER);
+
+        Club club = Club.builder()
+            .name("그리디")
+            .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
+            .clubCategory(ClubCategory.ACADEMIC_CULTURAL)
+            .logo("greedy-logo.png")
+            .instagram("https://greedy-instagram.com")
+            .description("그리디 소개글")
+            .build();
+        ReflectionTestUtils.setField(club, "id", 1L);
+
+        Recruitment recruitment = Recruitment.builder()
+            .club(club)
+            .title("그리디 모집글 제목")
+            .content("그리디 모집글 내용")
+            .recruitStart(LocalDateTime.of(2025, 1, 1, 0, 0))
+            .recruitEnd(LocalDateTime.of(2025, 1, 31, 23, 59))
+            .recruitForm("그리디 모집 링크")
+            .isAlwaysRecruiting(false)
+            .build();
+        ReflectionTestUtils.setField(recruitment, "id", 1L);
+
+        RecruitmentImage oldImage1 = RecruitmentImage.builder().recruitment(recruitment).image("오래된 그리디 모집글 이미지1.jpg")
+            .build();
+        RecruitmentImage oldImage2 = RecruitmentImage.builder().recruitment(recruitment).image("오래된 그리디 모집글 이미지2.jpg")
+            .build();
+
+        BDDMockito.given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
+        BDDMockito.given(recruitmentRepository.findById(1L)).willReturn(Optional.of(recruitment));
+        BDDMockito.given(recruitmentImageRepository.findByRecruitmentId(1L)).willReturn(List.of(oldImage1, oldImage2));
+        BDDMockito.given(appDataS3Client.getPresignedDeleteUrl(any())).willReturn("deleteUrl");
+        BDDMockito.given(appDataS3Client.getPresignedPutUrl(any())).willReturn("putUrl");
+
+        // when
+        UpdateRecruitmentResponse updateRecruitmentResponse = recruitmentService.updateRecruitment(
+            1L,
+            1L,
+            "그리디 모집글 제목 수정",
+            "그리디 모집글 내용 수정",
+            LocalDateTime.of(2026, 1, 1, 0, 0),
+            LocalDateTime.of(2026, 1, 31, 23, 59),
+            List.of("그리디 모집글 이미지 수정.jpg"),
+            "그리디 모집 링크 수정",
+            false
+        );
+
+        // then
+        assertThat(updateRecruitmentResponse.id()).isEqualTo(1L);
+        assertThat(updateRecruitmentResponse.deleteImageUrls()).hasSize(2);
+        assertThat(updateRecruitmentResponse.deleteImageUrls()).allMatch(url -> url.equals("deleteUrl"));
+        assertThat(updateRecruitmentResponse.uploadImageUrls()).hasSize(1);
+        assertThat(updateRecruitmentResponse.uploadImageUrls()).allMatch(url -> url.equals("putUrl"));
+
+        BDDMockito.verify(recruitmentImageRepository, times(1)).deleteAll(any());
+        BDDMockito.verify(recruitmentImageRepository, times(1)).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("모집글 수정 시 모집글이 존재하지 않으면 예외가 발생한다.")
+    void updateRecruitment_notFoundRecruitment() {
+        // given
+        User adminUser = User.builder().build();
+        ReflectionTestUtils.setField(adminUser, "id", 1L);
+        ReflectionTestUtils.setField(adminUser, "role", UserRole.CLUB_ADMIN);
+
+        BDDMockito.given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
+        BDDMockito.given(recruitmentRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when, then
+        Assertions.assertThatThrownBy(() -> recruitmentService.updateRecruitment(
+                1L, 999L, "그리디 모집글 제목", "그리디 모집글 내용", LocalDateTime.now(), LocalDateTime.now().plusDays(1),
+                List.of("그리디 모집글 이미지.jpgg"), "그리디 모집 링크", false
+            ))
+            .isInstanceOf(MokkojiException.class)
+            .hasMessageContaining(FailMessage.NOT_FOUNT_RECRUITMENT.getMessage());
+    }
+
+    @Test
+    @DisplayName("권한을 가진 관리자는 모집글을 삭제할 수 있다.")
+    void deleteRecruitment() {
+        // given
+        User adminUser = User.builder().build();
+        ReflectionTestUtils.setField(adminUser, "id", 1L);
+        ReflectionTestUtils.setField(adminUser, "role", UserRole.CLUB_MASTER);
+
+        Recruitment recruitment = Recruitment.builder()
+            .title("그리디 모집글 제목")
+            .content("그리디 모집글 내용")
+            .build();
+        ReflectionTestUtils.setField(recruitment, "id", 1L);
+
+        RecruitmentImage recruitmentImage = RecruitmentImage.builder()
+            .recruitment(recruitment)
+            .image("그리디 모집글 이미지.jpg")
+            .build();
+
+        BDDMockito.given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
+        BDDMockito.given(recruitmentRepository.findById(1L)).willReturn(Optional.of(recruitment));
+        BDDMockito.given(recruitmentImageRepository.findByRecruitmentId(1L)).willReturn(List.of(recruitmentImage));
+        BDDMockito.given(appDataS3Client.getPresignedDeleteUrl(any())).willReturn("deleteUrl");
+
+        // when
+        DeleteRecruitmentResponse result = recruitmentService.deleteRecruitment(1L, 1L);
+
+        // then
+        assertThat(result.id()).isEqualTo(1L);
+        assertThat(result.deleteImageUrls()).hasSize(1);
+        assertThat(result.deleteImageUrls()).contains("deleteUrl");
+
+        BDDMockito.verify(recruitmentImageRepository, times(1)).deleteAll(any());
+        BDDMockito.verify(recruitmentRepository, times(1)).delete(recruitment);
+    }
+
+    @Test
+    @DisplayName("특정 동아리의 모든 모집글을 최신순으로 조회한다.")
+    void getAllRecruitmentOfClub_sortedByNewest() {
+        // given
+        Club club = Club.builder()
+            .name("그리디")
+            .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
+            .clubCategory(ClubCategory.ACADEMIC_CULTURAL)
+            .logo("greedy-logo.png")
+            .instagram("https://greedy-instagram.com")
+            .description("그리디 소개글")
+            .build();
+        ReflectionTestUtils.setField(club, "id", 1L);
+
+        Recruitment olderRecruitment = Recruitment.builder()
+            .club(club)
+            .title("오래된 그리디 모집글 제목")
+            .content("오래된 그리디 모집글 내용")
+            .recruitStart(LocalDateTime.of(2025, 1, 1, 0, 0))
+            .recruitEnd(LocalDateTime.of(2025, 1, 31, 23, 59))
+            .recruitForm("오래된 그리디 모집 링크")
+            .isAlwaysRecruiting(false)
+            .build();
+        ReflectionTestUtils.setField(olderRecruitment, "id", 1L);
+        ReflectionTestUtils.setField(olderRecruitment, "createdAt", LocalDateTime.of(2025, 1, 1, 0, 0));
+
+        Recruitment newerRecruitment = Recruitment.builder()
+            .club(club)
+            .title("새 그리디 모집글 제목")
+            .content("새 그리디 모집글 내용")
+            .recruitStart(LocalDateTime.of(2026, 1, 1, 0, 0))
+            .recruitEnd(LocalDateTime.of(2026, 1, 31, 23, 59))
+            .recruitForm("새 그리디 모집 링크")
+            .isAlwaysRecruiting(false)
+            .build();
+        ReflectionTestUtils.setField(newerRecruitment, "id", 2L);
+        ReflectionTestUtils.setField(newerRecruitment, "createdAt", LocalDateTime.of(2026, 1, 1, 0, 0));
+
+        RecruitmentImage newerImage = RecruitmentImage.builder()
+            .recruitment(newerRecruitment)
+            .image("그리디 모집글 이미지.jpg")
+            .build();
+
+        BDDMockito.given(recruitmentRepository.findAllByClubId(1L))
+            .willReturn(List.of(olderRecruitment, newerRecruitment));
+        BDDMockito.given(recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(2L))
+            .willReturn(List.of(newerImage));
+        BDDMockito.given(recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(1L)).willReturn(List.of());
+        BDDMockito.given(appDataS3Client.getPublicUrl(any())).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        AllRecruitmentOfClubResponse allRecruitmentOfClubResponse = recruitmentService.getAllRecruitmentOfClub(1L);
+
+        // then
+        assertThat(allRecruitmentOfClubResponse.recruitments()).hasSize(2);
+
+        RecruitmentOfClubResponse firstRecruitment = allRecruitmentOfClubResponse.recruitments().get(0);
+        assertThat(firstRecruitment.id()).isEqualTo(2L);
+        assertThat(firstRecruitment.title()).isEqualTo("새 그리디 모집글 제목");
+        assertThat(firstRecruitment.firstImage()).isEqualTo("그리디 모집글 이미지.jpg");
+
+        RecruitmentOfClubResponse secondRecruitment = allRecruitmentOfClubResponse.recruitments().get(1);
+        assertThat(secondRecruitment.id()).isEqualTo(1L);
+        assertThat(secondRecruitment.title()).isEqualTo("오래된 그리디 모집글 제목");
+    }
+
+    @Test
+    @DisplayName("동아리의 최신 모집글을 조회할 수 있다.")
+    void getRecentRecruitmentOfClub() {
+        // given
+        Club club = Club.builder()
+            .name("그리디")
+            .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
+            .clubCategory(ClubCategory.ACADEMIC_CULTURAL)
+            .logo("greedy-logo.png")
+            .instagram("https://greedy-instagram.com")
+            .description("그리디 소개글")
+            .build();
+        ReflectionTestUtils.setField(club, "id", 1L);
+
+        Recruitment olderRecruitment = Recruitment.builder()
+            .club(club)
+            .title("오래된 그리디 모집글 제목")
+            .content("오래된 그리디 모집글 내용")
+            .recruitStart(LocalDateTime.of(2025, 1, 1, 0, 0))
+            .recruitEnd(LocalDateTime.of(2025, 1, 31, 23, 59))
+            .recruitForm("오래된 그리디 모집 링크")
+            .isAlwaysRecruiting(false)
+            .build();
+        ReflectionTestUtils.setField(olderRecruitment, "id", 1L);
+        ReflectionTestUtils.setField(olderRecruitment, "createdAt", LocalDateTime.of(2025, 1, 1, 0, 0));
+
+        Recruitment newerRecruitment = Recruitment.builder()
+            .club(club)
+            .title("새 그리디 모집글 제목")
+            .content("새 그리디 모집글 내용")
+            .recruitStart(LocalDateTime.of(2026, 1, 1, 0, 0))
+            .recruitEnd(LocalDateTime.of(2026, 1, 31, 23, 59))
+            .recruitForm("새 그리디 모집 링크")
+            .isAlwaysRecruiting(false)
+            .build();
+        ReflectionTestUtils.setField(newerRecruitment, "id", 2L);
+        ReflectionTestUtils.setField(newerRecruitment, "createdAt", LocalDateTime.of(2026, 1, 1, 0, 0));
+
+        RecruitmentImage olderImage = RecruitmentImage.builder()
+            .recruitment(newerRecruitment)
+            .image("오래된 그리디 모집글 이미지.jpg")
+            .build();
+        RecruitmentImage newerImage = RecruitmentImage.builder()
+            .recruitment(newerRecruitment)
+            .image("새 그리디 모집글 이미지.jpg")
+            .build();
+
+        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(1L))
+            .willReturn(Optional.of(newerRecruitment));
+        BDDMockito.given(recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(2L))
+            .willReturn(List.of(newerImage));
+        BDDMockito.given(appDataS3Client.getPublicUrl(any())).willAnswer(invocation -> invocation.getArgument(0));
+        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(1L, 1L)).willReturn(true);
+
+        // when
+        RecentRecruitmentOfClubResponse recentRecruitmentOfClubResponse = recruitmentService.getRecentRecruitmentOfClub(
+            1L, 1L);
+
+        // then
+        assertThat(recentRecruitmentOfClubResponse.id()).isEqualTo(2L);
+        assertThat(recentRecruitmentOfClubResponse.clubId()).isEqualTo(1L);
+        assertThat(recentRecruitmentOfClubResponse.isFavorite()).isTrue();
+        assertThat(recentRecruitmentOfClubResponse.imageUrls()).hasSize(1);
+        assertThat(recentRecruitmentOfClubResponse.imageUrls()).contains("새 그리디 모집글 이미지.jpg");
+    }
+
+    @Test
+    @DisplayName("동아리 최신 모집글이 없으면 상시모집 글을 조회한다.")
+    void getRecentRecruitmentOfClub_fallbackToAlwaysRecruiting() {
+        // given
+        Club club = Club.builder()
+            .name("그리디")
+            .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
+            .clubCategory(ClubCategory.ACADEMIC_CULTURAL)
+            .logo("greedy-logo.png")
+            .instagram("https://greedy-instagram.com")
+            .description("그리디 소개글")
+            .build();
+        ReflectionTestUtils.setField(club, "id", 1L);
+
+        Recruitment alwaysRecruitment = Recruitment.builder()
+            .club(club)
+            .title("그리디 상시 모집 제목")
+            .content("그리디 상시 모집 내용")
+            .recruitForm("그리디 상시 모집 링크")
+            .isAlwaysRecruiting(true)
+            .build();
+        ReflectionTestUtils.setField(alwaysRecruitment, "id", 1L);
+        ReflectionTestUtils.setField(alwaysRecruitment, "createdAt", LocalDateTime.of(2026, 1, 1, 0, 0));
+
+        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(1L)).willReturn(Optional.empty());
+        BDDMockito.given(recruitmentRepository.findTopByClubIdAndIsAlwaysRecruitingOrderByCreatedAtDesc(1L, true))
+            .willReturn(Optional.of(alwaysRecruitment));
+        BDDMockito.given(recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(1L)).willReturn(List.of());
+        BDDMockito.given(appDataS3Client.getPublicUrl(any())).willAnswer(invocation -> invocation.getArgument(0));
+        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(1L, 1L)).willReturn(false);
+
+        // when
+        RecentRecruitmentOfClubResponse recentRecruitmentOfClubResponse = recruitmentService.getRecentRecruitmentOfClub(
+            1L, 1L);
+
+        // then
+        assertThat(recentRecruitmentOfClubResponse.id()).isEqualTo(1L);
+        assertThat(recentRecruitmentOfClubResponse.isAlwaysRecruiting()).isTrue();
+    }
+
+    @Test
+    @DisplayName("특정 모집글을 상세 조회할 수 있다.")
+    void getSpecificRecruitment() {
+        // given
+        Club club = Club.builder()
+            .name("그리디")
+            .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
+            .clubCategory(ClubCategory.ACADEMIC_CULTURAL)
+            .logo("greedy-logo.png")
+            .instagram("https://greedy-instagram.com")
+            .description("그리디 소개글")
+            .build();
+        ReflectionTestUtils.setField(club, "id", 1L);
+
+        Recruitment recruitment = Recruitment.builder()
+            .club(club)
+            .title("그리디 모집글 제목")
+            .content("그리디 모집글 내용")
+            .recruitStart(LocalDateTime.of(2025, 1, 1, 0, 0))
+            .recruitEnd(LocalDateTime.of(2025, 1, 31, 23, 59))
+            .recruitForm("그리디 모집 링크")
+            .isAlwaysRecruiting(false)
+            .build();
+        ReflectionTestUtils.setField(recruitment, "id", 1L);
+
+        RecruitmentImage recruitmentImage = RecruitmentImage.builder().recruitment(recruitment).image("그리디 모집글 이미지.jpg")
+            .build();
+
+        BDDMockito.given(recruitmentRepository.findRecruitmentById(1L)).willReturn(Optional.of(recruitment));
+        BDDMockito.given(recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(1L))
+            .willReturn(List.of(recruitmentImage));
+        BDDMockito.given(appDataS3Client.getPublicUrl(any())).willAnswer(invocation -> invocation.getArgument(0));
+        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(1L, 1L)).willReturn(true);
+
+        // when
+        SpecificRecruitmentResponse specificRecruitmentResponse = recruitmentService.getSpecificRecruitment(1L, 1L);
+
+        // then
+        assertThat(specificRecruitmentResponse.id()).isEqualTo(1L);
+        assertThat(specificRecruitmentResponse.clubId()).isEqualTo(1L);
+        assertThat(specificRecruitmentResponse.isFavorite()).isTrue();
+        assertThat(specificRecruitmentResponse.imageUrls()).contains("그리디 모집글 이미지.jpg");
+    }
+
+    @Test
+    @DisplayName("전체 모집글을 조회할 수 있다. - (즐겨 찾기, 마감 임박, 모집 중, 상시 모집, 모집 전, 모집 마감)대로 정렬된다.")
+    void getAllRecruitment_sortedByPolicy() {
+        // given
+        Long userId = 1L;
+        ClubAffiliation filteringByAffiliation = ClubAffiliation.DEPARTMENT_CLUB;
+        ClubCategory filteringByCategory = ClubCategory.ACADEMIC_CULTURAL;
+
+        LocalDateTime now = LocalDateTime.now();
+
+        Club favoriteClub = Club.builder()
+            .clubAffiliation(filteringByAffiliation)
+            .clubCategory(filteringByCategory)
+            .build();
+        ReflectionTestUtils.setField(favoriteClub, "id", 1L);
+
+        Club imminentClub = Club.builder()
+            .clubAffiliation(filteringByAffiliation)
+            .clubCategory(filteringByCategory).build();
+        ReflectionTestUtils.setField(imminentClub, "id", 2L);
+
+        Club openClub = Club.builder()
+            .clubAffiliation(filteringByAffiliation)
+            .clubCategory(filteringByCategory)
+            .build();
+        ReflectionTestUtils.setField(openClub, "id", 3L);
+
+        Club alwaysClub = Club.builder()
+            .clubAffiliation(filteringByAffiliation)
+            .clubCategory(filteringByCategory)
+            .build();
+        ReflectionTestUtils.setField(alwaysClub, "id", 4L);
+
+        Club beforeClub = Club.builder()
+            .clubAffiliation(filteringByAffiliation)
+            .clubCategory(filteringByCategory)
+            .build();
+        ReflectionTestUtils.setField(beforeClub, "id", 5L);
+
+        Club closedClub = Club.builder()
+            .clubAffiliation(filteringByAffiliation)
+            .clubCategory(filteringByCategory)
+            .build();
+        ReflectionTestUtils.setField(closedClub, "id", 6L);
+
+        //즐겨찾기
+        Recruitment favoriteRecruitment = Recruitment.builder()
+            .club(favoriteClub)
+            .recruitStart(now.minusDays(2))
+            .recruitEnd(now.plusDays(10))
+            .isAlwaysRecruiting(false)
+            .build();
+        ReflectionTestUtils.setField(favoriteRecruitment, "id", 1L);
+
+        //모집 마감 임박
+        Recruitment imminentRecruitment = Recruitment.builder()
+            .club(imminentClub)
+            .recruitStart(now.minusDays(1))
+            .recruitEnd(now.plusMinutes(30))
+            .isAlwaysRecruiting(false)
+            .build();
+        ReflectionTestUtils.setField(imminentRecruitment, "id", 2L);
+
+        //모집 중
+        Recruitment openRecruitment = Recruitment.builder()
+            .club(openClub)
+            .recruitStart(now.minusDays(1))
+            .recruitEnd(now.plusDays(30))
+            .isAlwaysRecruiting(false)
+            .build();
+        ReflectionTestUtils.setField(openRecruitment, "id", 3L);
+
+        //상시 모집
+        Recruitment alwaysRecruitment = Recruitment.builder()
+            .club(alwaysClub)
+            .recruitStart(now.minusDays(100))
+            .recruitEnd(now.plusDays(1000))
+            .isAlwaysRecruiting(true)
+            .build();
+        ReflectionTestUtils.setField(alwaysRecruitment, "id", 4L);
+
+        //모집 전
+        Recruitment beforeRecruitment = Recruitment.builder()
+            .club(beforeClub)
+            .recruitStart(now.plusDays(3))
+            .recruitEnd(now.plusDays(10))
+            .isAlwaysRecruiting(false)
+            .build();
+        ReflectionTestUtils.setField(beforeRecruitment, "id", 5L);
+
+        //모집 마감
+        Recruitment closedRecruitment = Recruitment.builder()
+            .club(closedClub)
+            .recruitStart(now.minusDays(10))
+            .recruitEnd(now.minusDays(1))
+            .isAlwaysRecruiting(false)
+            .build();
+        ReflectionTestUtils.setField(closedRecruitment, "id", 6L);
+
+        PageRequest pageable = PageRequest.of(0, 10);
+
+        Page<Recruitment> page = new PageImpl<>(
+            List.of(openRecruitment, closedRecruitment, alwaysRecruitment, imminentRecruitment, beforeRecruitment, favoriteRecruitment),
+            pageable,
+            6
+        );
+
+        BDDMockito.given(recruitmentRepository.findRecruitments(
+                filteringByAffiliation,
+                filteringByCategory,
+                pageable
+            ))
+            .willReturn(page);
+
+        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, 1L)).willReturn(true);
+        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, 2L)).willReturn(false);
+        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, 3L)).willReturn(false);
+        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, 4L)).willReturn(false);
+        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, 5L)).willReturn(false);
+        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, 6L)).willReturn(false);
+
+        BDDMockito.given(appDataS3Client.getPublicUrl(any())).willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        AllRecruitmentResponse allRecruitmentResponse = recruitmentService.getAllRecruitment(
+            userId,
+            filteringByAffiliation,
+            filteringByCategory,
+            pageable
+        );
+
+        // then
+        assertThat(allRecruitmentResponse.recruitments()).hasSize(6);
+
+        List<Long> recruitmentIds = allRecruitmentResponse.recruitments().stream()
+            .map(RecruitmentPreviewResponse::id)
+            .toList();
+
+        assertThat(recruitmentIds).containsExactly(1L, 2L, 3L, 4L, 5L, 6L);
+    }
+}


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #302 

## 작업 배경
### 1. 특정 동아리의 모든 모집글 정렬 정책 변경
모집글 리스트를 띄우기 위해서는 정렬 정책이 필요합니다. 
기존 코드에 적용된 기준은 모집 마감일(recruitEnd)였습니다.
`Comparator.comparing(Recruitment::getRecruitEnd).reversed()`
하지만, 모집 마감일로 정렬할 경우 문제가 생길 여지가 있어 개선이 필요하다고 생각했습니다.

recruitEnd 기준으로만 정렬할 경우, 

> 1. 같은 모집 기수에서 모집글을 여러 번 등록한 경우 최신순 보장이 어렵고(실제 DB에 존재하는 예시), 
> 2. 동일한 마감일을 가진 데이터가 많아질수록 정렬 결과가 흔들릴 수 있습니다.

물론 recruitEnd가 동일할 때 createdAt 등 2차 정렬 조건을 추가하는 방식도 가능하지만,
정렬 정책을 명확히 하고 일관성을 유지하기 위해 `createdAt`을 단일 기준으로 사용하는 것이 더 자연스럽고 깔끔하다고 판단했습니다.

### 2. 최신 모집글 조회 조건 변경 (updatedAt → createdAt)
> 1. 모집글 전체 조회 로직
> 2. 최신 모집글 조회 로직

모집글 최신 기준을 updatedAt으로 사용하고 있던 로직이 존재했습니다.

[RecruitmentRepository 내부 메서드]
```
Optional<Recruitment> findTopByClubIdOrderByUpdatedAtDesc(Long clubId);

Optional<Recruitment> findTopByClubIdAndIsAlwaysRecruitingOrderByUpdatedAtDesc(Long clubId, boolean isAlwaysRecruiting);
```

하지만 `updatedAt`은 내용 수정/이미지 수정 등 단순 수정만으로도 최신으로 재정렬될 수 있어, [최근에 등록된 모집글]이라는 의미에서 어긋날 수 있습니다. 또한 정렬 정책을 서비스 전반에서 `createdAt` 기준으로 통일하는 것이 더 안전하고 예측 가능하다고 판단했습니다. 
특히 관리자 기능 확장으로, 동아리 데이터를 관리하는 흐름이 안정화되는 시점이어서, 이 변경이 더 적절하다고 생각했습니다!

## 작업 내용
### 1. 특정 동아리 모집글 목록 조회 시 정렬 기준 변경
- 기존: updatedAt 기반 최신순
- 변경: createdAt 기반 최신순으로 정책 변경

### 2. 최신 모집글 조회 기준 변경
  `updatedAt` → `createdAt`으로 변경하였습니다.

### 3. 테스트 코드 보강 및 리팩토링
기존에 recruitment 관련 테스트 코드가 존재하지 않아, controller 및 service 테스트를 구현했습니다.
이로 인해 위 언급했던 정책 변경 사항을 검증했습니다.

### 4. 전체 모집글 조회 API 페이지네이션 오류 수정
응답의 `totalPages`, `totalElements`가 전체 기준이 아닌 현재 페이지 기준으로 계산되고 있던 문제가 있었습니다.
프론트에서 해당 필드를 사용하지 않아 인지가 늦었으나, 백엔드 응답 신뢰성을 위해 수정해보았습니다.
(해당 값은 추후 무한 스크롤 등에서 사용할 가능성이 있어 유지하는 것이 좋을 것 같습니당)

### 5. 상시 모집 Enum 추가 및 적용 (`ALWAYS`)
상시 모집 관련 Enum을 추가 후 적용하였습니다. 

## 🚨 **참고 사항**
프로젝트 초기에 관리자 기능이 없어 DB에 수동 삽입을 진행했던 영향으로, 대다수의 데이터는 `createdAt`이 null이거나 실제 등록 시점과 다른 값을 가지고 있었습니다. 이번 정렬 정책 적용을 위해 `createdAt`을 모집 시작일(`recruitStart`)로 덮어쓰는 방식으로  DB에 적용해놓았습니다. 추가적으로 문제될만한 부분이 있다면 알려주시면 감사하겠습니다! 

추가로 테스트 코드를 작성하는 과정에서, 기존 로직에 대해 테스트가 부족해 인지하지 못했던 문제들을 발견하여 함께 수정하게 되었습니다.
PR 제목에 명시된 작업 범위와는 다르게 변경사항이 많아진 점 정말정말 죄송합니다 ㅠㅠ 
천천히 꼼꼼히 읽어봐주세요!
