### PR TITLE
Fix: 잘못된 jakarta 트랜잭션 springframwork 로 수정

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/external/sejong/SejongLoginClient.java
+++ b/src/main/java/com/greedy/mokkoji/api/external/sejong/SejongLoginClient.java
@@ -3,12 +3,12 @@ package com.greedy.mokkoji.api.external.sejong;
 import com.greedy.mokkoji.api.user.dto.resopnse.StudentInformationResponse;
 import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.enums.message.FailMessage;
-import jakarta.transaction.Transactional;
 import okhttp3.*;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.net.ssl.*;
 import java.io.IOException;

--- a/src/main/java/com/greedy/mokkoji/api/notification/service/NotificationService.java
+++ b/src/main/java/com/greedy/mokkoji/api/notification/service/NotificationService.java
@@ -4,9 +4,9 @@ import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.favorite.entity.Favorite;
 import com.greedy.mokkoji.db.favorite.repository.FavoriteRepository;
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -16,7 +16,7 @@ public class NotificationService {
     private final NotificationChannel notificationChannel;
     private final FavoriteRepository favoriteRepository;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public void sendNotification(final Club club, final Recruitment recruitment) {
         List<Favorite> favorites = favoriteRepository.findByClubIdWithFetchJoin(club.getId());
 

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -27,12 +27,12 @@ import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.message.FailMessage;
 import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import com.greedy.mokkoji.enums.user.UserRole;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.*;

--- a/src/main/java/com/greedy/mokkoji/api/scheduler/service/RecruitmentNotificationScheduler.java
+++ b/src/main/java/com/greedy/mokkoji/api/scheduler/service/RecruitmentNotificationScheduler.java
@@ -4,11 +4,11 @@ import com.greedy.mokkoji.api.notification.service.NotificationService;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.db.recruitment.repository.RecruitmentRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #304

## 👷 **작업한 내용**
- NotificationService의 sendNotification 메서드에 트랜잭션 readOnly 설정을 추가하여 해당 메서드가 읽기 전용 로직임을 명확히 하였습니다.
- @Transactional 어노테이션을 Spring Framework 기준으로 통일하였습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
