### PR TITLE
Fix : Club test 코드 enum 전달값 오류 수정

### DIFF
--- a/src/test/java/com/greedy/mokkoji/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/club/controller/ClubControllerTest.java
@@ -2,11 +2,7 @@ package com.greedy.mokkoji.club.controller;
 
 import com.greedy.mokkoji.api.club.dto.request.ClubCreateRequest;
 import com.greedy.mokkoji.api.club.dto.request.ClubUpdateRequest;
-import com.greedy.mokkoji.api.club.dto.response.ClubDetailResponse;
-import com.greedy.mokkoji.api.club.dto.response.ClubManageDetailResponse;
-import com.greedy.mokkoji.api.club.dto.response.ClubResponse;
-import com.greedy.mokkoji.api.club.dto.response.ClubUpdateResponse;
-import com.greedy.mokkoji.api.club.dto.response.ClubsPaginationResponse;
+import com.greedy.mokkoji.api.club.dto.response.*;
 import com.greedy.mokkoji.api.pagination.dto.PageResponse;
 import com.greedy.mokkoji.common.ControllerTest;
 import com.greedy.mokkoji.common.fixture.Fixture;
@@ -81,8 +77,8 @@ public class ClubControllerTest extends ControllerTest {
         final ClubDetailResponse expected = ClubDetailResponse.of(
                 club.getId(),
                 club.getName(),
-                club.getClubCategory().getDescription(),
-                club.getClubAffiliation().getDescription(),
+                club.getClubCategory(),
+                club.getClubAffiliation(),
                 club.getDescription(),
                 recruitment.getRecruitStart(),
                 recruitment.getRecruitEnd(),
@@ -105,8 +101,8 @@ public class ClubControllerTest extends ControllerTest {
         final List<ClubResponse> clubResponses = List.of(ClubResponse.of(
                 club.getId(),
                 club.getName(),
-                club.getClubCategory().getDescription(),
-                club.getClubAffiliation().getDescription(),
+                club.getClubCategory(),
+                club.getClubAffiliation(),
                 club.getDescription(),
                 recruitment.getRecruitStart(),
                 recruitment.getRecruitEnd(),
@@ -223,8 +219,8 @@ public class ClubControllerTest extends ControllerTest {
         final ClubManageDetailResponse actual = getDataFromResponse(response, ClubManageDetailResponse.class);
         final ClubManageDetailResponse expected = ClubManageDetailResponse.of(
                 managedClub.getName(),
-                managedClub.getClubCategory().name(),
-                managedClub.getClubAffiliation().name(),
+                managedClub.getClubCategory(),
+                managedClub.getClubAffiliation(),
                 managedClub.getDescription(),
                 managedClub.getLogo(),
                 managedClub.getInstagram()

--- a/src/test/java/com/greedy/mokkoji/club/service/ClubServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/club/service/ClubServiceTest.java
@@ -131,8 +131,8 @@ class ClubServiceTest {
         assertThat(response.clubs()).hasSize(2);
 
         assertThat(response.clubs().get(0).name()).isEqualTo("testClub1");
-        assertThat(response.clubs().get(0).category()).isEqualTo("학술/교양");
-        assertThat(response.clubs().get(0).affiliation()).isEqualTo("중앙");
+        assertThat(response.clubs().get(0).category()).isEqualTo(ClubCategory.ACADEMIC_CULTURAL);
+        assertThat(response.clubs().get(0).affiliation()).isEqualTo(ClubAffiliation.CENTRAL_CLUB);
         assertThat(response.clubs().get(0).description()).isEqualTo("testDescription1");
         assertThat(response.clubs().get(0).recruitStartDate()).isEqualTo("2025-01-01");
         assertThat(response.clubs().get(0).recruitEndDate()).isEqualTo("2025-03-30");
@@ -140,8 +140,8 @@ class ClubServiceTest {
         assertThat(response.clubs().get(0).isFavorite()).isEqualTo(true);
 
         assertThat(response.clubs().get(1).name()).isEqualTo("testClub2");
-        assertThat(response.clubs().get(1).category()).isEqualTo("문화/예술");
-        assertThat(response.clubs().get(1).affiliation()).isEqualTo("정인준/가인준");
+        assertThat(response.clubs().get(1).category()).isEqualTo(ClubCategory.CULTURAL_ART);
+        assertThat(response.clubs().get(1).affiliation()).isEqualTo(ClubAffiliation.DEPARTMENT_CLUB);
         assertThat(response.clubs().get(1).description()).isEqualTo("testDescription2");
         assertThat(response.clubs().get(1).recruitStartDate()).isEqualTo("2025-01-01");
         assertThat(response.clubs().get(1).recruitEndDate()).isEqualTo("2025-01-30");
@@ -173,8 +173,8 @@ class ClubServiceTest {
         //then
         assertThat(response).isNotNull();
         assertThat(response.name()).isEqualTo("testClub1");
-        assertThat(response.category()).isEqualTo("학술/교양");
-        assertThat(response.affiliation()).isEqualTo("중앙");
+        assertThat(response.category()).isEqualTo(ClubCategory.ACADEMIC_CULTURAL);
+        assertThat(response.affiliation()).isEqualTo(ClubAffiliation.CENTRAL_CLUB);
         assertThat(response.description()).isEqualTo("testDescription1");
         assertThat(response.recruitStartDate()).isEqualTo("2025-01-01");
         assertThat(response.recruitEndDate()).isEqualTo("2025-03-30");
@@ -230,7 +230,7 @@ class ClubServiceTest {
         //then
         assertThat(response).isNotNull();
         assertThat(response.name()).isEqualTo("testClub3");
-        assertThat(response.category()).isEqualTo("체육");
+        assertThat(response.category()).isEqualTo(ClubCategory.SPORTS);
         assertThat(response.recruitStartDate()).isNull();
         assertThat(response.recruitEndDate()).isNull();
         assertThat(response.recruitPost()).isNull();
@@ -374,8 +374,8 @@ class ClubServiceTest {
         //then
         assertThat(response).isNotNull();
         assertThat(response.name()).isEqualTo("testClub1");
-        assertThat(response.category()).isEqualTo(ClubCategory.ACADEMIC_CULTURAL.name());
-        assertThat(response.affiliation()).isEqualTo(ClubAffiliation.CENTRAL_CLUB.name());
+        assertThat(response.category()).isEqualTo(ClubCategory.ACADEMIC_CULTURAL);
+        assertThat(response.affiliation()).isEqualTo(ClubAffiliation.CENTRAL_CLUB);
         assertThat(response.description()).isEqualTo("testDescription1");
         assertThat(response.logo()).isEqualTo("testLogo1");
         assertThat(response.instagram()).isEqualTo("testInstagramURL1");


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #324

## 👷 **작업한 내용**
Club 카테고리와 소속 관련 enum을 영문 기반으로 주고받도록 변경하면서,
기존 테스트 코드가 이를 반영하지 않아 일부 테스트가 실패했습니다.

이에 따라 변경된 enum 형태에 맞게 테스트 코드를 수정했습니다.

## 🚨 **참고 사항**
앞으로 enum이나 DTO 스펙 변경 시,
테스트 코드도 함께 확인해주시면 더 안정적으로 반영될 것 같아요!