### PR TITLE
Refactor: GET /favorites 응답에 RecruitStatus 필드 추가

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubResponse.java
@@ -2,6 +2,7 @@ package com.greedy.mokkoji.api.club.dto.response;
 
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
+import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -18,6 +19,7 @@ public record ClubResponse(
         @Schema(example = "2025-11-25") String recruitStartDate,
         @Schema(example = "2025-12-04") String recruitEndDate,
         @Schema(example = "false") Boolean isAlwaysRecruiting,
+        @Schema(example = "OPEN") RecruitStatus recruitStatus,
         @Schema(example = "https://mokkoji-app-data.s3.ap-northeast-2.amazonaws.com/club-logo/1/greedy_{UUID}.jpg") String logo,
         @Schema(example = "true") Boolean isFavorite
 ) {
@@ -30,6 +32,7 @@ public record ClubResponse(
             final LocalDateTime recruitStartDate,
             final LocalDateTime recruitEndDate,
             final Boolean isAlwaysRecruiting,
+            final RecruitStatus recruitStatus,
             final String logo,
             final Boolean isFavorite) {
 
@@ -42,6 +45,7 @@ public record ClubResponse(
                 .recruitStartDate(recruitStartDate != null ? recruitStartDate.format(DateTimeFormatter.ISO_LOCAL_DATE) : null)
                 .recruitEndDate(recruitEndDate != null ? recruitEndDate.format(DateTimeFormatter.ISO_LOCAL_DATE) : null)
                 .isAlwaysRecruiting(isAlwaysRecruiting)
+                .recruitStatus(recruitStatus)
                 .logo(logo)
                 .isFavorite(isFavorite)
                 .build();

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -1,7 +1,15 @@
 package com.greedy.mokkoji.api.club.service;
 
-import com.greedy.mokkoji.api.club.dto.response.*;
-import com.greedy.mokkoji.api.club.dto.response.allClubs.*;
+import com.greedy.mokkoji.api.club.dto.response.ClubDetailResponse;
+import com.greedy.mokkoji.api.club.dto.response.ClubManageDetailResponse;
+import com.greedy.mokkoji.api.club.dto.response.ClubResponse;
+import com.greedy.mokkoji.api.club.dto.response.ClubUpdateResponse;
+import com.greedy.mokkoji.api.club.dto.response.ClubsPaginationResponse;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.AllClubsResponse;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.ClubPreviewResponse;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.ClubWithLatestRecruitment;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.LatestRecruitmentInfo;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.RecruitmentPreviewResponse;
 import com.greedy.mokkoji.api.external.AppDataS3Client;
 import com.greedy.mokkoji.api.pagination.dto.PageResponse;
 import com.greedy.mokkoji.common.exception.MokkojiException;
@@ -25,7 +33,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -258,6 +270,7 @@ public class ClubService {
                             recruitment != null ? recruitment.getRecruitStart() : null,
                             recruitment != null ? recruitment.getRecruitEnd() : null,
                             recruitment != null ? recruitment.isAlwaysRecruiting() : null,
+                            calculateRecruitStatus(recruitment),
                             appDataS3Client.getPublicUrl(club.getLogo()),
                             isFavorite);
                 })
@@ -371,5 +384,14 @@ public class ClubService {
         return (newLogoKey != null && oldLogoKey != null && !oldLogoKey.equals(newLogoKey))
                 ? appDataS3Client.getPresignedDeleteUrl(oldLogoKey)
                 : null;
+    }
+
+    private RecruitStatus calculateRecruitStatus(final Recruitment recruitment) {
+        if (recruitment == null) return null;
+        return RecruitStatus.from(
+                recruitment.isAlwaysRecruiting(),
+                recruitment.getRecruitStart(),
+                recruitment.getRecruitEnd()
+        );
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
+++ b/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
@@ -15,6 +15,7 @@ import com.greedy.mokkoji.db.recruitment.repository.RecruitmentRepository;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.db.user.repository.UserRepository;
 import com.greedy.mokkoji.enums.message.FailMessage;
+import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -73,6 +74,7 @@ public class FavoriteService {
                             recruitment != null ? recruitment.getRecruitStart() : null,
                             recruitment != null ? recruitment.getRecruitEnd() : null,
                             recruitment != null ? recruitment.isAlwaysRecruiting() : null,
+                            calculateRecruitStatus(recruitment),
                             appDataS3Client.getPublicUrl(club.getLogo()),
                             true
                     );
@@ -153,6 +155,15 @@ public class FavoriteService {
                 clubPage.getSize(),
                 clubPage.getTotalPages(),
                 (int) clubPage.getTotalElements()
+        );
+    }
+
+    private RecruitStatus calculateRecruitStatus(final Recruitment recruitment) {
+        if (recruitment == null) return null;
+        return RecruitStatus.from(
+                recruitment.isAlwaysRecruiting(),
+                recruitment.getRecruitStart(),
+                recruitment.getRecruitEnd()
         );
     }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #347 

## 👷 **작업한 내용**
- GET /favorites 응답에 RecruitStatus 필드 추가했습니다.
- `calculateRecruitStatus()` 메서드를 구현해서 모집상태를 구했습니다.
-  나중에 여러곳에서 동일한 로직이 필요하게 되면 `RecruitmentUtils` 같은 헬퍼 클래스로 분리하여 재사용성을 높이는 것도 좋아보입니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
