### PR TITLE
Feat : 동아리 전체조회 api의 위치 바꾸기

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/club/controller/ClubController.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/controller/ClubController.java
@@ -9,8 +9,8 @@ import com.greedy.mokkoji.api.club.dto.response.ClubDetailResponse;
 import com.greedy.mokkoji.api.club.dto.response.ClubManageDetailResponse;
 import com.greedy.mokkoji.api.club.dto.response.ClubUpdateResponse;
 import com.greedy.mokkoji.api.club.dto.response.ClubsPaginationResponse;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.AllClubsResponse;
 import com.greedy.mokkoji.api.club.service.ClubService;
-import com.greedy.mokkoji.api.recruitment.dto.response.allRecruitment.AllRecruitmentResponse;
 import com.greedy.mokkoji.common.response.APISuccessResponse;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
@@ -59,6 +59,22 @@ public class ClubController implements ClubControllerSwagger {
                 )
         );
     }
+
+    @GetMapping
+    public ResponseEntity<APISuccessResponse<AllClubsResponse>> getAllRecruitment(
+            @Authentication final AuthCredential authCredential,
+            @RequestParam(value = "affiliation", required = false) final ClubAffiliation affiliation,
+            @RequestParam(value = "category", required = false) final ClubCategory category,
+            @RequestParam(value = "page") final int page,
+            @RequestParam(value = "size") final int size
+    ) {
+        final Pageable pageable = PageRequest.of(page - 1, size);
+        return APISuccessResponse.of(
+                HttpStatus.OK,
+                clubService.getAllClubs(authCredential.userId(), affiliation, category, pageable)
+        );
+    }
+
 
     @PostMapping
     public ResponseEntity<APISuccessResponse<Void>> createClub(

--- a/src/main/java/com/greedy/mokkoji/api/club/controller/ClubController.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/controller/ClubController.java
@@ -10,7 +10,10 @@ import com.greedy.mokkoji.api.club.dto.response.ClubManageDetailResponse;
 import com.greedy.mokkoji.api.club.dto.response.ClubUpdateResponse;
 import com.greedy.mokkoji.api.club.dto.response.ClubsPaginationResponse;
 import com.greedy.mokkoji.api.club.service.ClubService;
+import com.greedy.mokkoji.api.recruitment.dto.response.allRecruitment.AllRecruitmentResponse;
 import com.greedy.mokkoji.common.response.APISuccessResponse;
+import com.greedy.mokkoji.enums.club.ClubAffiliation;
+import com.greedy.mokkoji.enums.club.ClubCategory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -36,7 +39,7 @@ public class ClubController implements ClubControllerSwagger {
         );
     }
 
-    @GetMapping
+    @GetMapping("/search")
     public ResponseEntity<APISuccessResponse<ClubsPaginationResponse>> getClubs(
             @Authentication final AuthCredential authCredential,
             @ModelAttribute(value = "clubSearchCond") final ClubSearchCond clubSearchCond,

--- a/src/main/java/com/greedy/mokkoji/api/club/controller/ClubController.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/controller/ClubController.java
@@ -61,7 +61,7 @@ public class ClubController implements ClubControllerSwagger {
     }
 
     @GetMapping
-    public ResponseEntity<APISuccessResponse<AllClubsResponse>> getAllRecruitment(
+    public ResponseEntity<APISuccessResponse<AllClubsResponse>> getAllClubs(
             @Authentication final AuthCredential authCredential,
             @RequestParam(value = "affiliation", required = false) final ClubAffiliation affiliation,
             @RequestParam(value = "category", required = false) final ClubCategory category,

--- a/src/main/java/com/greedy/mokkoji/api/club/controller/ClubControllerSwagger.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/controller/ClubControllerSwagger.java
@@ -30,7 +30,7 @@ public interface ClubControllerSwagger {
     );
 
     @Operation(
-            summary = "동아리 목록 조회 API",
+            summary = "동아리 검색 API",
             description = "페이지 번호(`page`)는 1부터 시작",
             security = {@SecurityRequirement(name = "JWT")}
     )

--- a/src/main/java/com/greedy/mokkoji/api/club/controller/ClubControllerSwagger.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/controller/ClubControllerSwagger.java
@@ -8,7 +8,10 @@ import com.greedy.mokkoji.api.club.dto.response.ClubDetailResponse;
 import com.greedy.mokkoji.api.club.dto.response.ClubManageDetailResponse;
 import com.greedy.mokkoji.api.club.dto.response.ClubUpdateResponse;
 import com.greedy.mokkoji.api.club.dto.response.ClubsPaginationResponse;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.AllClubsResponse;
 import com.greedy.mokkoji.common.response.APISuccessResponse;
+import com.greedy.mokkoji.enums.club.ClubAffiliation;
+import com.greedy.mokkoji.enums.club.ClubCategory;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -72,4 +75,19 @@ public interface ClubControllerSwagger {
             @Parameter(hidden = true) AuthCredential authCredential,
             @Parameter(name = "clubUpdateRequest", description = "동아리 수정 요청") ClubUpdateRequest clubUpdateRequest
     );
+
+    @Operation(
+            summary = "전체 동아리 조회 API",
+            description = "동아리 리스트를 반환합니다. 페이지 번호(`page`)는 1부터 시작.",
+            security = {@SecurityRequirement(name = "JWT")}
+    )
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    ResponseEntity<APISuccessResponse<AllClubsResponse>> getAllClubs(
+            @Parameter(hidden = true) AuthCredential authCredential,
+            @Parameter(name = "affiliation") ClubAffiliation affiliation,
+            @Parameter(name = "category") ClubCategory category,
+            @Parameter(name = "page", description = "페이지 번호") int page,
+            @Parameter(name = "size", description = "페이지 크기") int size
+    );
+
 }

--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/AllClubsResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/AllClubsResponse.java
@@ -5,14 +5,13 @@ import com.greedy.mokkoji.api.pagination.dto.PageResponse;
 import java.util.List;
 
 public record AllClubsResponse(
-        List<com.greedy.mokkoji.api.club.dto.response.allClubs.ClubPreviewResponse> clubs,
+        List<ClubPreviewResponse> clubs,
         PageResponse page
 ) {
-    public static com.greedy.mokkoji.api.club.dto.response.allClubs.AllClubsResponse of(
+    public static AllClubsResponse of(
             List<ClubPreviewResponse> clubs,
             PageResponse page
     ) {
-        return new com.greedy.mokkoji.api.club.dto.response.allClubs.AllClubsResponse(clubs, page);
+        return new AllClubsResponse(clubs, page);
     }
 }
-

--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/AllClubsResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/AllClubsResponse.java
@@ -1,0 +1,18 @@
+package com.greedy.mokkoji.api.club.dto.response.allClubs;
+
+import com.greedy.mokkoji.api.pagination.dto.PageResponse;
+
+import java.util.List;
+
+public record AllClubsResponse(
+        List<com.greedy.mokkoji.api.club.dto.response.allClubs.ClubPreviewResponse> clubs,
+        PageResponse page
+) {
+    public static com.greedy.mokkoji.api.club.dto.response.allClubs.AllClubsResponse of(
+            List<ClubPreviewResponse> clubs,
+            PageResponse page
+    ) {
+        return new com.greedy.mokkoji.api.club.dto.response.allClubs.AllClubsResponse(clubs, page);
+    }
+}
+

--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/ClubPreviewResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/ClubPreviewResponse.java
@@ -9,7 +9,8 @@ public record ClubPreviewResponse(
         @Schema(example = "그리디") String name,
         @Schema(example = "세종대 최고의 코딩 동아리") String description,
         @Schema(example = "https://mokkoji-app-data.s3.ap-northeast-2.amazonaws.com/club-logo/1/greedy_{UUID}.jpg") String logo,
-        @Schema(example = "true") boolean isFavorite,
+        @Schema(example = "true") boolean favorite,
+        @Schema(implementation = RecruitmentPreviewResponse.class)
         RecruitmentPreviewResponse recruitmentPreviewResponse
 ) {
 }

--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/ClubPreviewResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/ClubPreviewResponse.java
@@ -1,0 +1,14 @@
+package com.greedy.mokkoji.api.club.dto.response.allClubs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record ClubPreviewResponse(
+        @Schema(example = "1") Long id,
+        @Schema(example = "그리디") String name,
+        @Schema(example = "세종대 최고의 코딩 동아리") String description,
+        @Schema(example = "https://mokkoji-app-data.s3.ap-northeast-2.amazonaws.com/club-logo/1/greedy_{UUID}.jpg") String logo,
+        RecruitmentPreviewResponse recruitmentPreviewResponse
+) {
+}

--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/ClubPreviewResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/ClubPreviewResponse.java
@@ -9,6 +9,7 @@ public record ClubPreviewResponse(
         @Schema(example = "그리디") String name,
         @Schema(example = "세종대 최고의 코딩 동아리") String description,
         @Schema(example = "https://mokkoji-app-data.s3.ap-northeast-2.amazonaws.com/club-logo/1/greedy_{UUID}.jpg") String logo,
+        @Schema(example = "true") boolean isFavorite,
         RecruitmentPreviewResponse recruitmentPreviewResponse
 ) {
 }

--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/ClubWithLatestRecruitment.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/ClubWithLatestRecruitment.java
@@ -1,0 +1,12 @@
+package com.greedy.mokkoji.api.club.dto.response.allClubs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ClubWithLatestRecruitment(
+        @Schema(example = "1") Long id,
+        @Schema(example = "그리디") String name,
+        @Schema(example = "세종대 최고의 코딩 동아리") String description,
+        @Schema(example = "https://mokkoji-app-data.s3.ap-northeast-2.amazonaws.com/club-logo/1/greedy_{UUID}.jpg") String logo,
+        LatestRecruitmentInfo latestRecruitmentInfo
+) {
+}

--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/LatestRecruitmentInfo.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/LatestRecruitmentInfo.java
@@ -1,0 +1,11 @@
+package com.greedy.mokkoji.api.club.dto.response.allClubs;
+
+import java.time.LocalDateTime;
+
+public record LatestRecruitmentInfo(
+        Long id,
+        LocalDateTime recruitStart,
+        LocalDateTime recruitEnd,
+        boolean isAlwaysRecruiting
+) {
+}

--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/LatestRecruitmentInfo.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/LatestRecruitmentInfo.java
@@ -1,11 +1,13 @@
 package com.greedy.mokkoji.api.club.dto.response.allClubs;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
 public record LatestRecruitmentInfo(
-        Long id,
-        LocalDateTime recruitStart,
-        LocalDateTime recruitEnd,
-        boolean isAlwaysRecruiting
+        @Schema(example = "1") Long id,
+        @Schema(example = "2025-11-25T00:00:00") LocalDateTime recruitStart,
+        @Schema(example = "2025-12-04T23:59:59") LocalDateTime recruitEnd,
+        @Schema(example = "true") boolean isAlwaysRecruiting
 ) {
 }

--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/RecruitmentPreviewResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/RecruitmentPreviewResponse.java
@@ -11,7 +11,6 @@ public record RecruitmentPreviewResponse(
         @Schema(example = "1") Long id,
         @Schema(example = "2025-11-25T00:00:00") LocalDateTime recruitStart,
         @Schema(example = "2025-12-04T23:59:59") LocalDateTime recruitEnd,
-        @Schema(example = "OPEN") RecruitStatus recruitStatus,
-        @Schema(example = "true") boolean isFavorite
+        @Schema(example = "OPEN") RecruitStatus recruitStatus
 ) {
 }

--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/RecruitmentPreviewResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/RecruitmentPreviewResponse.java
@@ -1,0 +1,17 @@
+package com.greedy.mokkoji.api.club.dto.response.allClubs;
+
+import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record RecruitmentPreviewResponse(
+        @Schema(example = "1") Long id,
+        @Schema(example = "2025-11-25T00:00:00") LocalDateTime recruitStart,
+        @Schema(example = "2025-12-04T23:59:59") LocalDateTime recruitEnd,
+        @Schema(example = "OPEN") RecruitStatus recruitStatus,
+        @Schema(example = "true") boolean isFavorite
+) {
+}

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -27,7 +27,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 @Slf4j
@@ -143,41 +142,38 @@ public class ClubService {
             final Long userId,
             final List<ClubWithLatestRecruitment> clubs
     ) {
-        Map<Boolean, List<ClubPreviewResponse>> partitioned = clubs.stream()
+        return clubs.stream()
                 .map(c -> mapToClubPreviewResponse(userId, c))
-                .collect(java.util.stream.Collectors.partitioningBy(
-                        r -> r.recruitmentPreviewResponse() != null
-                ));
-
-        List<ClubPreviewResponse> withRecruitment = partitioned.get(true).stream()
-                .sorted(clubPriorityComparator(userId))
+                .sorted(clubSortComparator(userId))
                 .toList();
-
-        List<ClubPreviewResponse> withoutRecruitment = partitioned.get(false);
-
-        List<ClubPreviewResponse> result = new java.util.ArrayList<>(withRecruitment.size() + withoutRecruitment.size());
-        result.addAll(withRecruitment);
-        result.addAll(withoutRecruitment);
-        return result;
     }
 
     // 즐겨찾기 여부 → 모집 상태 → 마감일 순으로 정렬하는 Comparator 생성
-    private Comparator<ClubPreviewResponse> clubPriorityComparator(Long userId) {
-        Comparator<ClubPreviewResponse> comparator =
+    private Comparator<ClubPreviewResponse> clubSortComparator(Long userId) {
+        Comparator<ClubPreviewResponse> recruitmentComparator =
                 Comparator.comparing(
-                                (ClubPreviewResponse club) -> club.recruitmentPreviewResponse().recruitStatus().getPriority()
+                        (ClubPreviewResponse r) -> r.recruitmentPreviewResponse(),
+                        Comparator.nullsLast(
+                                Comparator
+                                        .comparing((RecruitmentPreviewResponse rp) -> rp.recruitStatus().getPriority())
+                                        .thenComparing(RecruitmentPreviewResponse::recruitEnd)
                         )
-                        .thenComparing(
-                                club -> club.recruitmentPreviewResponse().recruitEnd()
-                        );
+                );
 
-        return (userId == null)
-                ? comparator
-                : Comparator.comparing(
-                (ClubPreviewResponse club) -> club.recruitmentPreviewResponse().isFavorite()
-        ).reversed().thenComparing(comparator);
+        Comparator<ClubPreviewResponse> base = recruitmentComparator;
+
+        if (userId != null) {
+            return Comparator.comparing(
+                            (ClubPreviewResponse r) ->
+                                    r.recruitmentPreviewResponse() != null &&
+                                            r.recruitmentPreviewResponse().isFavorite()
+                    )
+                    .reversed()
+                    .thenComparing(base);
+        }
+
+        return base;
     }
-
 
     private ClubPreviewResponse mapToClubPreviewResponse(Long userId, ClubWithLatestRecruitment c) {
         return ClubPreviewResponse.builder()

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -59,7 +59,7 @@ public class ClubService {
                                                          final RecruitStatus status,
                                                          final Pageable pageable) {
 
-        final Page<Club> clubPage = clubRepository.searchClubs(keyword, category, affiliation, status, pageable);
+        final Page<Club> clubPage = clubRepository.findClubsWithLatestRecruitment(keyword, category, affiliation, status, pageable);
         final List<Club> clubs = clubPage.getContent();
         final List<ClubResponse> clubResponses = mapToClubResponses(userId, clubs);
 
@@ -75,7 +75,7 @@ public class ClubService {
             ClubCategory category,
             Pageable pageable
     ) {
-        List<ClubWithLatestRecruitment> clubs = clubRepository.findClubs(affiliation, category);
+        List<ClubWithLatestRecruitment> clubs = clubRepository.findAllClubsWithLatestRecruitment(affiliation, category);
 
         Set<Long> favoriteClubIds = loadFavoriteClubIds(userId);
 

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -1,15 +1,7 @@
 package com.greedy.mokkoji.api.club.service;
 
-import com.greedy.mokkoji.api.club.dto.response.ClubDetailResponse;
-import com.greedy.mokkoji.api.club.dto.response.ClubManageDetailResponse;
-import com.greedy.mokkoji.api.club.dto.response.ClubResponse;
-import com.greedy.mokkoji.api.club.dto.response.ClubUpdateResponse;
-import com.greedy.mokkoji.api.club.dto.response.ClubsPaginationResponse;
-import com.greedy.mokkoji.api.club.dto.response.allClubs.AllClubsResponse;
-import com.greedy.mokkoji.api.club.dto.response.allClubs.ClubPreviewResponse;
-import com.greedy.mokkoji.api.club.dto.response.allClubs.RecruitmentPreviewResponse;
-import com.greedy.mokkoji.api.club.dto.response.allClubs.ClubWithLatestRecruitment;
-import com.greedy.mokkoji.api.club.dto.response.allClubs.LatestRecruitmentInfo;
+import com.greedy.mokkoji.api.club.dto.response.*;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.*;
 import com.greedy.mokkoji.api.external.AppDataS3Client;
 import com.greedy.mokkoji.api.pagination.dto.PageResponse;
 import com.greedy.mokkoji.common.exception.MokkojiException;
@@ -197,14 +189,18 @@ public class ClubService {
 
     // 즐겨찾기 여부 → 모집 상태 → 마감일 순으로 정렬하는 Comparator 생성
     private Comparator<ClubPreviewResponse> clubSortComparator(Long userId) {
-        Comparator<ClubPreviewResponse> recruitmentComparator =
-                Comparator.comparing(
-                        ClubPreviewResponse::recruitmentPreviewResponse,
-                        Comparator.nullsLast(
-                                Comparator.comparing((RecruitmentPreviewResponse rp) -> rp.recruitStatus().getPriority())
-                                        .thenComparing(RecruitmentPreviewResponse::recruitEnd)
-                        )
+
+        Comparator<RecruitmentPreviewResponse> recruitmentSortComparator =
+                Comparator.nullsLast(
+                        Comparator.comparing((RecruitmentPreviewResponse rp) -> rp.recruitStatus().getPriority())
+                                .thenComparing(
+                                        RecruitmentPreviewResponse::recruitEnd,
+                                        Comparator.nullsLast(Comparator.naturalOrder())
+                                )
                 );
+
+        Comparator<ClubPreviewResponse> recruitmentComparator =
+                Comparator.comparing(ClubPreviewResponse::recruitmentPreviewResponse, recruitmentSortComparator);
 
         if (userId == null) return recruitmentComparator;
 

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -1,6 +1,7 @@
 package com.greedy.mokkoji.api.club.service;
 
 import com.greedy.mokkoji.api.club.dto.response.*;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.*;
 import com.greedy.mokkoji.api.external.AppDataS3Client;
 import com.greedy.mokkoji.api.pagination.dto.PageResponse;
 import com.greedy.mokkoji.common.exception.MokkojiException;
@@ -26,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Slf4j
@@ -61,13 +63,28 @@ public class ClubService {
                                                          final Pageable pageable) {
 
         final Page<Club> clubPage = clubRepository.searchClubs(keyword, category, affiliation, status, pageable);
-
         final List<Club> clubs = clubPage.getContent();
         final List<ClubResponse> clubResponses = mapToClubResponses(userId, clubs);
 
         final PageResponse pageResponse = createPageResponse(clubPage);
 
         return new ClubsPaginationResponse(clubResponses, pageResponse);
+    }
+
+    @Transactional(readOnly = true)
+    public AllClubsResponse getAllClubs(
+            final Long userId,
+            final ClubAffiliation affiliation,
+            final ClubCategory category,
+            final Pageable pageable
+    ) {
+        Page<ClubWithLatestRecruitment> clubPage = clubRepository.findClubs(affiliation, category, pageable);
+        List<ClubWithLatestRecruitment> filteredClubs = clubPage.getContent();
+        List<ClubPreviewResponse> clubResponses = mapToClubPreviewResponses(userId, filteredClubs);
+
+        PageResponse pageResponse = createPageResponse(clubPage);
+
+        return AllClubsResponse.of(clubResponses, pageResponse);
     }
 
     @Transactional
@@ -122,37 +139,75 @@ public class ClubService {
         return ClubUpdateResponse.of(updateLogo, deleteLogo);
     }
 
-    private void changeClubMasterRole(final String previousClubMasterStudentId, final String newClubMasterStudentId) {
-        userRepository.findByStudentId(previousClubMasterStudentId)
-                .ifPresent(user -> user.updateRole(UserRole.NORMAL));
+    private List<ClubPreviewResponse> mapToClubPreviewResponses(
+            final Long userId,
+            final List<ClubWithLatestRecruitment> clubs
+    ) {
+        Map<Boolean, List<ClubPreviewResponse>> partitioned = clubs.stream()
+                .map(c -> mapToClubPreviewResponse(userId, c))
+                .collect(java.util.stream.Collectors.partitioningBy(
+                        r -> r.recruitmentPreviewResponse() != null
+                ));
 
-        userRepository.findByStudentId(newClubMasterStudentId)
-                .ifPresent(user -> user.updateRole(UserRole.CLUB_MASTER));
+        List<ClubPreviewResponse> withRecruitment = partitioned.get(true).stream()
+                .sorted(clubPriorityComparator(userId))
+                .toList();
+
+        List<ClubPreviewResponse> withoutRecruitment = partitioned.get(false);
+
+        List<ClubPreviewResponse> result = new java.util.ArrayList<>(withRecruitment.size() + withoutRecruitment.size());
+        result.addAll(withRecruitment);
+        result.addAll(withoutRecruitment);
+        return result;
     }
 
-    private boolean getIsFavorite(final Long userId, final Long clubId) {
-        if (userId == null) { //회원 및 비회원 구별 로직
-            return false;
+    // 즐겨찾기 여부 → 모집 상태 → 마감일 순으로 정렬하는 Comparator 생성
+    private Comparator<ClubPreviewResponse> clubPriorityComparator(Long userId) {
+        Comparator<ClubPreviewResponse> comparator =
+                Comparator.comparing(
+                                (ClubPreviewResponse club) -> club.recruitmentPreviewResponse().recruitStatus().getPriority()
+                        )
+                        .thenComparing(
+                                club -> club.recruitmentPreviewResponse().recruitEnd()
+                        );
+
+        return (userId == null)
+                ? comparator
+                : Comparator.comparing(
+                (ClubPreviewResponse club) -> club.recruitmentPreviewResponse().isFavorite()
+        ).reversed().thenComparing(comparator);
+    }
+
+
+    private ClubPreviewResponse mapToClubPreviewResponse(Long userId, ClubWithLatestRecruitment c) {
+        return ClubPreviewResponse.builder()
+                .id(c.id())
+                .name(c.name())
+                .description(c.description())
+                .logo(appDataS3Client.getPublicUrl(c.logo()))
+                .recruitmentPreviewResponse(mapToLatestRecruitmentPreviewResponse(userId, c.id(), c.latestRecruitmentInfo()))
+                .build();
+    }
+
+    @Nullable
+    private RecruitmentPreviewResponse mapToLatestRecruitmentPreviewResponse(
+            Long userId,
+            Long clubId,
+            LatestRecruitmentInfo latest
+    ) {
+        if (latest == null || latest.id() == null) {
+            return null;
         }
-        return favoriteRepository.existsByUserIdAndClubId(userId, clubId);
+
+        return RecruitmentPreviewResponse.builder()
+                .id(latest.id())
+                .recruitStart(latest.recruitStart())
+                .recruitEnd(latest.recruitEnd())
+                .recruitStatus(RecruitStatus.from(latest.isAlwaysRecruiting(), latest.recruitStart(), latest.recruitEnd()))
+                .isFavorite(getIsFavorite(userId, clubId))
+                .build();
     }
 
-    private ClubDetailResponse mapToClubDetailResponse(final Club club, final Recruitment recruitment,
-                                                       final Boolean isFavorite) {
-        return ClubDetailResponse.of(
-                club.getId(),
-                club.getName(),
-                club.getClubCategory(),
-                club.getClubAffiliation(),
-                club.getDescription(),
-                recruitment != null ? recruitment.getRecruitStart() : null,
-                recruitment != null ? recruitment.getRecruitEnd() : null,
-                appDataS3Client.getPublicUrl(club.getLogo()),
-                isFavorite,
-                club.getInstagram(),
-                recruitment != null ? recruitment.getContent() : null
-        );
-    }
 
     private List<ClubResponse> mapToClubResponses(final Long userId, final List<Club> clubs) {
         return clubs.stream()
@@ -174,12 +229,20 @@ public class ClubService {
                 .toList();
     }
 
-    private PageResponse createPageResponse(final Page<Club> clubPage) {
-        return PageResponse.of(
-                clubPage.getNumber() + 1,
-                clubPage.getSize(),
-                clubPage.getTotalPages(),
-                (int) clubPage.getTotalElements()
+    private ClubDetailResponse mapToClubDetailResponse(final Club club, final Recruitment recruitment,
+                                                       final Boolean isFavorite) {
+        return ClubDetailResponse.of(
+                club.getId(),
+                club.getName(),
+                club.getClubCategory(),
+                club.getClubAffiliation(),
+                club.getDescription(),
+                recruitment != null ? recruitment.getRecruitStart() : null,
+                recruitment != null ? recruitment.getRecruitEnd() : null,
+                appDataS3Client.getPublicUrl(club.getLogo()),
+                isFavorite,
+                club.getInstagram(),
+                recruitment != null ? recruitment.getContent() : null
         );
     }
 
@@ -188,17 +251,6 @@ public class ClubService {
         if (!adminUser.getRole().canRegisterClub()) {
             throw new MokkojiException(FailMessage.FORBIDDEN_REGISTER_CLUB);
         }
-    }
-
-    private String getValidClubMasterStudentId(final String clubMasterStudentId) {
-        if (clubMasterStudentId == null || clubMasterStudentId.isBlank()) {
-            return null;
-        }
-
-        User masterUser = userRepository.findByStudentId(clubMasterStudentId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
-        masterUser.updateRole(UserRole.CLUB_MASTER);
-        return masterUser.getStudentId();
     }
 
     private Club validateClubManagerAuthority(final Long userId, final Long clubId) { //권한 부여: CLUB_MASTER, CLUB_ADMIN
@@ -212,6 +264,30 @@ public class ClubService {
         return club;
     }
 
+    private String getValidClubMasterStudentId(final String clubMasterStudentId) {
+        if (clubMasterStudentId == null || clubMasterStudentId.isBlank()) {
+            return null;
+        }
+
+        User masterUser = userRepository.findByStudentId(clubMasterStudentId)
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+        masterUser.updateRole(UserRole.CLUB_MASTER);
+        return masterUser.getStudentId();
+    }
+
+    private void changeClubMasterRole(final String previousClubMasterStudentId, final String newClubMasterStudentId) {
+        userRepository.findByStudentId(previousClubMasterStudentId)
+                .ifPresent(user -> user.updateRole(UserRole.NORMAL));
+
+        userRepository.findByStudentId(newClubMasterStudentId)
+                .ifPresent(user -> user.updateRole(UserRole.CLUB_MASTER));
+    }
+
+    private Club findClubOrThrow(Long clubId) {
+        return clubRepository.findById(clubId)
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB));
+    }
+
     private User findUserOrThrow(Long userId) {
         if (userId == null) {
             throw new MokkojiException(FailMessage.UNAUTHORIZED);
@@ -220,9 +296,24 @@ public class ClubService {
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
     }
 
-    private Club findClubOrThrow(Long clubId) {
-        return clubRepository.findById(clubId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB));
+    private boolean getIsFavorite(final Long userId, final Long clubId) {
+        if (userId == null) { //회원 및 비회원 구별 로직
+            return false;
+        }
+        return favoriteRepository.existsByUserIdAndClubId(userId, clubId);
+    }
+
+    private Comparator<ClubResponse> getFavoriteComparator() {
+        return Comparator.comparing(ClubResponse::isFavorite).reversed();
+    }
+
+    private static PageResponse createPageResponse(final Page<?> page) {
+        return PageResponse.of(
+                page.getNumber() + 1,
+                page.getSize(),
+                page.getTotalPages(),
+                (int) page.getTotalElements()
+        );
     }
 
     @Nullable
@@ -253,9 +344,5 @@ public class ClubService {
         return (newLogoKey != null && oldLogoKey != null && !oldLogoKey.equals(newLogoKey))
                 ? appDataS3Client.getPresignedDeleteUrl(oldLogoKey)
                 : null;
-    }
-
-    private Comparator<ClubResponse> getFavoriteComparator() {
-        return Comparator.comparing(ClubResponse::isFavorite).reversed();
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -1,7 +1,15 @@
 package com.greedy.mokkoji.api.club.service;
 
-import com.greedy.mokkoji.api.club.dto.response.*;
-import com.greedy.mokkoji.api.club.dto.response.allClubs.*;
+import com.greedy.mokkoji.api.club.dto.response.ClubDetailResponse;
+import com.greedy.mokkoji.api.club.dto.response.ClubManageDetailResponse;
+import com.greedy.mokkoji.api.club.dto.response.ClubResponse;
+import com.greedy.mokkoji.api.club.dto.response.ClubUpdateResponse;
+import com.greedy.mokkoji.api.club.dto.response.ClubsPaginationResponse;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.AllClubsResponse;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.ClubPreviewResponse;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.RecruitmentPreviewResponse;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.ClubWithLatestRecruitment;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.LatestRecruitmentInfo;
 import com.greedy.mokkoji.api.external.AppDataS3Client;
 import com.greedy.mokkoji.api.pagination.dto.PageResponse;
 import com.greedy.mokkoji.common.exception.MokkojiException;
@@ -25,9 +33,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Comparator;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 @Slf4j
 @Service
@@ -65,25 +71,30 @@ public class ClubService {
         final List<Club> clubs = clubPage.getContent();
         final List<ClubResponse> clubResponses = mapToClubResponses(userId, clubs);
 
-        final PageResponse pageResponse = createPageResponse(clubPage);
+        final PageResponse pageResponse = createPageResponses(clubPage);
 
         return new ClubsPaginationResponse(clubResponses, pageResponse);
     }
 
     @Transactional(readOnly = true)
     public AllClubsResponse getAllClubs(
-            final Long userId,
-            final ClubAffiliation affiliation,
-            final ClubCategory category,
-            final Pageable pageable
+            Long userId,
+            ClubAffiliation affiliation,
+            ClubCategory category,
+            Pageable pageable
     ) {
-        Page<ClubWithLatestRecruitment> clubPage = clubRepository.findClubs(affiliation, category, pageable);
-        List<ClubWithLatestRecruitment> filteredClubs = clubPage.getContent();
-        List<ClubPreviewResponse> clubResponses = mapToClubPreviewResponses(userId, filteredClubs);
+        List<ClubWithLatestRecruitment> clubs = clubRepository.findClubs(affiliation, category);
 
-        PageResponse pageResponse = createPageResponse(clubPage);
+        Set<Long> favoriteClubIds = loadFavoriteClubIds(userId);
 
-        return AllClubsResponse.of(clubResponses, pageResponse);
+        List<ClubPreviewResponse> sortedResponses =
+                toSortedClubPreviewResponses(clubs, favoriteClubIds, userId);
+
+        List<ClubPreviewResponse> pageContent = slicePage(sortedResponses, pageable);
+
+        PageResponse pageResponse = createPageResponse(pageable, sortedResponses.size());
+
+        return AllClubsResponse.of(pageContent, pageResponse);
     }
 
     @Transactional
@@ -138,16 +149,52 @@ public class ClubService {
         return ClubUpdateResponse.of(updateLogo, deleteLogo);
     }
 
-    private List<ClubPreviewResponse> mapToClubPreviewResponses(
-            final Long userId,
-            final List<ClubWithLatestRecruitment> clubs
+    private Set<Long> loadFavoriteClubIds(Long userId) {
+        if (userId == null) return Set.of();
+        return new HashSet<>(favoriteRepository.findClubIdsByUserId(userId));
+    }
+
+    private List<ClubPreviewResponse> toSortedClubPreviewResponses(
+            List<ClubWithLatestRecruitment> clubs,
+            Set<Long> favoriteClubIds,
+            Long userId
     ) {
         return clubs.stream()
-                .map(c -> mapToClubPreviewResponse(userId, c))
+                .map(c -> mapToClubPreviewResponse(c, favoriteClubIds))
                 .sorted(clubSortComparator(userId))
                 .toList();
     }
-    
+
+    private ClubPreviewResponse mapToClubPreviewResponse(
+            ClubWithLatestRecruitment c,
+            Set<Long> favoriteClubIds
+    ) {
+        boolean isFavorite = favoriteClubIds.contains(c.id());
+
+        return ClubPreviewResponse.builder()
+                .id(c.id())
+                .name(c.name())
+                .description(c.description())
+                .logo(appDataS3Client.getPublicUrl(c.logo()))
+                .favorite(isFavorite)
+                .recruitmentPreviewResponse(
+                        mapToLatestRecruitmentPreviewResponse(c.latestRecruitmentInfo())
+                )
+                .build();
+    }
+
+    private List<ClubPreviewResponse> slicePage(
+            List<ClubPreviewResponse> sortedResponses,
+            Pageable pageable
+    ) {
+        int total = sortedResponses.size();
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), total);
+
+        if (start >= total) return List.of();
+        return sortedResponses.subList(start, end);
+    }
+
     // 즐겨찾기 여부 → 모집 상태 → 마감일 순으로 정렬하는 Comparator 생성
     private Comparator<ClubPreviewResponse> clubSortComparator(Long userId) {
         Comparator<ClubPreviewResponse> recruitmentComparator =
@@ -159,30 +206,25 @@ public class ClubService {
                         )
                 );
 
-        if (userId == null) {
-            return recruitmentComparator;
-        }
+        if (userId == null) return recruitmentComparator;
 
-        return Comparator.comparing(ClubPreviewResponse::isFavorite)
+        return Comparator.comparing(ClubPreviewResponse::favorite)
                 .reversed()
                 .thenComparing(recruitmentComparator);
     }
 
-
-    private ClubPreviewResponse mapToClubPreviewResponse(Long userId, ClubWithLatestRecruitment c) {
-        return ClubPreviewResponse.builder()
-                .id(c.id())
-                .name(c.name())
-                .description(c.description())
-                .logo(appDataS3Client.getPublicUrl(c.logo()))
-                .recruitmentPreviewResponse(mapToLatestRecruitmentPreviewResponse(userId, c.id(), c.latestRecruitmentInfo()))
-                .build();
+    private static PageResponse createPageResponse(Pageable pageable, int totalElements) {
+        int totalPages = (int) Math.ceil((double) totalElements / pageable.getPageSize());
+        return PageResponse.of(
+                pageable.getPageNumber() + 1,
+                pageable.getPageSize(),
+                totalPages,
+                totalElements
+        );
     }
 
     @Nullable
     private RecruitmentPreviewResponse mapToLatestRecruitmentPreviewResponse(
-            Long userId,
-            Long clubId,
             LatestRecruitmentInfo latest
     ) {
         if (latest == null || latest.id() == null) {
@@ -196,7 +238,6 @@ public class ClubService {
                 .recruitStatus(RecruitStatus.from(latest.isAlwaysRecruiting(), latest.recruitStart(), latest.recruitEnd()))
                 .build();
     }
-
 
     private List<ClubResponse> mapToClubResponses(final Long userId, final List<Club> clubs) {
         return clubs.stream()
@@ -296,7 +337,7 @@ public class ClubService {
         return Comparator.comparing(ClubResponse::isFavorite).reversed();
     }
 
-    private static PageResponse createPageResponse(final Page<?> page) {
+    private static PageResponse createPageResponses(final Page<?> page) {
         return PageResponse.of(
                 page.getNumber() + 1,
                 page.getSize(),

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -147,33 +147,27 @@ public class ClubService {
                 .sorted(clubSortComparator(userId))
                 .toList();
     }
-
+    
     // 즐겨찾기 여부 → 모집 상태 → 마감일 순으로 정렬하는 Comparator 생성
     private Comparator<ClubPreviewResponse> clubSortComparator(Long userId) {
         Comparator<ClubPreviewResponse> recruitmentComparator =
                 Comparator.comparing(
-                        (ClubPreviewResponse r) -> r.recruitmentPreviewResponse(),
+                        ClubPreviewResponse::recruitmentPreviewResponse,
                         Comparator.nullsLast(
-                                Comparator
-                                        .comparing((RecruitmentPreviewResponse rp) -> rp.recruitStatus().getPriority())
+                                Comparator.comparing((RecruitmentPreviewResponse rp) -> rp.recruitStatus().getPriority())
                                         .thenComparing(RecruitmentPreviewResponse::recruitEnd)
                         )
                 );
 
-        Comparator<ClubPreviewResponse> base = recruitmentComparator;
-
-        if (userId != null) {
-            return Comparator.comparing(
-                            (ClubPreviewResponse r) ->
-                                    r.recruitmentPreviewResponse() != null &&
-                                            r.recruitmentPreviewResponse().isFavorite()
-                    )
-                    .reversed()
-                    .thenComparing(base);
+        if (userId == null) {
+            return recruitmentComparator;
         }
 
-        return base;
+        return Comparator.comparing(ClubPreviewResponse::isFavorite)
+                .reversed()
+                .thenComparing(recruitmentComparator);
     }
+
 
     private ClubPreviewResponse mapToClubPreviewResponse(Long userId, ClubWithLatestRecruitment c) {
         return ClubPreviewResponse.builder()
@@ -200,7 +194,6 @@ public class ClubService {
                 .recruitStart(latest.recruitStart())
                 .recruitEnd(latest.recruitEnd())
                 .recruitStatus(RecruitStatus.from(latest.isAlwaysRecruiting(), latest.recruitStart(), latest.recruitEnd()))
-                .isFavorite(getIsFavorite(userId, clubId))
                 .build();
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -60,7 +60,7 @@ public class ClubService {
                                                          final RecruitStatus status,
                                                          final Pageable pageable) {
 
-        final Page<Club> clubPage = clubRepository.findClubs(keyword, category, affiliation, status, pageable);
+        final Page<Club> clubPage = clubRepository.searchClubs(keyword, category, affiliation, status, pageable);
 
         final List<Club> clubs = clubPage.getContent();
         final List<ClubResponse> clubResponses = mapToClubResponses(userId, clubs);

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/allRecruitment/ClubPreviewResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/allRecruitment/ClubPreviewResponse.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
+@Schema(name = "Recruitment_ClubPreviewResponse")
 public record ClubPreviewResponse(
         @Schema(example = "1") Long id,
         @Schema(example = "그리디") String name,

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/allRecruitment/RecruitmentPreviewResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/dto/response/allRecruitment/RecruitmentPreviewResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import java.time.LocalDateTime;
 
 @Builder
+@Schema(name = "Recruitment_RecruitmentPreviewResponse")
 public record RecruitmentPreviewResponse(
         ClubPreviewResponse club,
         @Schema(example = "1") Long id,

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -121,11 +121,11 @@ public class RecruitmentService {
                         .recruitStart(recruitment.getRecruitStart())
                         .recruitEnd(recruitment.getRecruitEnd())
                         .status(
-                            RecruitStatus.from(
-                                recruitment.isAlwaysRecruiting(),
-                                recruitment.getRecruitStart(),
-                                recruitment.getRecruitEnd()
-                            )
+                                RecruitStatus.from(
+                                        recruitment.isAlwaysRecruiting(),
+                                        recruitment.getRecruitStart(),
+                                        recruitment.getRecruitEnd()
+                                )
                         )
                         .createdAt(recruitment.getCreatedAt())
                         .isAlwaysRecruiting(recruitment.isAlwaysRecruiting())
@@ -315,17 +315,17 @@ public class RecruitmentService {
 
     private List<RecruitmentPreviewResponse> mapToRecruitmentResponses(Long userId, List<Recruitment> filteredRecruitments) {
         return filteredRecruitments.stream()
-            .map(recruitment -> mapToRecruitmentPreviewResponse(userId, recruitment))
-            .sorted(recruitmentPriorityComparator(userId))
-            .toList();
+                .map(recruitment -> mapToRecruitmentPreviewResponse(userId, recruitment))
+                .sorted(recruitmentPriorityComparator(userId))
+                .toList();
     }
 
     private static PageResponse createPageResponse(Page<Recruitment> recruitmentPage) {
         return PageResponse.of(
-            recruitmentPage.getNumber() + 1,
-            recruitmentPage.getSize(),
-            recruitmentPage.getTotalPages(),
-            (int) recruitmentPage.getTotalElements()
+                recruitmentPage.getNumber() + 1,
+                recruitmentPage.getSize(),
+                recruitmentPage.getTotalPages(),
+                (int) recruitmentPage.getTotalElements()
         );
     }
 
@@ -356,22 +356,23 @@ public class RecruitmentService {
     // 즐겨찾기 여부 → 모집 상태 → 마감일 순으로 정렬하는 Comparator 생성
     private Comparator<RecruitmentPreviewResponse> recruitmentPriorityComparator(Long userId) {
         Comparator<RecruitmentPreviewResponse> comparator =
-            Comparator.comparing(
-                    (RecruitmentPreviewResponse response) ->
-                        RecruitStatus.from(response.isAlwaysRecruiting(), response.recruitStart(), response.recruitEnd()).getPriority()
-                )
-                .thenComparing(RecruitmentPreviewResponse::recruitEnd);
+                Comparator.comparing(
+                                (RecruitmentPreviewResponse response) ->
+                                        RecruitStatus.from(response.isAlwaysRecruiting(), response.recruitStart(), response.recruitEnd()).getPriority()
+                        )
+                        .thenComparing(RecruitmentPreviewResponse::recruitEnd);
 
         if (userId != null) {
             comparator = Comparator.comparing(RecruitmentPreviewResponse::isFavorite).reversed()
-                .thenComparing(comparator);
+                    .thenComparing(comparator);
         }
 
         return comparator;
     }
 
+
     private Comparator<Recruitment> newestFirstRecruitmentComparator() {
         return Comparator.comparing(Recruitment::getCreatedAt).reversed()
-            .thenComparing(Recruitment::getId, Comparator.reverseOrder());
+                .thenComparing(Recruitment::getId, Comparator.reverseOrder());
     }
 }

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryCustom.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryCustom.java
@@ -11,7 +11,7 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface ClubRepositoryCustom {
-    Page<Club> searchClubs(
+    Page<Club> findClubsWithLatestRecruitment(
             final String keyword,
             final ClubCategory category,
             final ClubAffiliation affiliation,
@@ -19,7 +19,7 @@ public interface ClubRepositoryCustom {
             final Pageable pageable
     );
 
-    List<ClubWithLatestRecruitment> findClubs(
+    List<ClubWithLatestRecruitment> findAllClubsWithLatestRecruitment(
             ClubAffiliation affiliation,
             ClubCategory category
     );

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryCustom.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.greedy.mokkoji.db.club.repository;
 
 import com.greedy.mokkoji.db.club.entity.Club;
+import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
@@ -8,7 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface ClubRepositoryCustom {
-    Page<Club> findClubs(
+    Page<Club> searchClubs(
             final String keyword,
             final ClubCategory category,
             final ClubAffiliation affiliation,

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryCustom.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.greedy.mokkoji.db.club.repository;
 
+import com.greedy.mokkoji.api.club.dto.response.allClubs.ClubWithLatestRecruitment;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
@@ -13,6 +14,12 @@ public interface ClubRepositoryCustom {
             final ClubCategory category,
             final ClubAffiliation affiliation,
             final RecruitStatus status,
+            final Pageable pageable
+    );
+
+    Page<ClubWithLatestRecruitment> findClubs(
+            final ClubAffiliation affiliation,
+            final ClubCategory category,
             final Pageable pageable
     );
 }

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryCustom.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryCustom.java
@@ -8,6 +8,8 @@ import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface ClubRepositoryCustom {
     Page<Club> searchClubs(
             final String keyword,
@@ -17,9 +19,8 @@ public interface ClubRepositoryCustom {
             final Pageable pageable
     );
 
-    Page<ClubWithLatestRecruitment> findClubs(
-            final ClubAffiliation affiliation,
-            final ClubCategory category,
-            final Pageable pageable
+    List<ClubWithLatestRecruitment> findClubs(
+            ClubAffiliation affiliation,
+            ClubCategory category
     );
 }

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryCustom.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryCustom.java
@@ -1,7 +1,6 @@
 package com.greedy.mokkoji.db.club.repository;
 
 import com.greedy.mokkoji.db.club.entity.Club;
-import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.recruitment.RecruitStatus;

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
@@ -1,10 +1,16 @@
 package com.greedy.mokkoji.db.club.repository;
 
+import com.greedy.mokkoji.api.club.dto.response.allClubs.ClubWithLatestRecruitment;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.LatestRecruitmentInfo;
 import com.greedy.mokkoji.db.club.entity.Club;
+import com.greedy.mokkoji.db.recruitment.entity.QRecruitment;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.*;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -66,6 +72,60 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
                         )
                         .fetchOne()
         ).orElse(0L);
+
+        return new PageImpl<>(clubs, pageable, total);
+    }
+
+    @Override
+    public Page<ClubWithLatestRecruitment> findClubs(ClubAffiliation affiliation, ClubCategory category, Pageable pageable) {
+
+        QRecruitment subRecruitment = new QRecruitment("subRecruitment");
+
+        List<ClubWithLatestRecruitment> clubs = queryFactory
+                .select(
+                        Projections.constructor(
+                                ClubWithLatestRecruitment.class,
+                                club.id,
+                                club.name,
+                                club.description,
+                                club.logo,
+                                Projections.constructor(
+                                        LatestRecruitmentInfo.class,
+                                        recruitment.id,
+                                        recruitment.recruitStart,
+                                        recruitment.recruitEnd,
+                                        recruitment.isAlwaysRecruiting
+                                )
+                        )
+                )
+                .from(club)
+                .leftJoin(recruitment).on(
+                        recruitment.club.eq(club),
+                        recruitment.createdAt.eq(
+                                JPAExpressions
+                                        .select(subRecruitment.createdAt.max())
+                                        .from(subRecruitment)
+                                        .where(subRecruitment.club.eq(club))
+                        )
+                )
+                .where(
+                        equalAffiliation(affiliation),
+                        equalCategory(category)
+                )
+                .orderBy(recruitment.createdAt.desc().nullsLast())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(club.count())
+                .from(club)
+                .where(
+                        equalAffiliation(affiliation),
+                        equalCategory(category)
+                );
+
+        long total = Optional.ofNullable(countQuery.fetchOne()).orElse(0L);
 
         return new PageImpl<>(clubs, pageable, total);
     }

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
@@ -33,11 +33,11 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Club> searchClubs(final String keyword,
-                                  final ClubCategory category,
-                                  final ClubAffiliation affiliation,
-                                  final RecruitStatus status,
-                                  final Pageable pageable) {
+    public Page<Club> findClubsWithLatestRecruitment(final String keyword,
+                                                     final ClubCategory category,
+                                                     final ClubAffiliation affiliation,
+                                                     final RecruitStatus status,
+                                                     final Pageable pageable) {
 
         final LocalDateTime now = LocalDateTime.now();
 
@@ -76,7 +76,7 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
     }
 
     @Override
-    public List<ClubWithLatestRecruitment> findClubs(ClubAffiliation affiliation, ClubCategory category) {
+    public List<ClubWithLatestRecruitment> findAllClubsWithLatestRecruitment(ClubAffiliation affiliation, ClubCategory category) {
         QRecruitment subRecruitment = new QRecruitment("subRecruitment");
 
         return queryFactory

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
@@ -28,11 +28,11 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Club> findClubs(final String keyword,
-                                final ClubCategory category,
-                                final ClubAffiliation affiliation,
-                                final RecruitStatus status,
-                                final Pageable pageable) {
+    public Page<Club> searchClubs(final String keyword,
+                                  final ClubCategory category,
+                                  final ClubAffiliation affiliation,
+                                  final RecruitStatus status,
+                                  final Pageable pageable) {
 
         final LocalDateTime now = LocalDateTime.now();
 

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
@@ -10,7 +10,6 @@ import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.JPAExpressions;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -77,11 +76,10 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
     }
 
     @Override
-    public Page<ClubWithLatestRecruitment> findClubs(ClubAffiliation affiliation, ClubCategory category, Pageable pageable) {
-
+    public List<ClubWithLatestRecruitment> findClubs(ClubAffiliation affiliation, ClubCategory category) {
         QRecruitment subRecruitment = new QRecruitment("subRecruitment");
 
-        List<ClubWithLatestRecruitment> clubs = queryFactory
+        return queryFactory
                 .select(
                         Projections.constructor(
                                 ClubWithLatestRecruitment.class,
@@ -112,21 +110,7 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
                         equalAffiliation(affiliation),
                         equalCategory(category)
                 )
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
                 .fetch();
-
-        JPAQuery<Long> countQuery = queryFactory
-                .select(club.count())
-                .from(club)
-                .where(
-                        equalAffiliation(affiliation),
-                        equalCategory(category)
-                );
-
-        long total = Optional.ofNullable(countQuery.fetchOne()).orElse(0L);
-
-        return new PageImpl<>(clubs, pageable, total);
     }
 
     private BooleanExpression likeClubName(final String keyword) {

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
@@ -112,7 +112,6 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
                         equalAffiliation(affiliation),
                         equalCategory(category)
                 )
-                .orderBy(recruitment.createdAt.desc().nullsLast())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/com/greedy/mokkoji/db/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/favorite/repository/FavoriteRepository.java
@@ -28,5 +28,4 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
     @Query("SELECT f.club.id FROM Favorite f WHERE f.user.id = :userId")
     List<Long> findClubIdsByUserId(@Param("userId") Long userId);
-
 }

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentImageRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentImageRepository.java
@@ -11,6 +11,4 @@ public interface RecruitmentImageRepository extends JpaRepository<RecruitmentIma
     List<RecruitmentImage> findByRecruitmentIdOrderByCreatedAtAsc(Long recruitmentId);
 
     List<RecruitmentImage> findByRecruitmentId(Long recruitmentId);
-
-    List<RecruitmentImage> findAllByImageIn(List<String> imageKeys);
 }

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentImageRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentImageRepository.java
@@ -11,4 +11,6 @@ public interface RecruitmentImageRepository extends JpaRepository<RecruitmentIma
     List<RecruitmentImage> findByRecruitmentIdOrderByCreatedAtAsc(Long recruitmentId);
 
     List<RecruitmentImage> findByRecruitmentId(Long recruitmentId);
+
+    List<RecruitmentImage> findAllByImageIn(List<String> imageKeys);
 }

--- a/src/test/java/com/greedy/mokkoji/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/club/controller/ClubControllerTest.java
@@ -2,11 +2,7 @@ package com.greedy.mokkoji.club.controller;
 
 import com.greedy.mokkoji.api.club.dto.request.ClubCreateRequest;
 import com.greedy.mokkoji.api.club.dto.request.ClubUpdateRequest;
-import com.greedy.mokkoji.api.club.dto.response.ClubDetailResponse;
-import com.greedy.mokkoji.api.club.dto.response.ClubManageDetailResponse;
-import com.greedy.mokkoji.api.club.dto.response.ClubResponse;
-import com.greedy.mokkoji.api.club.dto.response.ClubUpdateResponse;
-import com.greedy.mokkoji.api.club.dto.response.ClubsPaginationResponse;
+import com.greedy.mokkoji.api.club.dto.response.*;
 import com.greedy.mokkoji.api.pagination.dto.PageResponse;
 import com.greedy.mokkoji.common.ControllerTest;
 import com.greedy.mokkoji.common.fixture.Fixture;
@@ -81,8 +77,8 @@ public class ClubControllerTest extends ControllerTest {
         final ClubDetailResponse expected = ClubDetailResponse.of(
                 club.getId(),
                 club.getName(),
-                club.getClubCategory().getDescription(),
-                club.getClubAffiliation().getDescription(),
+                club.getClubCategory(),
+                club.getClubAffiliation(),
                 club.getDescription(),
                 recruitment.getRecruitStart(),
                 recruitment.getRecruitEnd(),
@@ -105,8 +101,8 @@ public class ClubControllerTest extends ControllerTest {
         final List<ClubResponse> clubResponses = List.of(ClubResponse.of(
                 club.getId(),
                 club.getName(),
-                club.getClubCategory().getDescription(),
-                club.getClubAffiliation().getDescription(),
+                club.getClubCategory(),
+                club.getClubAffiliation(),
                 club.getDescription(),
                 recruitment.getRecruitStart(),
                 recruitment.getRecruitEnd(),
@@ -223,8 +219,8 @@ public class ClubControllerTest extends ControllerTest {
         final ClubManageDetailResponse actual = getDataFromResponse(response, ClubManageDetailResponse.class);
         final ClubManageDetailResponse expected = ClubManageDetailResponse.of(
                 managedClub.getName(),
-                managedClub.getClubCategory().name(),
-                managedClub.getClubAffiliation().name(),
+                managedClub.getClubCategory(),
+                managedClub.getClubAffiliation(),
                 managedClub.getDescription(),
                 managedClub.getLogo(),
                 managedClub.getInstagram()

--- a/src/test/java/com/greedy/mokkoji/club/service/ClubServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/club/service/ClubServiceTest.java
@@ -116,7 +116,7 @@ class ClubServiceTest {
         final List<Club> clubs = List.of(club1, club2);
         final Page<Club> clubPage = new PageImpl<>(clubs, pageable, clubs.size());
 
-        BDDMockito.given(clubRepository.findClubs(any(), any(), any(), any(), any())).willReturn(clubPage);
+        BDDMockito.given(clubRepository.searchClubs(any(), any(), any(), any(), any())).willReturn(clubPage);
         BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(clubId1)).willReturn(Optional.ofNullable(recruitment1));
         BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(clubId2)).willReturn(Optional.ofNullable(recruitment2));
         BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, clubId1)).willReturn(true);
@@ -131,8 +131,8 @@ class ClubServiceTest {
         assertThat(response.clubs()).hasSize(2);
 
         assertThat(response.clubs().get(0).name()).isEqualTo("testClub1");
-        assertThat(response.clubs().get(0).category()).isEqualTo("학술/교양");
-        assertThat(response.clubs().get(0).affiliation()).isEqualTo("중앙");
+        assertThat(response.clubs().get(0).category()).isEqualTo(ClubCategory.ACADEMIC_CULTURAL);
+        assertThat(response.clubs().get(0).affiliation()).isEqualTo(ClubAffiliation.CENTRAL_CLUB);
         assertThat(response.clubs().get(0).description()).isEqualTo("testDescription1");
         assertThat(response.clubs().get(0).recruitStartDate()).isEqualTo("2025-01-01");
         assertThat(response.clubs().get(0).recruitEndDate()).isEqualTo("2025-03-30");
@@ -140,8 +140,8 @@ class ClubServiceTest {
         assertThat(response.clubs().get(0).isFavorite()).isEqualTo(true);
 
         assertThat(response.clubs().get(1).name()).isEqualTo("testClub2");
-        assertThat(response.clubs().get(1).category()).isEqualTo("문화/예술");
-        assertThat(response.clubs().get(1).affiliation()).isEqualTo("정인준/가인준");
+        assertThat(response.clubs().get(1).category()).isEqualTo(ClubCategory.CULTURAL_ART);
+        assertThat(response.clubs().get(1).affiliation()).isEqualTo(ClubAffiliation.DEPARTMENT_CLUB);
         assertThat(response.clubs().get(1).description()).isEqualTo("testDescription2");
         assertThat(response.clubs().get(1).recruitStartDate()).isEqualTo("2025-01-01");
         assertThat(response.clubs().get(1).recruitEndDate()).isEqualTo("2025-01-30");
@@ -150,7 +150,7 @@ class ClubServiceTest {
 
         assertThat(response.pagination().totalElements()).isEqualTo(2);
 
-        BDDMockito.verify(clubRepository, times(1)).findClubs(any(), any(), any(), any(), any(Pageable.class));
+        BDDMockito.verify(clubRepository, times(1)).searchClubs(any(), any(), any(), any(), any(Pageable.class));
         BDDMockito.verify(recruitmentRepository, times(2)).findTopByClubIdOrderByCreatedAtDesc(anyLong());
         BDDMockito.verify(favoriteRepository, times(2)).existsByUserIdAndClubId(anyLong(), anyLong());
     }
@@ -173,8 +173,8 @@ class ClubServiceTest {
         //then
         assertThat(response).isNotNull();
         assertThat(response.name()).isEqualTo("testClub1");
-        assertThat(response.category()).isEqualTo("학술/교양");
-        assertThat(response.affiliation()).isEqualTo("중앙");
+        assertThat(response.category()).isEqualTo(ClubCategory.ACADEMIC_CULTURAL);
+        assertThat(response.affiliation()).isEqualTo(ClubAffiliation.CENTRAL_CLUB);
         assertThat(response.description()).isEqualTo("testDescription1");
         assertThat(response.recruitStartDate()).isEqualTo("2025-01-01");
         assertThat(response.recruitEndDate()).isEqualTo("2025-03-30");
@@ -230,7 +230,7 @@ class ClubServiceTest {
         //then
         assertThat(response).isNotNull();
         assertThat(response.name()).isEqualTo("testClub3");
-        assertThat(response.category()).isEqualTo("체육");
+        assertThat(response.category()).isEqualTo(ClubCategory.SPORTS);
         assertThat(response.recruitStartDate()).isNull();
         assertThat(response.recruitEndDate()).isNull();
         assertThat(response.recruitPost()).isNull();
@@ -374,8 +374,8 @@ class ClubServiceTest {
         //then
         assertThat(response).isNotNull();
         assertThat(response.name()).isEqualTo("testClub1");
-        assertThat(response.category()).isEqualTo(ClubCategory.ACADEMIC_CULTURAL.name());
-        assertThat(response.affiliation()).isEqualTo(ClubAffiliation.CENTRAL_CLUB.name());
+        assertThat(response.category()).isEqualTo(ClubCategory.ACADEMIC_CULTURAL);
+        assertThat(response.affiliation()).isEqualTo(ClubAffiliation.CENTRAL_CLUB);
         assertThat(response.description()).isEqualTo("testDescription1");
         assertThat(response.logo()).isEqualTo("testLogo1");
         assertThat(response.instagram()).isEqualTo("testInstagramURL1");
@@ -519,7 +519,7 @@ class ClubServiceTest {
         final List<Club> clubs = List.of(club1, club2);
         final Page<Club> clubPage = new PageImpl<>(clubs, pageable, clubs.size());
 
-        BDDMockito.given(clubRepository.findClubs(any(), any(), any(), any(), any())).willReturn(clubPage);
+        BDDMockito.given(clubRepository.searchClubs(any(), any(), any(), any(), any())).willReturn(clubPage);
         BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(clubId1)).willReturn(Optional.ofNullable(recruitment1));
         BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(clubId2)).willReturn(Optional.ofNullable(recruitment2));
         BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, clubId1)).willReturn(false);


### PR DESCRIPTION
# 🔥 Pull Request

## ⛳️ 작업 브랜치  
close #312

---

## 👷 작업 내용

### 1) 동아리 전체 조회 API를 recruitment → club 도메인으로 이동
- 기존 전체 조회 API가 recruitment 패키지에 존재해 구조적으로 부자연스러웠습니다.  
- club 기준의 조회가 더 자연스러워, 새로운 전체 조회 API를 **club 패키지**로 이동하여 구현했습니다.  
- 기존 API는 일단 유지하며, 신규 API 정상 동작 확인 후 삭제할 예정입니다.

---

### 2) 정렬 기준 개선
정렬 우선순위를 아래와 같이 통일했습니다:

1. **즐겨찾기 여부(favorite)** — true 우선  
2. **모집 상태(priority)** — 마감임박, 모집 중, 상시모집, 모집 마감 순
3. **모집 마감일(recruitEnd)** 임박 순  
---

### 3) Swagger 예시값 정상 노출되도록 수정
- club/recruitment 양쪽에 동일한 DTO명(`ClubPreviewResponse`)이 존재해 Swagger 모델 충돌이 발생했습니다.  
- club 패키지 DTO에 Swagger 스키마 네임을 명시적으로 지정하여  
  **club 안에 recruitmentPreviewResponse가 포함된 형태로 예시가 올바르게 노출되도록** 수정했습니다.  
- import 조정만으로는 해결되지 않아, Swagger 스키마 이름을 분리하는 방식으로 충돌을 해결했습니다.

---

### 3) 도메인 `/clubs`로 통합
- 기존 검색 API가 `/clubs` 도메인을 사용하고 있어 신규 전체 조회 API와 충돌이 발생했습니다.  
- 전체 조회 API를 `/clubs`로 통일하고, 기존 검색 API 도메인은 `search/clubs`로 변경했습니다.

---

## 🚨 참고 사항

### 1) 테스트 코드는 추후 작성 예정입니다.  
현재는 API 이동 및 오류 해결이 우선이라 안정성 검증 후 테스트 추가할 예정입니다.

### 2) 기존 전체조회 API는 일단 유지합니다.  
신규 API가 프론트와 정상 연동되면 기존 recruitment 전체조회 API는 삭제할 예정입니다.

### 3) 코드 자동정렬은 이번 PR에 포함하지 않았습니다.
전체 자동정렬을 적용하면 변경 파일이 약 25개 정도로 너무 많아져서,  
이번 PR에서는 기능 중심 변경만 포함했습니다.  
추후 별도 브랜치를 파서 코드 스타일 자동정렬 작업을 진행할 예정입니다.