### PR TITLE
Fix: 상시모집 마감일 정렬 시 NPE 발생 문제 수정

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -27,14 +27,17 @@ import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.message.FailMessage;
 import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import com.greedy.mokkoji.enums.user.UserRole;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -49,22 +52,23 @@ public class RecruitmentService {
 
     @Transactional
     public CreateRecruitmentResponse createRecruitment(
-            final Long userId,
-            final Long clubId,
-            final String title,
-            final String content,
-            final LocalDateTime recruitStart,
-            final LocalDateTime recruitEnd,
-            final List<String> imageNames,
-            final String recruitForm,
-            final boolean isAlwaysRecruiting) {
+        final Long userId,
+        final Long clubId,
+        final String title,
+        final String content,
+        final LocalDateTime recruitStart,
+        final LocalDateTime recruitEnd,
+        final List<String> imageNames,
+        final String recruitForm,
+        final boolean isAlwaysRecruiting) {
 
         validateAdmin(userId);
 
         Club club = clubRepository.findById(clubId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB));
+            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB));
 
-        Recruitment recruitment = buildAndSaveRecruitment(club, title, content, recruitStart, recruitEnd, recruitForm, isAlwaysRecruiting);
+        Recruitment recruitment = buildAndSaveRecruitment(club, title, content, recruitStart, recruitEnd, recruitForm,
+            isAlwaysRecruiting);
         List<String> uploadImageUrls = uploadRecruitmentImages(recruitment, imageNames);
 
         return CreateRecruitmentResponse.of(recruitment.getId(), uploadImageUrls);
@@ -72,20 +76,20 @@ public class RecruitmentService {
 
     @Transactional
     public UpdateRecruitmentResponse updateRecruitment(
-            final Long userId,
-            final Long recruitmentId,
-            final String title,
-            final String content,
-            final LocalDateTime recruitStart,
-            final LocalDateTime recruitEnd,
-            final List<String> imageNames,
-            final String recruitForm,
-            final boolean isAlwaysRecruiting
+        final Long userId,
+        final Long recruitmentId,
+        final String title,
+        final String content,
+        final LocalDateTime recruitStart,
+        final LocalDateTime recruitEnd,
+        final List<String> imageNames,
+        final String recruitForm,
+        final boolean isAlwaysRecruiting
     ) {
         validateAdmin(userId);
 
         Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUNT_RECRUITMENT));
+            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUNT_RECRUITMENT));
 
         recruitment.updateRecruitment(title, content, recruitStart, recruitEnd, recruitForm, isAlwaysRecruiting);
 
@@ -100,7 +104,7 @@ public class RecruitmentService {
         validateAdmin(userId);
 
         Recruitment recruitment = recruitmentRepository.findById(recruitmentId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUNT_RECRUITMENT));
+            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUNT_RECRUITMENT));
 
         List<String> deleteImageUrls = deleteImages(recruitmentId);
         recruitmentRepository.delete(recruitment);
@@ -113,25 +117,25 @@ public class RecruitmentService {
         List<Recruitment> recruitments = recruitmentRepository.findAllByClubId(clubId);
 
         List<RecruitmentOfClubResponse> recruitmentList = recruitments.stream()
-                .sorted(newestFirstRecruitmentComparator())
-                .map(recruitment -> RecruitmentOfClubResponse.builder()
-                        .id(recruitment.getId())
-                        .title(recruitment.getTitle())
-                        .content(recruitment.getContent())
-                        .recruitStart(recruitment.getRecruitStart())
-                        .recruitEnd(recruitment.getRecruitEnd())
-                        .status(
-                                RecruitStatus.from(
-                                        recruitment.isAlwaysRecruiting(),
-                                        recruitment.getRecruitStart(),
-                                        recruitment.getRecruitEnd()
-                                )
-                        )
-                        .createdAt(recruitment.getCreatedAt())
-                        .isAlwaysRecruiting(recruitment.isAlwaysRecruiting())
-                        .build()
+            .sorted(newestFirstRecruitmentComparator())
+            .map(recruitment -> RecruitmentOfClubResponse.builder()
+                .id(recruitment.getId())
+                .title(recruitment.getTitle())
+                .content(recruitment.getContent())
+                .recruitStart(recruitment.getRecruitStart())
+                .recruitEnd(recruitment.getRecruitEnd())
+                .status(
+                    RecruitStatus.from(
+                        recruitment.isAlwaysRecruiting(),
+                        recruitment.getRecruitStart(),
+                        recruitment.getRecruitEnd()
+                    )
                 )
-                .toList();
+                .createdAt(recruitment.getCreatedAt())
+                .isAlwaysRecruiting(recruitment.isAlwaysRecruiting())
+                .build()
+            )
+            .toList();
 
         return AllRecruitmentOfClubResponse.of(recruitmentList);
     }
@@ -142,38 +146,39 @@ public class RecruitmentService {
         Optional<Recruitment> recentRecruitment = recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(clubId);
 
         Recruitment recruitment = recentRecruitment.orElseGet(() ->
-                recruitmentRepository.findTopByClubIdAndIsAlwaysRecruitingOrderByCreatedAtDesc(clubId, true)
-                        .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUNT_RECRUITMENT))
+            recruitmentRepository.findTopByClubIdAndIsAlwaysRecruitingOrderByCreatedAtDesc(clubId, true)
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUNT_RECRUITMENT))
         );
 
         Club club = recruitment.getClub();
 
         List<RecruitmentImage> recruitmentImages = recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(
-                recruitment.getId());
+            recruitment.getId());
 
         List<String> imageUrls = recruitmentImages.stream()
-                .map(image -> appDataS3Client.getPublicUrl(image.getImage()))
-                .toList();
+            .map(image -> appDataS3Client.getPublicUrl(image.getImage()))
+            .toList();
 
         Boolean isFavorite = isFavorite(userId, club.getId());
 
         return RecentRecruitmentOfClubResponse.of(
-                recruitment.getId(),
-                recruitment.getTitle(),
-                club.getName(),
-                appDataS3Client.getPublicUrl(club.getLogo()),
-                club.getId(),
-                recruitment.getContent(),
-                recruitment.getRecruitStart(),
-                recruitment.getRecruitEnd(),
-                RecruitStatus.from(recruitment.isAlwaysRecruiting(), recruitment.getRecruitStart(), recruitment.getRecruitEnd()),
-                recruitment.getCreatedAt(),
-                imageUrls,
-                recruitment.getRecruitForm(),
-                isFavorite,
-                club.getInstagram(),
-                club.getClubCategory(),
-                recruitment.isAlwaysRecruiting()
+            recruitment.getId(),
+            recruitment.getTitle(),
+            club.getName(),
+            appDataS3Client.getPublicUrl(club.getLogo()),
+            club.getId(),
+            recruitment.getContent(),
+            recruitment.getRecruitStart(),
+            recruitment.getRecruitEnd(),
+            RecruitStatus.from(recruitment.isAlwaysRecruiting(), recruitment.getRecruitStart(),
+                recruitment.getRecruitEnd()),
+            recruitment.getCreatedAt(),
+            imageUrls,
+            recruitment.getRecruitForm(),
+            isFavorite,
+            club.getInstagram(),
+            club.getClubCategory(),
+            recruitment.isAlwaysRecruiting()
         );
     }
 
@@ -181,41 +186,42 @@ public class RecruitmentService {
     @Transactional
     public SpecificRecruitmentResponse getSpecificRecruitment(final Long userId, final Long recruitmentId) {
         Recruitment recruitment = recruitmentRepository.findRecruitmentById(recruitmentId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUNT_RECRUITMENT));
+            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUNT_RECRUITMENT));
 
         List<RecruitmentImage> recruitmentImages = recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(
-                recruitmentId);
+            recruitmentId);
 
         List<String> imageUrls = recruitmentImages.stream()
-                .map(image -> appDataS3Client.getPublicUrl(image.getImage()))
-                .toList();
+            .map(image -> appDataS3Client.getPublicUrl(image.getImage()))
+            .toList();
 
         Club club = recruitment.getClub();
 
         return SpecificRecruitmentResponse.of(
-                recruitment.getId(),
-                recruitment.getTitle(),
-                club.getName(),
-                appDataS3Client.getPublicUrl(club.getLogo()),
-                club.getId(),
-                recruitment.getContent(),
-                recruitment.getRecruitStart(),
-                recruitment.getRecruitEnd(),
-                RecruitStatus.from(recruitment.isAlwaysRecruiting(), recruitment.getRecruitStart(), recruitment.getRecruitEnd()),
-                recruitment.getCreatedAt(),
-                imageUrls,
-                recruitment.getRecruitForm(),
-                isFavorite(userId, club.getId()),
-                club.getInstagram(),
-                club.getClubCategory(),
-                recruitment.isAlwaysRecruiting()
+            recruitment.getId(),
+            recruitment.getTitle(),
+            club.getName(),
+            appDataS3Client.getPublicUrl(club.getLogo()),
+            club.getId(),
+            recruitment.getContent(),
+            recruitment.getRecruitStart(),
+            recruitment.getRecruitEnd(),
+            RecruitStatus.from(recruitment.isAlwaysRecruiting(), recruitment.getRecruitStart(),
+                recruitment.getRecruitEnd()),
+            recruitment.getCreatedAt(),
+            imageUrls,
+            recruitment.getRecruitForm(),
+            isFavorite(userId, club.getId()),
+            club.getInstagram(),
+            club.getClubCategory(),
+            recruitment.isAlwaysRecruiting()
         );
     }
 
     @Transactional
     public AllRecruitmentResponse getAllRecruitment(final Long userId, final ClubAffiliation affiliation,
-                                                    final ClubCategory category,
-                                                    final Pageable pageable) {
+        final ClubCategory category,
+        final Pageable pageable) {
 
         Page<Recruitment> recruitmentPage = recruitmentRepository.findRecruitments(affiliation, category, pageable);
         List<Recruitment> filteredRecruitments = recruitmentPage.getContent();
@@ -233,7 +239,7 @@ public class RecruitmentService {
         }
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
 
         if (user.getRole().equals(UserRole.NORMAL)) {
             throw new MokkojiException(FailMessage.FORBIDDEN);
@@ -241,17 +247,17 @@ public class RecruitmentService {
     }
 
     private Recruitment buildAndSaveRecruitment(Club club, String title, String content,
-                                                LocalDateTime recruitStart, LocalDateTime recruitEnd,
-                                                String recruitForm, boolean isAlwaysRecruiting) {
+        LocalDateTime recruitStart, LocalDateTime recruitEnd,
+        String recruitForm, boolean isAlwaysRecruiting) {
         Recruitment recruitment = Recruitment.builder()
-                .club(club)
-                .title(title)
-                .content(content)
-                .recruitStart(recruitStart)
-                .recruitEnd(recruitEnd)
-                .recruitForm(recruitForm)
-                .isAlwaysRecruiting(isAlwaysRecruiting)
-                .build();
+            .club(club)
+            .title(title)
+            .content(content)
+            .recruitStart(recruitStart)
+            .recruitEnd(recruitEnd)
+            .recruitForm(recruitForm)
+            .isAlwaysRecruiting(isAlwaysRecruiting)
+            .build();
 
         recruitmentRepository.save(recruitment);
         return recruitment;
@@ -272,9 +278,9 @@ public class RecruitmentService {
             presignedUrls.add(presignedPutUrl);
 
             RecruitmentImage recruitmentImage = RecruitmentImage.builder()
-                    .recruitment(recruitment)
-                    .image(imageKey)
-                    .build();
+                .recruitment(recruitment)
+                .image(imageKey)
+                .build();
             recruitmentImages.add(recruitmentImage);
         }
 
@@ -298,8 +304,8 @@ public class RecruitmentService {
         List<RecruitmentImage> oldImages = recruitmentImageRepository.findByRecruitmentId(recruitmentId);
 
         List<String> deleteImageUrls = oldImages.stream()
-                .map(image -> appDataS3Client.getPresignedDeleteUrl(image.getImage()))
-                .toList();
+            .map(image -> appDataS3Client.getPresignedDeleteUrl(image.getImage()))
+            .toList();
 
         recruitmentImageRepository.deleteAll(oldImages);
 
@@ -313,19 +319,20 @@ public class RecruitmentService {
         return favoriteRepository.existsByUserIdAndClubId(userId, clubId);
     }
 
-    private List<RecruitmentPreviewResponse> mapToRecruitmentResponses(Long userId, List<Recruitment> filteredRecruitments) {
+    private List<RecruitmentPreviewResponse> mapToRecruitmentResponses(Long userId,
+        List<Recruitment> filteredRecruitments) {
         return filteredRecruitments.stream()
-                .map(recruitment -> mapToRecruitmentPreviewResponse(userId, recruitment))
-                .sorted(recruitmentPriorityComparator(userId))
-                .toList();
+            .map(recruitment -> mapToRecruitmentPreviewResponse(userId, recruitment))
+            .sorted(recruitmentPriorityComparator(userId))
+            .toList();
     }
 
     private static PageResponse createPageResponse(Page<Recruitment> recruitmentPage) {
         return PageResponse.of(
-                recruitmentPage.getNumber() + 1,
-                recruitmentPage.getSize(),
-                recruitmentPage.getTotalPages(),
-                (int) recruitmentPage.getTotalElements()
+            recruitmentPage.getNumber() + 1,
+            recruitmentPage.getSize(),
+            recruitmentPage.getTotalPages(),
+            (int) recruitmentPage.getTotalElements()
         );
     }
 
@@ -333,38 +340,43 @@ public class RecruitmentService {
         boolean isFavorite = isFavorite(userId, recruitment.getClub().getId());
 
         ClubPreviewResponse clubPreview = new ClubPreviewResponse(
-                recruitment.getClub().getId(),
-                recruitment.getClub().getName(),
-                recruitment.getClub().getDescription(),
-                recruitment.getClub().getClubCategory(),
-                recruitment.getClub().getClubAffiliation(),
-                appDataS3Client.getPublicUrl(recruitment.getClub().getLogo())
+            recruitment.getClub().getId(),
+            recruitment.getClub().getName(),
+            recruitment.getClub().getDescription(),
+            recruitment.getClub().getClubCategory(),
+            recruitment.getClub().getClubAffiliation(),
+            appDataS3Client.getPublicUrl(recruitment.getClub().getLogo())
         );
 
         return new RecruitmentPreviewResponse(
-                clubPreview,
-                recruitment.getId(),
-                recruitment.getTitle(),
-                recruitment.getRecruitStart(),
-                recruitment.getRecruitEnd(),
-                RecruitStatus.from(recruitment.isAlwaysRecruiting(), recruitment.getRecruitStart(), recruitment.getRecruitEnd()),
-                isFavorite,
-                recruitment.isAlwaysRecruiting()
+            clubPreview,
+            recruitment.getId(),
+            recruitment.getTitle(),
+            recruitment.getRecruitStart(),
+            recruitment.getRecruitEnd(),
+            RecruitStatus.from(recruitment.isAlwaysRecruiting(), recruitment.getRecruitStart(),
+                recruitment.getRecruitEnd()),
+            isFavorite,
+            recruitment.isAlwaysRecruiting()
         );
     }
 
     // 즐겨찾기 여부 → 모집 상태 → 마감일 순으로 정렬하는 Comparator 생성
     private Comparator<RecruitmentPreviewResponse> recruitmentPriorityComparator(Long userId) {
         Comparator<RecruitmentPreviewResponse> comparator =
-                Comparator.comparing(
-                                (RecruitmentPreviewResponse response) ->
-                                        RecruitStatus.from(response.isAlwaysRecruiting(), response.recruitStart(), response.recruitEnd()).getPriority()
-                        )
-                        .thenComparing(RecruitmentPreviewResponse::recruitEnd);
+            Comparator.comparing(
+                    (RecruitmentPreviewResponse response) ->
+                        RecruitStatus.from(response.isAlwaysRecruiting(), response.recruitStart(), response.recruitEnd())
+                            .getPriority()
+                )
+                .thenComparing(
+                    RecruitmentPreviewResponse::recruitEnd,
+                    Comparator.nullsLast(LocalDateTime::compareTo)
+                );
 
         if (userId != null) {
             comparator = Comparator.comparing(RecruitmentPreviewResponse::isFavorite).reversed()
-                    .thenComparing(comparator);
+                .thenComparing(comparator);
         }
 
         return comparator;
@@ -372,6 +384,6 @@ public class RecruitmentService {
 
     private Comparator<Recruitment> newestFirstRecruitmentComparator() {
         return Comparator.comparing(Recruitment::getCreatedAt).reversed()
-                .thenComparing(Recruitment::getId, Comparator.reverseOrder());
+            .thenComparing(Recruitment::getId, Comparator.reverseOrder());
     }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #321

## **문제 상황**
현재 전체 모집글 정렬 로직은 다음 우선순위로 정렬됩니다.

> 즐겨찾기 여부  → 모집 상태  (마감 임박(IMMINENT) → 모집 중(OPEN) → 상시 모집(ALWAYS) → 모집 전(BEFORE) → 모집 마감(CLOSED))  → 모집 마감일 순

해당 정렬 로직은 아래 Comparator를 기반으로 동작하고 있습니다.
```
// 즐겨찾기 여부 → 모집 상태 → 마감일 순으로 정렬하는 Comparator 생성
    private Comparator<RecruitmentPreviewResponse> recruitmentPriorityComparator(Long userId) {
        Comparator<RecruitmentPreviewResponse> comparator =
                Comparator.comparing(
                                (RecruitmentPreviewResponse response) ->
                                        RecruitStatus.from(response.isAlwaysRecruiting(), response.recruitStart(), response.recruitEnd()).getPriority()
                        )
                        .thenComparing(RecruitmentPreviewResponse::recruitEnd);

        if (userId != null) {
            comparator = Comparator.comparing(RecruitmentPreviewResponse::isFavorite).reversed()
                    .thenComparing(comparator);
        }

        return comparator;
    }
```
모집 상태는 상시모집 여부, 모집 시작일, 모집 마감일을 기준으로 판별되며,
모집 상태가 동일한 경우 모집 마감일(`recruitEnd`) 을 기준으로 추가 정렬하도록 되어 있습니다.

그러나 최근 데이터 최신화 작업 이후,
상시모집인 동아리의 경우 `recruitEnd` 값이 `null` 인 데이터가 DB에 존재하게 되었고,
전체 모집글 정렬 과정에서 `recruitEnd == null` 인 케이스가 포함되면서
`LocalDateTime.compareTo` 호출 시 NPE가 발생하는 문제가 확인되었습니다.

## 👷 **작업한 내용**
- 전체 모집글 정렬 로직에서 상시모집 케이스로 인해 발생하던 NPE 문제를 수정했습니다.
- `Comparator.thenComparing` 단계에서 모집 마감일(`recruitEnd`) 비교 시 `Comparator.nullsLast(LocalDateTime::compareTo)` 를 적용하여 마감일이 없는 상시모집 데이터도 안전하게 정렬되도록 개선했습니다.
    - 해당 수정은 null 처리 방식만 보완한 것으로, 기존 정렬 우선순위인 즐겨찾기 여부 → 모집 상태(IMMINENT → OPEN → ALWAYS → BEFORE → CLOSED) → 마감일 순은 변경되지 않습니다.

## 🚨 **참고 사항**
- 상시모집은 도메인 특성상 마감일이 존재하지 않는 것이 정상적인 상태이므로, 값을 임의로 치환하지 않고 `Comparator` 레벨에서 null 처리 정책만 적용했습니다.
-  동일한 모집 상태 내에서만 마감일 기준 정렬이 수행되기 때문에 정렬 결과의 의미나 정책에는 영향을 주지 않습니다.
