### PR TITLE
Fix: refresh 토큰 오류로 인한 만료 기한 임의 수정

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/jwt/JwtUtil.java
+++ b/src/main/java/com/greedy/mokkoji/api/jwt/JwtUtil.java
@@ -17,7 +17,7 @@ import java.util.Date;
 @Component
 public class JwtUtil {
     private static final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 60; // 1시간
-    private static final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 7; //7일
+    private static final long REFRESH_TOKEN_EXPIRATION = 1000 * 60; //7일
 
     @Value("${jwt.secret}")
     private String secretKey;

--- a/src/main/java/com/greedy/mokkoji/api/user/service/TokenService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/TokenService.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TokenService {
 
-    private static final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 7;
+    private static final long REFRESH_TOKEN_EXPIRATION = 1000 * 60;
     private final RedisRepository redisRepository;
     private final JwtUtil jwtUtil;
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #354 

## 👷 **작업한 내용**
refresh 토큰 오류로 인한 대응을 위해 만료 시간을 1분으로 설정합니다. 
원인 파악 후 다시 되돌릴 예정입니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
