### PR TITLE
Refactor : 이메일 디자인 수정하기

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/notification/service/EmailNotificationChannel.java
+++ b/src/main/java/com/greedy/mokkoji/api/notification/service/EmailNotificationChannel.java
@@ -33,6 +33,8 @@ public class EmailNotificationChannel implements NotificationChannel {
     private String senderMail;
     @Value("${mokkoji.base-url}")
     private String baseUrl;
+    @Value("${mokkoji.mail.banner-url}")
+    private String mailBannerUrl;
 
     private String generateHtmlText(
             final Long clubId,
@@ -42,23 +44,46 @@ public class EmailNotificationChannel implements NotificationChannel {
     ) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일");
 
-        return "<!DOCTYPE html>" +
-                "<html>" +
-                "<head>" +
-                "<meta charset='UTF-8'>" +
-                "<title>동아리 모집 안내</title>" +
-                "</head>" +
-                "<body style='font-family: Arial, sans-serif; margin: 20px;'>" +
-                "<h2 style='color: #2E86C1;'>🎉 " + clubName + " 모집 시작! 🎉</h2>" +
-                "<p>안녕하세요!</p>" +
-                "<p>모꼬지에서 즐겨찾기하신 <strong>" + clubName + "</strong> 동아리가 신규 회원을 모집합니다.</p>" +
-                "<p>📅 <strong>모집 기간:</strong> " + recruitStart.format(formatter) + " ~ " + recruitEnd.format(formatter) + "</p>" +
-                "<p>지금 바로 지원하여 기회를 놓치지 마세요!</p>" +
-                "<a href='" + baseUrl + "/club/" + clubId + "' " +
-                "style='display: inline-block; padding: 10px 20px; margin-top: 20px; font-size: 16px; color: white; background-color: #2E86C1; text-decoration: none; border-radius: 5px;'>신청하러 가기</a>" +
-                "<p>감사합니다!<br>모꼬지 팀 드림</p>" +
-                "</body>" +
-                "</html>";
+        return """
+                <!DOCTYPE html>
+                <html>
+                <head>
+                    <meta charset="UTF-8">
+                    <title>동아리 모집 안내</title>
+                </head>
+                <body style="font-family: Arial, sans-serif;">
+                
+                    <!-- 배너 이미지 -->
+                    <img src="%s"
+                         alt="모꼬지 배너"
+                         style="width: 100%%; display: block; margin: 0 0 20px 0; max-width: 600px;" />
+                    <div style="margin: 40px">
+                    <h3>📣 %s 모집 안내!</h3>
+                    <p style="margin: 0 0 8px 0;">안녕하세요! <strong>모꼬지</strong>입니다:)</p>
+                    <p style="margin: 0 0 30px 0;">즐겨찾기하신 <strong>%s</strong> 동아리가 신규 회원을 모집합니다.</p>
+                    <p style="margin: 0 0 8px 0;"><strong>모집 기간 : %s ~ %s</strong></p>
+                    <p style="margin: 0 0 30px 0;">지금 바로 지원하여 기회를 놓치지 마세요!</p>
+                    <p style="margin: 0 0 30px 0;">모꼬지 드림.</p>
+                
+                    <a href="%s/club/%d"
+                       style="display: inline-block; padding: 10px 15px;
+                              font-size: 14px; color: #000000; background-color: #4AF38A;
+                              text-decoration: none; border-radius: 40px; font-weight: 500;">
+                       신청하러 가기
+                    </a>
+                    </div>
+                </body>
+                </html>
+                """.formatted(
+                mailBannerUrl,
+                clubName,
+                clubName,
+                recruitStart.format(formatter),
+                recruitEnd.format(formatter),
+                baseUrl,
+                clubId
+        );
+
     }
 
     @Override

--- a/src/main/java/com/greedy/mokkoji/api/notification/service/EmailNotificationChannel.java
+++ b/src/main/java/com/greedy/mokkoji/api/notification/service/EmailNotificationChannel.java
@@ -24,7 +24,7 @@ import static com.greedy.mokkoji.enums.message.FailMessage.INTERNAL_SERVER_ERROR
 @RequiredArgsConstructor
 public class EmailNotificationChannel implements NotificationChannel {
     private static final String SUBJECT = "동아리 모집 안내";
-    private static final String SENDER_NAME = "모꼬지";
+    private static final String SENDER_NAME = "모꼬지(mokkoji)";
     private static final String OFFICIAL_EMAIL = "noreply@mokkoji.com";
     private final JavaMailSender mailSender;
     private final DiscordNotifier discordNotifier;

--- a/src/main/java/com/greedy/mokkoji/api/notification/service/EmailNotificationChannel.java
+++ b/src/main/java/com/greedy/mokkoji/api/notification/service/EmailNotificationChannel.java
@@ -23,7 +23,7 @@ import static com.greedy.mokkoji.enums.message.FailMessage.INTERNAL_SERVER_ERROR
 @Component
 @RequiredArgsConstructor
 public class EmailNotificationChannel implements NotificationChannel {
-    private static final String SUBJECT = "동아리 모집 시작";
+    private static final String SUBJECT = "동아리 모집 안내";
     private static final String SENDER_NAME = "모꼬지";
     private static final String OFFICIAL_EMAIL = "noreply@mokkoji.com";
     private final JavaMailSender mailSender;


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #315 
---
## 👷 **작업한 내용**
# ⭐️ **구현사항**
### 참고) 수정 전 기존 이미지
<img width="400" height=auto alt="Image" src="https://github.com/user-attachments/assets/6d3c1196-027d-4cb4-81ee-8b8dbf206f35" />

---
### 1) html 가독성 높이기
* 기존 문자열을 +로 이어 붙이던 방식에서 가독성과 수정 편의를 위해 Java Text Block(""") 형태로 변경했습니다.
(수정 전)
<img width="500" height=auto alt="Image" src="https://github.com/user-attachments/assets/8e804418-90bb-4e98-a234-93587a364340" />

(수정 후)
<img width="500" height=auto alt="스크린샷 2026-01-13 오후 3 46 53" src="https://github.com/user-attachments/assets/479bc6f4-fb47-44ca-88a8-dd57454ebae6" />

---
### 2) 디자인 변경
(figma 디자인)
<img width="400" height=auto alt="Image" src="https://github.com/user-attachments/assets/15caaa02-07db-4a4d-a765-15230ae68383" />

(실제 구현)
<img width="400" height=auto alt="Image" src="https://github.com/user-attachments/assets/9b7aae63-c829-4ae8-b14e-fa78308593e2" />

---
### 3) 글 수정 
(지원 시작 -> 지원 안내)
저희는 지원 시작일 뿐만 아니라, 마감 3일 전과 마감 당일 또한 메일을 보내기 때문에
"지원 시작"이라는 멘트보다 "지원 안내"라는 멘트가 더 적절하다고 판단했습니다.

---
### 4) 이메일 제목 수정
(동아리 모집 시작 -> 모집 안내)
이유는 3번과 같습니다.

---
## 🚨 **참고 사항**
* 이메일 배너 이미지는 S3에 업로드된 이미지를 불러오는 방식을 사용합니다.
* 개발/운영 AWS 계정에 각각 배너 이미지를 저장하고, yml 설정 파일에 S3 이미지 URL을 등록해 환경별로 불러오는 구조입니다.
* 노션의 yml파일 수정, s3에 이미지 업로드 완료하였습니다~
