### PR TITLE
Fix: Java 21.0.9로 다운그레이드하여 SSL handshake 오류 해결

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,4 +1,4 @@
-FROM amazoncorretto:21
+FROM amazoncorretto:21.0.9
 WORKDIR /app
 COPY build/libs/mokkoji-0.0.1-SNAPSHOT.jar /app/mokkoji.jar
 CMD ["java", "-Duser.timezone=Asia/Seoul", "-Dspring.profiles.active=dev", "-jar", "/app/mokkoji.jar"]

--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -1,4 +1,4 @@
-FROM amazoncorretto:21
+FROM amazoncorretto:21.0.9
 WORKDIR /app
 COPY build/libs/mokkoji-0.0.1-SNAPSHOT.jar /app/mokkoji.jar
 CMD ["java", "-Duser.timezone=Asia/Seoul", "-Dspring.profiles.active=prod", "-jar", "/app/mokkoji.jar"]


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #341 

## 👷 **작업한 내용**
## 문제 상황
개발(dev) 서버에서 로그인 시 **SSL 핸드쉐이크가 끊기는 문제**가 발생했습니다.

## 원인
- 개발 서버(dev): **Java 21.0.10**  
- 운영 서버(prod): **Java 21.0.9**  
- Java 21.0.10이 **2026년 1월 20일** 출시되면서 TLS/SSL 관련 보안 정책과 기본값이 강화되었습니다.
- Postman 테스트 결과:
  - **21.0.9**: 정상 작동  
  - **21.0.10**: SSL 핸드쉐이크 실패 로그 발생  
- IntelliJ 서버 로그에서도 동일한 오류(`javax.net.ssl.SSLHandshakeException`)를 확인했습니다.

![SSL Handshake Error](https://github.com/user-attachments/assets/c291c0b8-fb60-4288-9a92-1427e9d48abe)

## 해결 방법
개발 서버와 운영 서버의 **Java 버전을 동일하게 맞춤**으로써 문제 해결했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
