### PR TITLE
Refactor: 예외 원인 추적을 위한 로깅 정책 개선

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/external/sejong/SejongLoginClient.java
+++ b/src/main/java/com/greedy/mokkoji/api/external/sejong/SejongLoginClient.java
@@ -3,6 +3,7 @@ package com.greedy.mokkoji.api.external.sejong;
 import com.greedy.mokkoji.api.user.dto.resopnse.StudentInformationResponse;
 import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.enums.message.FailMessage;
+import lombok.extern.slf4j.Slf4j;
 import okhttp3.*;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -18,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Component
 public class SejongLoginClient {
 
@@ -92,6 +94,7 @@ public class SejongLoginClient {
         }
 
         if (name == null || department == null || grade == null) {
+            log.error("[세종인증] 학생정보 파싱 실패(로그인 실패 가능) - 필드 누락(이름={}, 학과={}, 학년={})", name, department, grade);
             throw new MokkojiException(FailMessage.INTERNAL_SERVER_ERROR_SEJONG_AUTH);
         }
 
@@ -123,7 +126,7 @@ public class SejongLoginClient {
             authenticate(client, id, password);
             return fetchStudentInformation(client);
         } catch (Exception e) {
-            throw new MokkojiException(FailMessage.INTERNAL_SERVER_ERROR_SEJONG_AUTH);
+            throw new MokkojiException(FailMessage.INTERNAL_SERVER_ERROR_SEJONG_AUTH, e);
         }
     }
 
@@ -161,11 +164,12 @@ public class SejongLoginClient {
         try {
             Response response = client.newCall(request).execute();
             if (response.body() == null) {
+                log.error("[세종인증] 실패: 응답 본문 누락 url={}, code={}", request.url(), response.code());
                 throw new MokkojiException(FailMessage.INTERNAL_SERVER_ERROR_SEJONG_AUTH);
             }
             return response;
         } catch (IOException e) {
-            throw new MokkojiException(FailMessage.INTERNAL_SERVER_ERROR_SEJONG_AUTH);
+            throw new MokkojiException(FailMessage.INTERNAL_SERVER_ERROR_SEJONG_AUTH, e);
         }
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/external/sejong/SejongLoginRestClient.java
+++ b/src/main/java/com/greedy/mokkoji/api/external/sejong/SejongLoginRestClient.java
@@ -93,7 +93,7 @@ public class SejongLoginRestClient {
 
             return StudentInformationResponse.of(name, major, grade);
         } catch (Exception e) {
-            throw new MokkojiException(FailMessage.INTERNAL_SERVER_ERROR_SEJONG_AUTH);
+            throw new MokkojiException(FailMessage.INTERNAL_SERVER_ERROR_SEJONG_AUTH, e);
         }
     }
 }

--- a/src/main/java/com/greedy/mokkoji/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/greedy/mokkoji/common/exception/GlobalExceptionHandler.java
@@ -36,7 +36,7 @@ public class GlobalExceptionHandler {
         final int failCode = failMessage.getCode();
         final String failMessageMessage = failMessage.getMessage();
 
-        errorLog(failCode, failMessageMessage);
+        errorLog(failCode, failMessageMessage, exception.getCause());
 
         return APIErrorResponse.of(failMessage.getHttpStatus(), failCode, failMessageMessage);
     }
@@ -172,13 +172,19 @@ public class GlobalExceptionHandler {
         final FailMessage failMessage = FailMessage.INTERNAL_SERVER_ERROR;
         final int failCode = failMessage.getCode();
         final String failMessageMessage = exception.getMessage();
-        errorLog(failCode, failMessageMessage);
+        errorLog(failCode, failMessageMessage, exception);
         return APIErrorResponse.of(failMessage.getHttpStatus(), failCode, failMessageMessage);
     }
 
     private void errorLog(final int failCode, final String failMessage) {
         log.error("[{}] URI: {}, 실패 코드: {}, 실패 메세지: {}",
                 commonLogInformation.getRequestIdentifier(), commonLogInformation.getUri(), failCode, failMessage
+        );
+    }
+
+    private void errorLog(final int failCode, final String failMessage, final Throwable cause) {
+        log.error("[{}] URI: {}, 실패 코드: {}, 실패 메세지: {}",
+            commonLogInformation.getRequestIdentifier(), commonLogInformation.getUri(), failCode, failMessage, cause
         );
     }
 }

--- a/src/main/java/com/greedy/mokkoji/common/exception/MokkojiException.java
+++ b/src/main/java/com/greedy/mokkoji/common/exception/MokkojiException.java
@@ -12,4 +12,9 @@ public class MokkojiException extends RuntimeException {
         super(failMessage.getMessage());
         this.failMessage = failMessage;
     }
+
+    public MokkojiException(final FailMessage failMessage, final Throwable cause) {
+        super(failMessage.getMessage(), cause);
+        this.failMessage = failMessage;
+    }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #331 

## 👷 **작업 배경**
개발 환경에서 세종 로그인 요청이 `INTERNAL_SERVER_ERROR_SEJONG_AUTH`로만 내려와 실제 실패 원인을 확인하기 어려운 문제가 있었습니다. 원인 예외가 로그에 남지 않아 외부 인증 실패 시점과 원인을 빠르게 파악할 수 있도록 로깅/예외 정책을 개선했습니다.

## 👷 **작업한 내용**
- 세종 포털 로그인 연동(`SejongLoginRestClient`, `SejongLoginClient`)에서 예외 발생 시 원인을 함께 전달하도록 수정해, 운영/개발 환경 이슈를 추적할 수 있도록 개선했습니다.
- 학생정보 파싱 과정에서 필드 누락 시 원인 파악을 위한 에러 로그를 추가했습니다.
- 응답 본문이 비어있는 경우 로그를 남긴 후 예외를 던지도록 했습니다.

## 🚨 **참고 사항**
`GlobalExceptionHandler`에서 `MokkojiException`은 `exception.getCause()`를 로깅합니다.
→ 서비스에서 래핑된 예외의 실제 원인을 우선적으로 확인하기 위함입니다.

반면 `Exception`(일반 예외)은 exception 자체를 로깅합니다.
→ 예상치 못한 서버 오류는 발생 지점까지 포함해 확인하는 편이 대응에 유리하다고 판단했습니다.
