### PR TITLE
Fix: 동아리 모집공고 목록 응답에서 불필요한 firstImage 필드 제거

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/allRecruitmentOfClub/RecruitmentOfClubResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/allRecruitmentOfClub/RecruitmentOfClubResponse.java
@@ -15,7 +15,6 @@ public record RecruitmentOfClubResponse(
         @Schema(example = "2025-12-04T23:59:59") LocalDateTime recruitEnd,
         @Schema(example = "OPEN") RecruitStatus status,
         @Schema(example = "2025-11-20T10:00:00") LocalDateTime createdAt,
-        @Schema(example = "https://mokkoji-app-data.s3.ap-northeast-2.amazonaws.com/recruitment-image/1/2/{UUID}.jpg") String firstImage,
         @Schema(example = "false") boolean isAlwaysRecruiting
 ) {
 }

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -123,7 +123,6 @@ public class RecruitmentService {
                         .recruitEnd(recruitment.getRecruitEnd())
                         .status(RecruitStatus.from(recruitment.getRecruitStart(), recruitment.getRecruitEnd()))
                         .createdAt(recruitment.getCreatedAt())
-                        .firstImage(getFirstImageUrl(recruitment.getId()))
                         .isAlwaysRecruiting(recruitment.isAlwaysRecruiting())
                         .build()
                 )
@@ -316,13 +315,6 @@ public class RecruitmentService {
         recruitmentImageRepository.deleteAll(oldImages);
 
         return deleteImageUrls;
-    }
-
-    private String getFirstImageUrl(Long recruitmentId) {
-        return recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(recruitmentId).stream()
-                .findFirst()
-                .map(image -> appDataS3Client.getPublicUrl(image.getImage()))
-                .orElse(null);
     }
 
     private boolean isFavorite(final Long userId, final Long clubId) {

--- a/src/test/java/com/greedy/mokkoji/favorite/controller/FavoriteControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/favorite/controller/FavoriteControllerTest.java
@@ -29,6 +29,7 @@ public class FavoriteControllerTest extends ControllerTest {
     @BeforeEach
     void setUp() {
         favoriteRepository.deleteAll();
+        commentRepository.deleteAll();
         userRepository.deleteAll();
         recruitmentRepository.deleteAll();
         clubRepository.deleteAll();

--- a/src/test/java/com/greedy/mokkoji/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/recruitment/service/RecruitmentServiceTest.java
@@ -329,10 +329,6 @@ public class RecruitmentServiceTest {
 
         BDDMockito.given(recruitmentRepository.findAllByClubId(1L))
             .willReturn(List.of(olderRecruitment, newerRecruitment));
-        BDDMockito.given(recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(2L))
-            .willReturn(List.of(newerImage));
-        BDDMockito.given(recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(1L)).willReturn(List.of());
-        BDDMockito.given(appDataS3Client.getPublicUrl(any())).willAnswer(invocation -> invocation.getArgument(0));
 
         // when
         AllRecruitmentOfClubResponse allRecruitmentOfClubResponse = recruitmentService.getAllRecruitmentOfClub(1L);

--- a/src/test/java/com/greedy/mokkoji/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/recruitment/service/RecruitmentServiceTest.java
@@ -343,7 +343,6 @@ public class RecruitmentServiceTest {
         RecruitmentOfClubResponse firstRecruitment = allRecruitmentOfClubResponse.recruitments().get(0);
         assertThat(firstRecruitment.id()).isEqualTo(2L);
         assertThat(firstRecruitment.title()).isEqualTo("새 그리디 모집글 제목");
-        assertThat(firstRecruitment.firstImage()).isEqualTo("그리디 모집글 이미지.jpg");
 
         RecruitmentOfClubResponse secondRecruitment = allRecruitmentOfClubResponse.recruitments().get(1);
         assertThat(secondRecruitment.id()).isEqualTo(1L);


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #308

## 👷 **작업한 내용**
RecruitmentOfClubResponse에서 사용하지 않는 firstImage 필드와 연관된 메서드 삭제했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
