### PR TITLE
Feat: 전체 동아리조회 로직에 키워드기반 탐색 추가하기

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/club/controller/ClubController.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/controller/ClubController.java
@@ -63,6 +63,7 @@ public class ClubController implements ClubControllerSwagger {
     @GetMapping
     public ResponseEntity<APISuccessResponse<AllClubsResponse>> getAllClubs(
             @Authentication final AuthCredential authCredential,
+            @RequestParam(value = "keyword", required = false) final String keyword,
             @RequestParam(value = "affiliation", required = false) final ClubAffiliation affiliation,
             @RequestParam(value = "category", required = false) final ClubCategory category,
             @RequestParam(value = "page") final int page,
@@ -71,7 +72,7 @@ public class ClubController implements ClubControllerSwagger {
         final Pageable pageable = PageRequest.of(page - 1, size);
         return APISuccessResponse.of(
                 HttpStatus.OK,
-                clubService.getAllClubs(authCredential.userId(), affiliation, category, pageable)
+                clubService.getAllClubs(authCredential.userId(), keyword, affiliation, category, pageable)
         );
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/club/controller/ClubControllerSwagger.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/controller/ClubControllerSwagger.java
@@ -84,6 +84,7 @@ public interface ClubControllerSwagger {
     @ApiResponse(responseCode = "200", description = "조회 성공")
     ResponseEntity<APISuccessResponse<AllClubsResponse>> getAllClubs(
             @Parameter(hidden = true) AuthCredential authCredential,
+            @Parameter(name = "keyword", description = "검색 키워드") String keyword,
             @Parameter(name = "affiliation") ClubAffiliation affiliation,
             @Parameter(name = "category") ClubCategory category,
             @Parameter(name = "page", description = "페이지 번호") int page,

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -101,12 +101,13 @@ public class ClubService {
 
     @Transactional(readOnly = true)
     public AllClubsResponse getAllClubs(
-            Long userId,
-            ClubAffiliation affiliation,
-            ClubCategory category,
-            Pageable pageable
+            final Long userId,
+            final String keyword,
+            final ClubAffiliation affiliation,
+            final ClubCategory category,
+            final Pageable pageable
     ) {
-        List<ClubWithLatestRecruitment> clubs = clubRepository.findAllClubsWithLatestRecruitment(affiliation, category);
+        List<ClubWithLatestRecruitment> clubs = clubRepository.findAllClubsWithLatestRecruitment(keyword, affiliation, category);
 
         Set<Long> favoriteClubIds = loadFavoriteClubIds(userId);
 

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryCustom.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryCustom.java
@@ -20,7 +20,8 @@ public interface ClubRepositoryCustom {
     );
 
     List<ClubWithLatestRecruitment> findAllClubsWithLatestRecruitment(
-            ClubAffiliation affiliation,
-            ClubCategory category
+            final String keyword,
+            final ClubAffiliation affiliation,
+            final ClubCategory category
     );
 }

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
@@ -76,7 +76,7 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
     }
 
     @Override
-    public List<ClubWithLatestRecruitment> findAllClubsWithLatestRecruitment(ClubAffiliation affiliation, ClubCategory category) {
+    public List<ClubWithLatestRecruitment> findAllClubsWithLatestRecruitment(final String keyword, final ClubAffiliation affiliation, final ClubCategory category) {
         QRecruitment subRecruitment = new QRecruitment("subRecruitment");
         QRecruitment subRecruitment2 = new QRecruitment("subRecruitment2");
 
@@ -116,6 +116,7 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
                         )
                 )
                 .where(
+                        likeClubName(keyword),
                         equalAffiliation(affiliation),
                         equalCategory(category)
                 )

--- a/src/test/java/com/greedy/mokkoji/club/service/ClubServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/club/service/ClubServiceTest.java
@@ -147,13 +147,13 @@ class ClubServiceTest {
                 latestRecruitmentInfo2
         );
 
-        BDDMockito.given(clubRepository.findAllClubsWithLatestRecruitment(any(), any())).willReturn(List.of(clubWithRecruitment1, clubWithRecruitment2));
+        BDDMockito.given(clubRepository.findAllClubsWithLatestRecruitment(any(), any(), any())).willReturn(List.of(clubWithRecruitment1, clubWithRecruitment2));
         BDDMockito.given(favoriteRepository.findClubIdsByUserId(userId)).willReturn(List.of(clubId1));
         BDDMockito.given(appDataS3Client.getPublicUrl("testLogo1")).willReturn("testLogo1");
         BDDMockito.given(appDataS3Client.getPublicUrl("testLogo2")).willReturn("testLogo2");
 
         //when
-        AllClubsResponse response = clubService.getAllClubs(userId, null, null, pageable);
+        AllClubsResponse response = clubService.getAllClubs(userId, null, null, null, pageable);
 
         //then
         assertThat(response.clubs()).hasSize(2);
@@ -170,7 +170,7 @@ class ClubServiceTest {
 
         assertThat(response.page().totalElements()).isEqualTo(2);
 
-        verify(clubRepository, times(1)).findAllClubsWithLatestRecruitment(any(), any());
+        verify(clubRepository, times(1)).findAllClubsWithLatestRecruitment(any(), any(), any());
         verify(favoriteRepository, times(1)).findClubIdsByUserId(userId);
     }
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #352

## 👷 **작업한 내용**
전체 동아리 조회 페이지에 키워드 기반 검색 기능을 추가했습니다.
* 전체 동아리 조회 API에 keyword 파라미터 추가
* 키워드 기반 검색을 지원하도록 쿼리 로직을 수정

-> 검색 기능 추가에 따라 Swagger 문서와 테스트 코드도 함께 수정했습니다.

## 🚨 **참고 사항**
<img width="1512" height="821" alt="Image" src="https://github.com/user-attachments/assets/131b93cc-a3a1-44c5-a5b5-77a3b74090c4" />
해당 화면 상단에 있는 검색창을 카테고리쪽으로 내려오게 구현하기 위함입니다.
