### PR TITLE
Fix: 상시모집(모집일정 null) 조회 시 발생하던 NPE 문제 수정

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
+++ b/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
@@ -107,6 +107,10 @@ public class FavoriteService {
 
         final List<Recruitment> recruitments = recruitmentRepository.findLatestRecruitmentsByFavoriteClubs(favoriteClubIds);
 
+        if (recruitments == null || recruitments.isEmpty()) {
+            return null;
+        }
+
         return recruitments.stream()
                 .filter(recruitment -> isSameMonth(recruitment, yearMonth))
                 .map(recruitment -> RecruitClubsResponse.of(
@@ -119,6 +123,8 @@ public class FavoriteService {
     }
 
     private boolean isSameMonth(Recruitment recruitment, YearMonth yearMonth) {
+        if (recruitment.getRecruitStart() == null || recruitment.getRecruitEnd() == null) return false;
+
         YearMonth startMonth = YearMonth.from(recruitment.getRecruitStart());
         if (startMonth.equals(yearMonth)) return true;
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #343

## 👷 **작업한 내용**
<img width="400" alt="Image" src="https://github.com/user-attachments/assets/c6bb14e9-7506-4e87-b83f-b2dbd35cb958" />

현재 모집 일정은 동아리의 마지막 모집글의 모집 시작일/마감일이 조회하려는 
월(YearMonth)에 포함되는지 기준으로 필터링하고 있습니다.

그런데 상시모집의 경우 모집 시작일(recruitStart)과 모집 마감일(recruitEnd)이 null이여서 
`NullPointerException`이 발생했습니다.

이에 따라,
* 모집글이 null인 경우
* 모집 시작일/마감일이 null인 경우
를 null-safe 하게 처리하도록 로직을 보완할 예정입니다.


## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
