### PR TITLE
Fix: 전체 동아리 조회 시 중복 조회 수정 

### DIFF
--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
@@ -78,6 +78,7 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
     @Override
     public List<ClubWithLatestRecruitment> findAllClubsWithLatestRecruitment(ClubAffiliation affiliation, ClubCategory category) {
         QRecruitment subRecruitment = new QRecruitment("subRecruitment");
+        QRecruitment subRecruitment2 = new QRecruitment("subRecruitment2");
 
         return queryFactory
                 .select(
@@ -99,11 +100,19 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
                 .from(club)
                 .leftJoin(recruitment).on(
                         recruitment.club.eq(club),
-                        recruitment.createdAt.eq(
+                        recruitment.id.eq(
                                 JPAExpressions
-                                        .select(subRecruitment.createdAt.max())
+                                        .select(subRecruitment.id.max())
                                         .from(subRecruitment)
-                                        .where(subRecruitment.club.eq(club))
+                                        .where(
+                                                subRecruitment.club.eq(club),
+                                                subRecruitment.createdAt.eq(
+                                                        JPAExpressions
+                                                                .select(subRecruitment2.createdAt.max())
+                                                                .from(subRecruitment2)
+                                                                .where(subRecruitment2.club.eq(club))
+                                                )
+                                        )
                         )
                 )
                 .where(

--- a/src/test/java/com/greedy/mokkoji/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/club/controller/ClubControllerTest.java
@@ -2,7 +2,12 @@ package com.greedy.mokkoji.club.controller;
 
 import com.greedy.mokkoji.api.club.dto.request.ClubCreateRequest;
 import com.greedy.mokkoji.api.club.dto.request.ClubUpdateRequest;
-import com.greedy.mokkoji.api.club.dto.response.*;
+import com.greedy.mokkoji.api.club.dto.response.ClubDetailResponse;
+import com.greedy.mokkoji.api.club.dto.response.ClubManageDetailResponse;
+import com.greedy.mokkoji.api.club.dto.response.ClubUpdateResponse;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.AllClubsResponse;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.ClubPreviewResponse;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.RecruitmentPreviewResponse;
 import com.greedy.mokkoji.api.pagination.dto.PageResponse;
 import com.greedy.mokkoji.common.ControllerTest;
 import com.greedy.mokkoji.common.fixture.Fixture;
@@ -14,6 +19,7 @@ import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.message.FailMessage;
+import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import com.greedy.mokkoji.enums.user.UserRole;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -98,17 +104,27 @@ public class ClubControllerTest extends ControllerTest {
         //given
         String authorizationForBearer = authorizationForBearerAccessToken(user);
 
-        final List<ClubResponse> clubResponses = List.of(ClubResponse.of(
-                club.getId(),
-                club.getName(),
-                club.getClubCategory(),
-                club.getClubAffiliation(),
-                club.getDescription(),
-                recruitment.getRecruitStart(),
-                recruitment.getRecruitEnd(),
-                club.getLogo(),
-                true
-        ));
+        final RecruitmentPreviewResponse recruitmentPreviewResponse =
+                RecruitmentPreviewResponse.builder()
+                        .id(recruitment.getId())
+                        .recruitStart(recruitment.getRecruitStart())
+                        .recruitEnd(recruitment.getRecruitEnd())
+                        .recruitStatus(RecruitStatus.from(
+                                recruitment.isAlwaysRecruiting(),
+                                recruitment.getRecruitStart(),
+                                recruitment.getRecruitEnd()
+                        ))
+                        .build();
+
+        final List<ClubPreviewResponse> clubResponses =
+                List.of(ClubPreviewResponse.builder()
+                        .id(club.getId())
+                        .name(club.getName())
+                        .description(club.getDescription())
+                        .logo(club.getLogo())
+                        .favorite(true)
+                        .recruitmentPreviewResponse(recruitmentPreviewResponse)
+                        .build());
 
         final int pageNumber = 1;
         final int pageSize = 10;
@@ -132,8 +148,8 @@ public class ClubControllerTest extends ControllerTest {
 
         //when
         final int statusCode = response.statusCode();
-        final ClubsPaginationResponse actual = getDataFromResponse(response, ClubsPaginationResponse.class);
-        final ClubsPaginationResponse expected = ClubsPaginationResponse.of(clubResponses, pageResponse);
+        final AllClubsResponse actual = getDataFromResponse(response, AllClubsResponse.class);
+        final AllClubsResponse expected = AllClubsResponse.of(clubResponses, pageResponse);
 
         assertThat(statusCode).isEqualTo(HttpStatus.OK.value());
         assertThat(expected).usingRecursiveComparison().isEqualTo(actual);


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #335 

## 👷 **작업한 내용**

## 문제상황
 - 동아리 전체 조회 시 같은 동아리가 중복으로 조회되는 문제가 발생했습니다.

## 원인
```java
.from(club)
.leftJoin(recruitment).on(
    recruitment.club.eq(club),
    recruitment.createdAt.eq(
        JPAExpressions
            .select(subRecruitment.createdAt.max())
            .from(subRecruitment)
            .where(subRecruitment.club.eq(club))
    )
```
- `ClubRepositoryImpl.findAllClubsWithLatestRecruitment` 메서드에서 최신 모집글을 조인할 때 `createdAt` 기준으로만 비교하고 있었습니다.
- 동일한 `createdAt` 값을 가진 모집글이 여러 개 존재하는 경우 `MAX(createdAt)` 조건을 모두 만족하여 중복 조인이 발생했습니다.
- DB 데이터 확인 결과 동일한 `createdAt` 값을 가진 모집글이 존재하는 동아리만 중복 조회되는 것을 확인했습니다.

## 해결방법
 - 중첩 서브쿼리를 사용하여 `MAX(createdAt)` 조건을 만족하는 모집글들 중 `MAX(id)` 를 가지는 모집글 하나만 조인하도록 처리했습니다.

## 추가수정사항
  - 테스트 코드의 DTO를 실제 API 응답 구조에 맞게 수정했습니다.
  `ClubsPaginationResponse` → `AllClubsResponse`

## 🚨 **참고 사항**

