### PR TITLE
Refactor: GET /favorites 응답에 isAlwaysRecruiting 필드 추가

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubResponse.java
@@ -17,6 +17,7 @@ public record ClubResponse(
         @Schema(example = "세종대 최고의 코딩 동아리") String description,
         @Schema(example = "2025-11-25") String recruitStartDate,
         @Schema(example = "2025-12-04") String recruitEndDate,
+        @Schema(example = "false") Boolean isAlwaysRecruiting,
         @Schema(example = "https://mokkoji-app-data.s3.ap-northeast-2.amazonaws.com/club-logo/1/greedy_{UUID}.jpg") String logo,
         @Schema(example = "true") Boolean isFavorite
 ) {
@@ -28,6 +29,7 @@ public record ClubResponse(
             final String description,
             final LocalDateTime recruitStartDate,
             final LocalDateTime recruitEndDate,
+            final Boolean isAlwaysRecruiting,
             final String logo,
             final Boolean isFavorite) {
 
@@ -39,6 +41,7 @@ public record ClubResponse(
                 .description(description)
                 .recruitStartDate(recruitStartDate != null ? recruitStartDate.format(DateTimeFormatter.ISO_LOCAL_DATE) : null)
                 .recruitEndDate(recruitEndDate != null ? recruitEndDate.format(DateTimeFormatter.ISO_LOCAL_DATE) : null)
+                .isAlwaysRecruiting(isAlwaysRecruiting)
                 .logo(logo)
                 .isFavorite(isFavorite)
                 .build();

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -257,6 +257,7 @@ public class ClubService {
                             club.getDescription(),
                             recruitment != null ? recruitment.getRecruitStart() : null,
                             recruitment != null ? recruitment.getRecruitEnd() : null,
+                            recruitment != null ? recruitment.isAlwaysRecruiting() : null,
                             appDataS3Client.getPublicUrl(club.getLogo()),
                             isFavorite);
                 })

--- a/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
+++ b/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
@@ -72,6 +72,7 @@ public class FavoriteService {
                             club.getDescription(),
                             recruitment != null ? recruitment.getRecruitStart() : null,
                             recruitment != null ? recruitment.getRecruitEnd() : null,
+                            recruitment != null ? recruitment.isAlwaysRecruiting() : null,
                             appDataS3Client.getPublicUrl(club.getLogo()),
                             true
                     );


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #345 

## 👷 **작업한 내용**
- GET /favorites 반환값으로 상시모집(isAlwaysRecruiting) 필드를 추가했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
