### PR TITLE
Fix : 클럽 리스트 반환 시 isAlwaysRecruiting 필드 추가하기

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/RecruitmentPreviewResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/RecruitmentPreviewResponse.java
@@ -11,6 +11,7 @@ public record RecruitmentPreviewResponse(
         @Schema(example = "1") Long id,
         @Schema(example = "2025-11-25T00:00:00") LocalDateTime recruitStart,
         @Schema(example = "2025-12-04T23:59:59") LocalDateTime recruitEnd,
-        @Schema(example = "OPEN") RecruitStatus recruitStatus
+        @Schema(example = "OPEN") RecruitStatus recruitStatus,
+        @Schema(example = "true") boolean isAlwaysRecruiting
 ) {
 }

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -253,6 +253,7 @@ public class ClubService {
                 .recruitStart(latest.recruitStart())
                 .recruitEnd(latest.recruitEnd())
                 .recruitStatus(RecruitStatus.from(latest.isAlwaysRecruiting(), latest.recruitStart(), latest.recruitEnd()))
+                .isAlwaysRecruiting(latest.isAlwaysRecruiting())
                 .build();
     }
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #350

## 👷 **작업한 내용**
기존에 recruitmentStatus 필드가 있어서 isAlwaysRecruiting은 사실 불필요한 필드이지만,
프론트 측에서 오류를 우선적으로 해결해야 해서 임시로 추가해두었습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
