### PR TITLE
 Fix: 모든 enum API 응답을 enum 타입으로 통일

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubDetailResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubDetailResponse.java
@@ -1,5 +1,7 @@
 package com.greedy.mokkoji.api.club.dto.response;
 
+import com.greedy.mokkoji.enums.club.ClubAffiliation;
+import com.greedy.mokkoji.enums.club.ClubCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -10,8 +12,8 @@ import java.time.format.DateTimeFormatter;
 public record ClubDetailResponse(
         @Schema(example = "1") Long id,
         @Schema(example = "그리디") String name,
-        @Schema(example = "학술/교양") String category,
-        @Schema(example = "정인준/가인준") String affiliation,
+        @Schema(example = "ACADEMIC_CULTURAL") ClubCategory category,
+        @Schema(example = "DEPARTMENT_CLUB") ClubAffiliation affiliation,
         @Schema(example = "세종대 최고의 코딩 동아리") String description,
         @Schema(example = "2025-11-25") String recruitStartDate,
         @Schema(example = "2025-12-04") String recruitEndDate,
@@ -23,8 +25,8 @@ public record ClubDetailResponse(
     public static ClubDetailResponse of(
             final Long id,
             final String name,
-            final String category,
-            final String affiliation,
+            final ClubCategory category,
+            final ClubAffiliation affiliation,
             final String description,
             final LocalDateTime recruitStartDate,
             final LocalDateTime recruitEndDate,

--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubManageDetailResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubManageDetailResponse.java
@@ -1,18 +1,27 @@
 package com.greedy.mokkoji.api.club.dto.response;
 
+import com.greedy.mokkoji.enums.club.ClubAffiliation;
+import com.greedy.mokkoji.enums.club.ClubCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 public record ClubManageDetailResponse(
         @Schema(example = "그리디") String name,
-        @Schema(example = "ACADEMIC_CULTURAL") String category,
-        @Schema(example = "DEPARTMENT_CLUB") String affiliation,
+        @Schema(example = "ACADEMIC_CULTURAL") ClubCategory category,
+        @Schema(example = "DEPARTMENT_CLUB") ClubAffiliation affiliation,
         @Schema(example = "세종대 최고의 코딩 동아리") String description,
         @Schema(example = "https://mokkoji-app-data.s3.ap-northeast-2.amazonaws.com/club-logo/1/greedy_{UUID}.jpg") String logo,
         @Schema(example = "https://instagram.com/greedy_sejong") String instagram
 ) {
-    public static ClubManageDetailResponse of(final String name, final String category, final String affiliation, final String description, final String logo, final String instagram) {
+    public static ClubManageDetailResponse of(
+            final String name,
+            final ClubCategory category,
+            final ClubAffiliation affiliation,
+            final String description,
+            final String logo,
+            final String instagram
+    ) {
         return new ClubManageDetailResponse(name, category, affiliation, description, logo, instagram);
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubResponse.java
@@ -1,5 +1,7 @@
 package com.greedy.mokkoji.api.club.dto.response;
 
+import com.greedy.mokkoji.enums.club.ClubAffiliation;
+import com.greedy.mokkoji.enums.club.ClubCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -10,8 +12,8 @@ import java.time.format.DateTimeFormatter;
 public record ClubResponse(
         @Schema(example = "1") Long id,
         @Schema(example = "그리디") String name,
-        @Schema(example = "학술/교양") String category,
-        @Schema(example = "정인준/가인준") String affiliation,
+        @Schema(example = "ACADEMIC_CULTURAL") ClubCategory category,
+        @Schema(example = "DEPARTMENT_CLUB") ClubAffiliation affiliation,
         @Schema(example = "세종대 최고의 코딩 동아리") String description,
         @Schema(example = "2025-11-25") String recruitStartDate,
         @Schema(example = "2025-12-04") String recruitEndDate,
@@ -21,8 +23,8 @@ public record ClubResponse(
     public static ClubResponse of(
             final Long id,
             final String name,
-            final String category,
-            final String affiliation,
+            final ClubCategory category,
+            final ClubAffiliation affiliation,
             final String description,
             final LocalDateTime recruitStartDate,
             final LocalDateTime recruitEndDate,

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -92,8 +92,8 @@ public class ClubService {
 
         return ClubManageDetailResponse.of(
                 club.getName(),
-                club.getClubCategory().name(),
-                club.getClubAffiliation().name(),
+                club.getClubCategory(),
+                club.getClubAffiliation(),
                 club.getDescription(),
                 appDataS3Client.getPublicUrl(club.getLogo()),
                 club.getInstagram()
@@ -142,8 +142,8 @@ public class ClubService {
         return ClubDetailResponse.of(
                 club.getId(),
                 club.getName(),
-                club.getClubCategory().getDescription(),
-                club.getClubAffiliation().getDescription(),
+                club.getClubCategory(),
+                club.getClubAffiliation(),
                 club.getDescription(),
                 recruitment != null ? recruitment.getRecruitStart() : null,
                 recruitment != null ? recruitment.getRecruitEnd() : null,
@@ -162,8 +162,8 @@ public class ClubService {
                     boolean isFavorite = getIsFavorite(userId, club.getId());
                     return ClubResponse.of(club.getId(),
                             club.getName(),
-                            club.getClubCategory().getDescription(),
-                            club.getClubAffiliation().getDescription(),
+                            club.getClubCategory(),
+                            club.getClubAffiliation(),
                             club.getDescription(),
                             recruitment != null ? recruitment.getRecruitStart() : null,
                             recruitment != null ? recruitment.getRecruitEnd() : null,

--- a/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
+++ b/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
@@ -67,8 +67,8 @@ public class FavoriteService {
                     return ClubResponse.of(
                             club.getId(),
                             club.getName(),
-                            club.getClubCategory().getDescription(),
-                            club.getClubAffiliation().getDescription(),
+                            club.getClubCategory(),
+                            club.getClubAffiliation(),
                             club.getDescription(),
                             recruitment != null ? recruitment.getRecruitStart() : null,
                             recruitment != null ? recruitment.getRecruitEnd() : null,

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/recentRecruitment/RecentRecruitmentOfClubResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/recentRecruitment/RecentRecruitmentOfClubResponse.java
@@ -1,5 +1,6 @@
 package com.greedy.mokkoji.api.recruitment.dto.response.recentRecruitment;
 
+import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -21,7 +22,7 @@ public record RecentRecruitmentOfClubResponse(
         @Schema(example = "https://forms.gle/abcdEFGH1234") String recruitForm,
         @Schema(example = "true") Boolean isFavorite,
         @Schema(example = "https://instagram.com/greedy_sejong") String instagramUrl,
-        @Schema(example = "학술/교양") String category,
+        @Schema(example = "ACADEMIC_CULTURAL") ClubCategory category,
         @Schema(example = "false") boolean isAlwaysRecruiting
 ) {
 
@@ -40,7 +41,7 @@ public record RecentRecruitmentOfClubResponse(
             String recruitForm,
             Boolean isFavorite,
             String instagramUrl,
-            String category,
+            ClubCategory category,
             boolean isAlwaysRecruiting
     ) {
         return new RecentRecruitmentOfClubResponse(

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/specificRecruitment/SpecificRecruitmentResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/specificRecruitment/SpecificRecruitmentResponse.java
@@ -1,5 +1,6 @@
 package com.greedy.mokkoji.api.recruitment.dto.response.specificRecruitment;
 
+import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -21,7 +22,7 @@ public record SpecificRecruitmentResponse(
         @Schema(example = "https://forms.gle/abcdEFGH1234") String recruitForm,
         @Schema(example = "true") Boolean isFavorite,
         @Schema(example = "https://instagram.com/greedy_sejong") String instagramUrl,
-        @Schema(example = "학술/교양") String category,
+        @Schema(example = "ACADEMIC_CULTURAL") ClubCategory category,
         @Schema(example = "false") boolean isAlwaysRecruiting
 ) {
 
@@ -40,7 +41,7 @@ public record SpecificRecruitmentResponse(
             String recruitForm,
             Boolean isFavorite,
             String instagramUrl,
-            String category,
+            ClubCategory category,
             boolean isAlwaysRecruiting
     ) {
         return new SpecificRecruitmentResponse(

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -168,7 +168,7 @@ public class RecruitmentService {
                 recruitment.getRecruitForm(),
                 isFavorite,
                 club.getInstagram(),
-                club.getClubCategory().getDescription(),
+                club.getClubCategory(),
                 recruitment.isAlwaysRecruiting()
         );
     }
@@ -203,7 +203,7 @@ public class RecruitmentService {
                 recruitment.getRecruitForm(),
                 isFavorite(userId, club.getId()),
                 club.getInstagram(),
-                club.getClubCategory().getDescription(),
+                club.getClubCategory(),
                 recruitment.isAlwaysRecruiting()
         );
     }

--- a/src/main/java/com/greedy/mokkoji/api/user/dto/resopnse/UserRoleResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/dto/resopnse/UserRoleResponse.java
@@ -1,11 +1,12 @@
 package com.greedy.mokkoji.api.user.dto.resopnse;
 
+import com.greedy.mokkoji.enums.user.UserRole;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record UserRoleResponse(
-        @Schema(example = "CLUB_ADMIN") String role
+        @Schema(example = "CLUB_ADMIN") UserRole role
 ) {
-    public static UserRoleResponse of(final String role) {
+    public static UserRoleResponse of(final UserRole role) {
         return new UserRoleResponse(role);
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -113,7 +113,7 @@ public class UserService {
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
 
         return UserRoleResponse.of(
-                user.getRole().toString()
+                user.getRole()
         );
     }
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #310 

## 👷 **작업한 내용**
 기존 API 응답에서 enum 타입을 일관성 없이 처리하고 있었습니다:
  - 일부는 enum.name() 반환 (영문)
  - 일부는 enum.getDescription() 반환 (한글)
  - 일부는 enum.toString() 반환

모든 enum 반환 타입을 enum으로 통일하여 Jackson이 자동으로 JSON 직렬화하도록 개선했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
