### PR TITLE
Fix: 동아리 상세 조회 응답에 모집글 관련 필드 추가

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubDetailResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubDetailResponse.java
@@ -2,6 +2,7 @@ package com.greedy.mokkoji.api.club.dto.response;
 
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
+import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -20,7 +21,10 @@ public record ClubDetailResponse(
         @Schema(example = "https://mokkoji-app-data.s3.ap-northeast-2.amazonaws.com/club-logo/1/greedy_{UUID}.jpg") String logo,
         @Schema(example = "true") Boolean isFavorite,
         @Schema(example = "https://instagram.com/greedy_club") String instagram,
-        @Schema(example = "세종대학교 개발 동아리에서 신입 회원을 모집합니다!") String recruitPost
+        @Schema(example = "세종대학교 개발 동아리에서 신입 회원을 모집합니다!") String recruitPost,
+        @Schema(example = "OPEN") RecruitStatus status,
+        @Schema(example = "2025-11-20T10:00:00") LocalDateTime createdAt,
+        @Schema(example = "false") boolean isAlwaysRecruiting
 ) {
     public static ClubDetailResponse of(
             final Long id,
@@ -33,7 +37,10 @@ public record ClubDetailResponse(
             final String logo,
             final Boolean isFavorite,
             final String instagram,
-            final String recruitPost
+            final String recruitPost,
+            final RecruitStatus status,
+            final LocalDateTime createdAt,
+            final boolean isAlwaysRecruiting
     ) {
 
         return ClubDetailResponse.builder()
@@ -48,6 +55,9 @@ public record ClubDetailResponse(
                 .isFavorite(isFavorite)
                 .instagram(instagram)
                 .recruitPost(recruitPost)
+                .status(status)
+                .createdAt(createdAt)
+                .isAlwaysRecruiting(isAlwaysRecruiting)
                 .build();
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -25,6 +25,11 @@ import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.message.FailMessage;
 import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import com.greedy.mokkoji.enums.user.UserRole;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
@@ -32,12 +37,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
 
 @Slf4j
 @Service
@@ -53,19 +52,19 @@ public class ClubService {
     private static PageResponse createPageResponse(Pageable pageable, int totalElements) {
         int totalPages = (int) Math.ceil((double) totalElements / pageable.getPageSize());
         return PageResponse.of(
-                pageable.getPageNumber() + 1,
-                pageable.getPageSize(),
-                totalPages,
-                totalElements
+            pageable.getPageNumber() + 1,
+            pageable.getPageSize(),
+            totalPages,
+            totalElements
         );
     }
 
     private static PageResponse createPageResponses(final Page<?> page) {
         return PageResponse.of(
-                page.getNumber() + 1,
-                page.getSize(),
-                page.getTotalPages(),
-                (int) page.getTotalElements()
+            page.getNumber() + 1,
+            page.getSize(),
+            page.getTotalPages(),
+            (int) page.getTotalElements()
         );
     }
 
@@ -73,10 +72,10 @@ public class ClubService {
     public ClubDetailResponse findClub(final Long userId, final Long clubId) {
 
         final Club club = clubRepository.findById(clubId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB));
+            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB));
         final Recruitment recruitment = recruitmentRepository
-                .findTopByClubIdOrderByCreatedAtDesc(club.getId())
-                .orElse(null);
+            .findTopByClubIdOrderByCreatedAtDesc(club.getId())
+            .orElse(null);
         final Boolean isFavorite = getIsFavorite(userId, clubId);
 
         return mapToClubDetailResponse(club, recruitment, isFavorite);
@@ -84,13 +83,14 @@ public class ClubService {
 
     @Transactional(readOnly = true)
     public ClubsPaginationResponse findClubsByConditions(final Long userId,
-                                                         final String keyword,
-                                                         final ClubCategory category,
-                                                         final ClubAffiliation affiliation,
-                                                         final RecruitStatus status,
-                                                         final Pageable pageable) {
+        final String keyword,
+        final ClubCategory category,
+        final ClubAffiliation affiliation,
+        final RecruitStatus status,
+        final Pageable pageable) {
 
-        final Page<Club> clubPage = clubRepository.findClubsWithLatestRecruitment(keyword, category, affiliation, status, pageable);
+        final Page<Club> clubPage = clubRepository.findClubsWithLatestRecruitment(keyword, category, affiliation,
+            status, pageable);
         final List<Club> clubs = clubPage.getContent();
         final List<ClubResponse> clubResponses = mapToClubResponses(userId, clubs);
 
@@ -101,18 +101,19 @@ public class ClubService {
 
     @Transactional(readOnly = true)
     public AllClubsResponse getAllClubs(
-            final Long userId,
-            final String keyword,
-            final ClubAffiliation affiliation,
-            final ClubCategory category,
-            final Pageable pageable
+        final Long userId,
+        final String keyword,
+        final ClubAffiliation affiliation,
+        final ClubCategory category,
+        final Pageable pageable
     ) {
-        List<ClubWithLatestRecruitment> clubs = clubRepository.findAllClubsWithLatestRecruitment(keyword, affiliation, category);
+        List<ClubWithLatestRecruitment> clubs = clubRepository.findAllClubsWithLatestRecruitment(keyword, affiliation,
+            category);
 
         Set<Long> favoriteClubIds = loadFavoriteClubIds(userId);
 
         List<ClubPreviewResponse> sortedResponses =
-                toSortedClubPreviewResponses(clubs, favoriteClubIds, userId);
+            toSortedClubPreviewResponses(clubs, favoriteClubIds, userId);
 
         List<ClubPreviewResponse> pageContent = slicePage(sortedResponses, pageable);
 
@@ -123,17 +124,17 @@ public class ClubService {
 
     @Transactional
     public void createClub(final Long userId, final String name, final ClubCategory category,
-                           final ClubAffiliation affiliation, final String clubMasterStudentId) {
+        final ClubAffiliation affiliation, final String clubMasterStudentId) {
         validateClubRegistrar(userId);
         String validStudentId = getValidClubMasterStudentId(clubMasterStudentId);
 
         clubRepository.save(
-                Club.builder()
-                        .name(name)
-                        .clubCategory(category)
-                        .clubAffiliation(affiliation)
-                        .clubMasterStudentId(validStudentId)
-                        .build()
+            Club.builder()
+                .name(name)
+                .clubCategory(category)
+                .clubAffiliation(affiliation)
+                .clubMasterStudentId(validStudentId)
+                .build()
         );
     }
 
@@ -142,19 +143,20 @@ public class ClubService {
         Club club = validateClubManagerAuthority(userId, clubId);
 
         return ClubManageDetailResponse.of(
-                club.getName(),
-                club.getClubCategory(),
-                club.getClubAffiliation(),
-                club.getDescription(),
-                appDataS3Client.getPublicUrl(club.getLogo()),
-                club.getInstagram()
+            club.getName(),
+            club.getClubCategory(),
+            club.getClubAffiliation(),
+            club.getDescription(),
+            appDataS3Client.getPublicUrl(club.getLogo()),
+            club.getInstagram()
         );
     }
 
     @Transactional
     public ClubUpdateResponse updateClub(
-            final Long userId, final Long clubId, final String name, final ClubCategory category, final ClubAffiliation affiliation,
-            final String description, final String clubMasterStudentId, final String logo, final String instagram
+        final Long userId, final Long clubId, final String name, final ClubCategory category,
+        final ClubAffiliation affiliation,
+        final String description, final String clubMasterStudentId, final String logo, final String instagram
     ) {
         Club club = validateClubManagerAuthority(userId, clubId);
 
@@ -174,48 +176,52 @@ public class ClubService {
     }
 
     private Set<Long> loadFavoriteClubIds(Long userId) {
-        if (userId == null) return Set.of();
+        if (userId == null) {
+            return Set.of();
+        }
         return new HashSet<>(favoriteRepository.findClubIdsByUserId(userId));
     }
 
     private List<ClubPreviewResponse> toSortedClubPreviewResponses(
-            List<ClubWithLatestRecruitment> clubs,
-            Set<Long> favoriteClubIds,
-            Long userId
+        List<ClubWithLatestRecruitment> clubs,
+        Set<Long> favoriteClubIds,
+        Long userId
     ) {
         return clubs.stream()
-                .map(c -> mapToClubPreviewResponse(c, favoriteClubIds))
-                .sorted(clubSortComparator(userId))
-                .toList();
+            .map(c -> mapToClubPreviewResponse(c, favoriteClubIds))
+            .sorted(clubSortComparator(userId))
+            .toList();
     }
 
     private ClubPreviewResponse mapToClubPreviewResponse(
-            ClubWithLatestRecruitment c,
-            Set<Long> favoriteClubIds
+        ClubWithLatestRecruitment c,
+        Set<Long> favoriteClubIds
     ) {
         boolean isFavorite = favoriteClubIds.contains(c.id());
 
         return ClubPreviewResponse.builder()
-                .id(c.id())
-                .name(c.name())
-                .description(c.description())
-                .logo(appDataS3Client.getPublicUrl(c.logo()))
-                .favorite(isFavorite)
-                .recruitmentPreviewResponse(
-                        mapToLatestRecruitmentPreviewResponse(c.latestRecruitmentInfo())
-                )
-                .build();
+            .id(c.id())
+            .name(c.name())
+            .description(c.description())
+            .logo(appDataS3Client.getPublicUrl(c.logo()))
+            .favorite(isFavorite)
+            .recruitmentPreviewResponse(
+                mapToLatestRecruitmentPreviewResponse(c.latestRecruitmentInfo())
+            )
+            .build();
     }
 
     private List<ClubPreviewResponse> slicePage(
-            List<ClubPreviewResponse> sortedResponses,
-            Pageable pageable
+        List<ClubPreviewResponse> sortedResponses,
+        Pageable pageable
     ) {
         int total = sortedResponses.size();
         int start = (int) pageable.getOffset();
         int end = Math.min(start + pageable.getPageSize(), total);
 
-        if (start >= total) return List.of();
+        if (start >= total) {
+            return List.of();
+        }
         return sortedResponses.subList(start, end);
     }
 
@@ -223,77 +229,85 @@ public class ClubService {
     private Comparator<ClubPreviewResponse> clubSortComparator(Long userId) {
 
         Comparator<RecruitmentPreviewResponse> recruitmentSortComparator =
-                Comparator.nullsLast(
-                        Comparator.comparing((RecruitmentPreviewResponse rp) -> rp.recruitStatus().getPriority())
-                                .thenComparing(
-                                        RecruitmentPreviewResponse::recruitEnd,
-                                        Comparator.nullsLast(Comparator.naturalOrder())
-                                )
-                );
+            Comparator.nullsLast(
+                Comparator.comparing((RecruitmentPreviewResponse rp) -> rp.recruitStatus().getPriority())
+                    .thenComparing(
+                        RecruitmentPreviewResponse::recruitEnd,
+                        Comparator.nullsLast(Comparator.naturalOrder())
+                    )
+            );
 
         Comparator<ClubPreviewResponse> recruitmentComparator =
-                Comparator.comparing(ClubPreviewResponse::recruitmentPreviewResponse, recruitmentSortComparator);
+            Comparator.comparing(ClubPreviewResponse::recruitmentPreviewResponse, recruitmentSortComparator);
 
-        if (userId == null) return recruitmentComparator;
+        if (userId == null) {
+            return recruitmentComparator;
+        }
 
         return Comparator.comparing(ClubPreviewResponse::favorite)
-                .reversed()
-                .thenComparing(recruitmentComparator);
+            .reversed()
+            .thenComparing(recruitmentComparator);
     }
 
     @Nullable
     private RecruitmentPreviewResponse mapToLatestRecruitmentPreviewResponse(
-            LatestRecruitmentInfo latest
+        LatestRecruitmentInfo latest
     ) {
         if (latest == null || latest.id() == null) {
             return null;
         }
 
         return RecruitmentPreviewResponse.builder()
-                .id(latest.id())
-                .recruitStart(latest.recruitStart())
-                .recruitEnd(latest.recruitEnd())
-                .recruitStatus(RecruitStatus.from(latest.isAlwaysRecruiting(), latest.recruitStart(), latest.recruitEnd()))
-                .isAlwaysRecruiting(latest.isAlwaysRecruiting())
-                .build();
+            .id(latest.id())
+            .recruitStart(latest.recruitStart())
+            .recruitEnd(latest.recruitEnd())
+            .recruitStatus(RecruitStatus.from(latest.isAlwaysRecruiting(), latest.recruitStart(), latest.recruitEnd()))
+            .isAlwaysRecruiting(latest.isAlwaysRecruiting())
+            .build();
     }
 
     private List<ClubResponse> mapToClubResponses(final Long userId, final List<Club> clubs) {
         return clubs.stream()
-                .map(club -> {
-                    Recruitment recruitment = recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(club.getId())
-                            .orElse(null);
-                    boolean isFavorite = getIsFavorite(userId, club.getId());
-                    return ClubResponse.of(club.getId(),
-                            club.getName(),
-                            club.getClubCategory(),
-                            club.getClubAffiliation(),
-                            club.getDescription(),
-                            recruitment != null ? recruitment.getRecruitStart() : null,
-                            recruitment != null ? recruitment.getRecruitEnd() : null,
-                            recruitment != null ? recruitment.isAlwaysRecruiting() : null,
-                            calculateRecruitStatus(recruitment),
-                            appDataS3Client.getPublicUrl(club.getLogo()),
-                            isFavorite);
-                })
-                .sorted(getFavoriteComparator())
-                .toList();
+            .map(club -> {
+                Recruitment recruitment = recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(club.getId())
+                    .orElse(null);
+                boolean isFavorite = getIsFavorite(userId, club.getId());
+                return ClubResponse.of(club.getId(),
+                    club.getName(),
+                    club.getClubCategory(),
+                    club.getClubAffiliation(),
+                    club.getDescription(),
+                    recruitment != null ? recruitment.getRecruitStart() : null,
+                    recruitment != null ? recruitment.getRecruitEnd() : null,
+                    recruitment != null ? recruitment.isAlwaysRecruiting() : null,
+                    calculateRecruitStatus(recruitment),
+                    appDataS3Client.getPublicUrl(club.getLogo()),
+                    isFavorite);
+            })
+            .sorted(getFavoriteComparator())
+            .toList();
     }
 
     private ClubDetailResponse mapToClubDetailResponse(final Club club, final Recruitment recruitment,
-                                                       final Boolean isFavorite) {
+        final Boolean isFavorite) {
         return ClubDetailResponse.of(
-                club.getId(),
-                club.getName(),
-                club.getClubCategory(),
-                club.getClubAffiliation(),
-                club.getDescription(),
-                recruitment != null ? recruitment.getRecruitStart() : null,
-                recruitment != null ? recruitment.getRecruitEnd() : null,
-                appDataS3Client.getPublicUrl(club.getLogo()),
-                isFavorite,
-                club.getInstagram(),
-                recruitment != null ? recruitment.getContent() : null
+            club.getId(),
+            club.getName(),
+            club.getClubCategory(),
+            club.getClubAffiliation(),
+            club.getDescription(),
+            recruitment != null ? recruitment.getRecruitStart() : null,
+            recruitment != null ? recruitment.getRecruitEnd() : null,
+            appDataS3Client.getPublicUrl(club.getLogo()),
+            isFavorite,
+            club.getInstagram(),
+            recruitment != null ? recruitment.getContent() : null,
+            recruitment != null
+                ? RecruitStatus.from(recruitment.isAlwaysRecruiting(), recruitment.getRecruitStart(),
+                recruitment.getRecruitEnd())
+                : null,
+            recruitment != null ? recruitment.getCreatedAt() : null,
+            recruitment != null ? recruitment.isAlwaysRecruiting() : false
         );
     }
 
@@ -321,22 +335,22 @@ public class ClubService {
         }
 
         User masterUser = userRepository.findByStudentId(clubMasterStudentId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
         masterUser.updateRole(UserRole.CLUB_MASTER);
         return masterUser.getStudentId();
     }
 
     private void changeClubMasterRole(final String previousClubMasterStudentId, final String newClubMasterStudentId) {
         userRepository.findByStudentId(previousClubMasterStudentId)
-                .ifPresent(user -> user.updateRole(UserRole.NORMAL));
+            .ifPresent(user -> user.updateRole(UserRole.NORMAL));
 
         userRepository.findByStudentId(newClubMasterStudentId)
-                .ifPresent(user -> user.updateRole(UserRole.CLUB_MASTER));
+            .ifPresent(user -> user.updateRole(UserRole.CLUB_MASTER));
     }
 
     private Club findClubOrThrow(Long clubId) {
         return clubRepository.findById(clubId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB));
+            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB));
     }
 
     private User findUserOrThrow(Long userId) {
@@ -344,7 +358,7 @@ public class ClubService {
             throw new MokkojiException(FailMessage.UNAUTHORIZED);
         }
         return userRepository.findById(userId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+            .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
     }
 
     private boolean getIsFavorite(final Long userId, final Long clubId) {
@@ -377,23 +391,25 @@ public class ClubService {
     @Nullable
     private String generatePresignedPutUrl(final String newLogoKey) {
         return (newLogoKey != null)
-                ? appDataS3Client.getPresignedPutUrl(newLogoKey)
-                : null;
+            ? appDataS3Client.getPresignedPutUrl(newLogoKey)
+            : null;
     }
 
     @Nullable
     private String generatePresignedDeleteUrl(String newLogoKey, String oldLogoKey) {
         return (newLogoKey != null && oldLogoKey != null && !oldLogoKey.equals(newLogoKey))
-                ? appDataS3Client.getPresignedDeleteUrl(oldLogoKey)
-                : null;
+            ? appDataS3Client.getPresignedDeleteUrl(oldLogoKey)
+            : null;
     }
 
     private RecruitStatus calculateRecruitStatus(final Recruitment recruitment) {
-        if (recruitment == null) return null;
+        if (recruitment == null) {
+            return null;
+        }
         return RecruitStatus.from(
-                recruitment.isAlwaysRecruiting(),
-                recruitment.getRecruitStart(),
-                recruitment.getRecruitEnd()
+            recruitment.isAlwaysRecruiting(),
+            recruitment.getRecruitStart(),
+            recruitment.getRecruitEnd()
         );
     }
 }

--- a/src/test/java/com/greedy/mokkoji/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/club/controller/ClubControllerTest.java
@@ -1,5 +1,10 @@
 package com.greedy.mokkoji.club.controller;
 
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 import com.greedy.mokkoji.api.club.dto.request.ClubCreateRequest;
 import com.greedy.mokkoji.api.club.dto.request.ClubUpdateRequest;
 import com.greedy.mokkoji.api.club.dto.response.ClubDetailResponse;
@@ -23,6 +28,7 @@ import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import com.greedy.mokkoji.enums.user.UserRole;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,13 +36,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-
-import static io.restassured.RestAssured.given;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 public class ClubControllerTest extends ControllerTest {
 
@@ -71,27 +70,33 @@ public class ClubControllerTest extends ControllerTest {
 
         //when
         final ExtractableResponse<Response> response = given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", authorizationForBearer)
-                .when().get(prefixUrl + "/clubs/{clubId}", club.getId())
-                .then().log().all()
-                .extract();
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .when().get(prefixUrl + "/clubs/{clubId}", club.getId())
+            .then().log().all()
+            .extract();
 
         //then
         final int statusCode = response.statusCode();
         final ClubDetailResponse actual = getDataFromResponse(response, ClubDetailResponse.class); //그리디 로고
         final ClubDetailResponse expected = ClubDetailResponse.of(
-                club.getId(),
-                club.getName(),
-                club.getClubCategory(),
-                club.getClubAffiliation(),
-                club.getDescription(),
+            club.getId(),
+            club.getName(),
+            club.getClubCategory(),
+            club.getClubAffiliation(),
+            club.getDescription(),
+            recruitment.getRecruitStart(),
+            recruitment.getRecruitEnd(),
+            Fixture.FIXTURE_CLUB_LOGO,
+            true,
+            club.getInstagram(),
+            recruitment.getContent(),
+            RecruitStatus.from(
+                recruitment.isAlwaysRecruiting(),
                 recruitment.getRecruitStart(),
-                recruitment.getRecruitEnd(),
-                Fixture.FIXTURE_CLUB_LOGO,
-                true,
-                club.getInstagram(),
-                recruitment.getContent()
+                recruitment.getRecruitEnd()),
+            recruitment.getCreatedAt(),
+            recruitment.isAlwaysRecruiting()
         );
 
         assertThat(statusCode).isEqualTo(HttpStatus.OK.value());
@@ -105,46 +110,46 @@ public class ClubControllerTest extends ControllerTest {
         String authorizationForBearer = authorizationForBearerAccessToken(user);
 
         final RecruitmentPreviewResponse recruitmentPreviewResponse =
-                RecruitmentPreviewResponse.builder()
-                        .id(recruitment.getId())
-                        .recruitStart(recruitment.getRecruitStart())
-                        .recruitEnd(recruitment.getRecruitEnd())
-                        .recruitStatus(RecruitStatus.from(
-                                recruitment.isAlwaysRecruiting(),
-                                recruitment.getRecruitStart(),
-                                recruitment.getRecruitEnd()
-                        ))
-                        .build();
+            RecruitmentPreviewResponse.builder()
+                .id(recruitment.getId())
+                .recruitStart(recruitment.getRecruitStart())
+                .recruitEnd(recruitment.getRecruitEnd())
+                .recruitStatus(RecruitStatus.from(
+                    recruitment.isAlwaysRecruiting(),
+                    recruitment.getRecruitStart(),
+                    recruitment.getRecruitEnd()
+                ))
+                .build();
 
         final List<ClubPreviewResponse> clubResponses =
-                List.of(ClubPreviewResponse.builder()
-                        .id(club.getId())
-                        .name(club.getName())
-                        .description(club.getDescription())
-                        .logo(club.getLogo())
-                        .favorite(true)
-                        .recruitmentPreviewResponse(recruitmentPreviewResponse)
-                        .build());
+            List.of(ClubPreviewResponse.builder()
+                .id(club.getId())
+                .name(club.getName())
+                .description(club.getDescription())
+                .logo(club.getLogo())
+                .favorite(true)
+                .recruitmentPreviewResponse(recruitmentPreviewResponse)
+                .build());
 
         final int pageNumber = 1;
         final int pageSize = 10;
         final PageResponse pageResponse = PageResponse.of(
-                pageNumber,
-                pageSize,
-                1,
-                1
+            pageNumber,
+            pageSize,
+            1,
+            1
         );
 
         when(appDataS3Client.getPublicUrl(any())).thenReturn(Fixture.FIXTURE_CLUB_LOGO);
 
         final ExtractableResponse<Response> response = given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", authorizationForBearer)
-                .param("page", pageNumber)
-                .param("size", pageSize)
-                .when().get(prefixUrl + "/clubs")
-                .then().log().all()
-                .extract();
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .param("page", pageNumber)
+            .param("size", pageSize)
+            .when().get(prefixUrl + "/clubs")
+            .then().log().all()
+            .extract();
 
         //when
         final int statusCode = response.statusCode();
@@ -160,31 +165,31 @@ public class ClubControllerTest extends ControllerTest {
     void createClub() {
         //given
         final User adminUser = User.builder()
-                .name("관리자")
-                .email("admin@test.com")
-                .studentId("12345678")
-                .grade("4")
-                .department("컴퓨터공학과")
-                .role(UserRole.CLUB_ADMIN)
-                .build();
+            .name("관리자")
+            .email("admin@test.com")
+            .studentId("12345678")
+            .grade("4")
+            .department("컴퓨터공학과")
+            .role(UserRole.CLUB_ADMIN)
+            .build();
         userRepository.save(adminUser);
         String authorizationForBearer = authorizationForBearerAccessToken(adminUser);
 
         final ClubCreateRequest request = new ClubCreateRequest(
-                "새로운 동아리",
-                ClubCategory.ACADEMIC_CULTURAL,
-                ClubAffiliation.DEPARTMENT_CLUB,
-                adminUser.getStudentId()
+            "새로운 동아리",
+            ClubCategory.ACADEMIC_CULTURAL,
+            ClubAffiliation.DEPARTMENT_CLUB,
+            adminUser.getStudentId()
         );
 
         //when
         final ExtractableResponse<Response> response = given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", authorizationForBearer)
-                .body(request)
-                .when().post(prefixUrl + "/clubs")
-                .then().log().all()
-                .extract();
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .body(request)
+            .when().post(prefixUrl + "/clubs")
+            .then().log().all()
+            .extract();
 
         //then
         final int statusCode = response.statusCode();
@@ -201,45 +206,45 @@ public class ClubControllerTest extends ControllerTest {
     void getClubManageDetail() {
         //given
         final User adminUser = User.builder()
-                .name("관리자")
-                .email("admin@test.com")
-                .studentId("12345678")
-                .grade("4")
-                .department("컴퓨터공학과")
-                .role(UserRole.CLUB_ADMIN)
-                .build();
+            .name("관리자")
+            .email("admin@test.com")
+            .studentId("12345678")
+            .grade("4")
+            .department("컴퓨터공학과")
+            .role(UserRole.CLUB_ADMIN)
+            .build();
         userRepository.save(adminUser);
 
         final Club managedClub = Club.builder()
-                .name("관리할 동아리")
-                .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
-                .clubCategory(ClubCategory.SPORTS)
-                .clubMasterStudentId(adminUser.getStudentId())
-                .description("동아리 설명")
-                .instagram("instagram.com")
-                .build();
+            .name("관리할 동아리")
+            .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
+            .clubCategory(ClubCategory.SPORTS)
+            .clubMasterStudentId(adminUser.getStudentId())
+            .description("동아리 설명")
+            .instagram("instagram.com")
+            .build();
         clubRepository.save(managedClub);
         String authorizationForBearer = authorizationForBearerAccessToken(adminUser);
         when(appDataS3Client.getPublicUrl(null)).thenReturn(null);
 
         //when
         final ExtractableResponse<Response> response = given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", authorizationForBearer)
-                .when().get(prefixUrl + "/clubs/manage/{clubId}", managedClub.getId())
-                .then().log().all()
-                .extract();
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .when().get(prefixUrl + "/clubs/manage/{clubId}", managedClub.getId())
+            .then().log().all()
+            .extract();
 
         //then
         final int statusCode = response.statusCode();
         final ClubManageDetailResponse actual = getDataFromResponse(response, ClubManageDetailResponse.class);
         final ClubManageDetailResponse expected = ClubManageDetailResponse.of(
-                managedClub.getName(),
-                managedClub.getClubCategory(),
-                managedClub.getClubAffiliation(),
-                managedClub.getDescription(),
-                managedClub.getLogo(),
-                managedClub.getInstagram()
+            managedClub.getName(),
+            managedClub.getClubCategory(),
+            managedClub.getClubAffiliation(),
+            managedClub.getDescription(),
+            managedClub.getLogo(),
+            managedClub.getInstagram()
         );
 
         assertThat(statusCode).isEqualTo(HttpStatus.OK.value());
@@ -251,32 +256,32 @@ public class ClubControllerTest extends ControllerTest {
     void updateClub() {
         //given
         final User clubMasterUser = User.builder()
-                .name("동아리장")
-                .email("master@test.com")
-                .grade("3")
-                .studentId("21123456")
-                .role(UserRole.CLUB_MASTER)
-                .build();
+            .name("동아리장")
+            .email("master@test.com")
+            .grade("3")
+            .studentId("21123456")
+            .role(UserRole.CLUB_MASTER)
+            .build();
         userRepository.save(clubMasterUser);
         String authorizationForBearer = authorizationForBearerAccessToken(clubMasterUser);
 
         final Club managedClub = Club.builder()
-                .name("수정할 동아리")
-                .clubCategory(ClubCategory.SPORTS)
-                .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
-                .clubMasterStudentId(clubMasterUser.getStudentId())
-                .build();
+            .name("수정할 동아리")
+            .clubCategory(ClubCategory.SPORTS)
+            .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
+            .clubMasterStudentId(clubMasterUser.getStudentId())
+            .build();
         ReflectionTestUtils.setField(managedClub, "logo", "logo.jpg");
         clubRepository.save(managedClub);
 
         final ClubUpdateRequest request = new ClubUpdateRequest(
-                "수정된 동아리",
-                ClubCategory.CULTURAL_ART,
-                ClubAffiliation.DEPARTMENT_CLUB,
-                "동아리 수정 완료",
-                "12345678",
-                "new-logo.jpg",
-                "new-instagram.com"
+            "수정된 동아리",
+            ClubCategory.CULTURAL_ART,
+            ClubAffiliation.DEPARTMENT_CLUB,
+            "동아리 수정 완료",
+            "12345678",
+            "new-logo.jpg",
+            "new-instagram.com"
         );
 
         when(appDataS3Client.getPresignedPutUrl(any())).thenReturn("presignedPutUrl");
@@ -284,12 +289,12 @@ public class ClubControllerTest extends ControllerTest {
 
         //when
         final ExtractableResponse<Response> response = given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", authorizationForBearer)
-                .body(request)
-                .when().patch(prefixUrl + "/clubs/manage/{clubId}", managedClub.getId())
-                .then().log().all()
-                .extract();
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .body(request)
+            .when().patch(prefixUrl + "/clubs/manage/{clubId}", managedClub.getId())
+            .then().log().all()
+            .extract();
 
         //then
         final int statusCode = response.statusCode();
@@ -317,18 +322,18 @@ public class ClubControllerTest extends ControllerTest {
 
         //when
         final ExtractableResponse<Response> response = given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", authorizationForBearer)
-                .when().get(prefixUrl + "/clubs/{clubId}", nonExistentClubId)
-                .then().log().all()
-                .extract();
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .when().get(prefixUrl + "/clubs/{clubId}", nonExistentClubId)
+            .then().log().all()
+            .extract();
 
         //then
         final int actualStatusCode = response.statusCode();
         final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
         final APIErrorResponse expectedResponse = new APIErrorResponse(
-                FailMessage.NOT_FOUND_CLUB.getCode(),
-                FailMessage.NOT_FOUND_CLUB.getMessage()
+            FailMessage.NOT_FOUND_CLUB.getCode(),
+            FailMessage.NOT_FOUND_CLUB.getMessage()
         );
 
         assertThat(actualStatusCode).isEqualTo(HttpStatus.NOT_FOUND.value());
@@ -340,38 +345,38 @@ public class ClubControllerTest extends ControllerTest {
     void createClubForbidden() {
         //given
         final User normalUser = User.builder()
-                .name("일반사용자")
-                .email("normal@test.com")
-                .studentId("11112222")
-                .grade("2")
-                .department("소프트웨어학과")
-                .role(UserRole.NORMAL)
-                .build();
+            .name("일반사용자")
+            .email("normal@test.com")
+            .studentId("11112222")
+            .grade("2")
+            .department("소프트웨어학과")
+            .role(UserRole.NORMAL)
+            .build();
         userRepository.save(normalUser);
         String authorizationForBearer = authorizationForBearerAccessToken(normalUser);
 
         final ClubCreateRequest request = new ClubCreateRequest(
-                "새로운 동아리",
-                ClubCategory.ACADEMIC_CULTURAL,
-                ClubAffiliation.DEPARTMENT_CLUB,
-                null
+            "새로운 동아리",
+            ClubCategory.ACADEMIC_CULTURAL,
+            ClubAffiliation.DEPARTMENT_CLUB,
+            null
         );
 
         //when
         final ExtractableResponse<Response> response = given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", authorizationForBearer)
-                .body(request)
-                .when().post(prefixUrl + "/clubs")
-                .then().log().all()
-                .extract();
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .body(request)
+            .when().post(prefixUrl + "/clubs")
+            .then().log().all()
+            .extract();
 
         //then
         final int actualStatusCode = response.statusCode();
         final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
         final APIErrorResponse expectedResponse = new APIErrorResponse(
-                FailMessage.FORBIDDEN_REGISTER_CLUB.getCode(),
-                FailMessage.FORBIDDEN_REGISTER_CLUB.getMessage()
+            FailMessage.FORBIDDEN_REGISTER_CLUB.getCode(),
+            FailMessage.FORBIDDEN_REGISTER_CLUB.getMessage()
         );
 
         assertThat(actualStatusCode).isEqualTo(HttpStatus.FORBIDDEN.value());
@@ -383,41 +388,41 @@ public class ClubControllerTest extends ControllerTest {
     void updateClubForbidden() {
         //given
         final User normalUser = User.builder()
-                .name("일반사용자")
-                .email("normal2@test.com")
-                .studentId("22223333")
-                .grade("2")
-                .department("소프트웨어학과")
-                .role(UserRole.NORMAL)
-                .build();
+            .name("일반사용자")
+            .email("normal2@test.com")
+            .studentId("22223333")
+            .grade("2")
+            .department("소프트웨어학과")
+            .role(UserRole.NORMAL)
+            .build();
         userRepository.save(normalUser);
         String authorizationForBearer = authorizationForBearerAccessToken(normalUser);
 
         final ClubUpdateRequest request = new ClubUpdateRequest(
-                "수정된 동아리",
-                ClubCategory.CULTURAL_ART,
-                ClubAffiliation.DEPARTMENT_CLUB,
-                "동아리 수정",
-                null,
-                null,
-                null
+            "수정된 동아리",
+            ClubCategory.CULTURAL_ART,
+            ClubAffiliation.DEPARTMENT_CLUB,
+            "동아리 수정",
+            null,
+            null,
+            null
         );
 
         //when
         final ExtractableResponse<Response> response = given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", authorizationForBearer)
-                .body(request)
-                .when().patch(prefixUrl + "/clubs/manage/{clubId}", club.getId())
-                .then().log().all()
-                .extract();
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .body(request)
+            .when().patch(prefixUrl + "/clubs/manage/{clubId}", club.getId())
+            .then().log().all()
+            .extract();
 
         //then
         final int actualStatusCode = response.statusCode();
         final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
         final APIErrorResponse expectedResponse = new APIErrorResponse(
-                FailMessage.FORBIDDEN_MANAGE_CLUB.getCode(),
-                FailMessage.FORBIDDEN_MANAGE_CLUB.getMessage()
+            FailMessage.FORBIDDEN_MANAGE_CLUB.getCode(),
+            FailMessage.FORBIDDEN_MANAGE_CLUB.getMessage()
         );
 
         assertThat(actualStatusCode).isEqualTo(HttpStatus.FORBIDDEN.value());
@@ -431,38 +436,38 @@ public class ClubControllerTest extends ControllerTest {
         final String nonExistentStudentId = "99999999";
 
         final User adminUser = User.builder()
-                .name("관리자")
-                .email("admin2@test.com")
-                .studentId("99998888")
-                .grade("4")
-                .department("컴퓨터공학과")
-                .role(UserRole.CLUB_ADMIN)
-                .build();
+            .name("관리자")
+            .email("admin2@test.com")
+            .studentId("99998888")
+            .grade("4")
+            .department("컴퓨터공학과")
+            .role(UserRole.CLUB_ADMIN)
+            .build();
         userRepository.save(adminUser);
         String authorizationForBearer = authorizationForBearerAccessToken(adminUser);
 
         final ClubCreateRequest request = new ClubCreateRequest(
-                "새로운 동아리",
-                ClubCategory.ACADEMIC_CULTURAL,
-                ClubAffiliation.DEPARTMENT_CLUB,
-                nonExistentStudentId
+            "새로운 동아리",
+            ClubCategory.ACADEMIC_CULTURAL,
+            ClubAffiliation.DEPARTMENT_CLUB,
+            nonExistentStudentId
         );
 
         //when
         final ExtractableResponse<Response> response = given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .header("Authorization", authorizationForBearer)
-                .body(request)
-                .when().post(prefixUrl + "/clubs")
-                .then().log().all()
-                .extract();
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", authorizationForBearer)
+            .body(request)
+            .when().post(prefixUrl + "/clubs")
+            .then().log().all()
+            .extract();
 
         //then
         final int actualStatusCode = response.statusCode();
         final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
         final APIErrorResponse expectedResponse = new APIErrorResponse(
-                FailMessage.NOT_FOUND_USER.getCode(),
-                FailMessage.NOT_FOUND_USER.getMessage()
+            FailMessage.NOT_FOUND_USER.getCode(),
+            FailMessage.NOT_FOUND_USER.getMessage()
         );
 
         assertThat(actualStatusCode).isEqualTo(HttpStatus.NOT_FOUND.value());

--- a/src/test/java/com/greedy/mokkoji/club/service/ClubServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/club/service/ClubServiceTest.java
@@ -20,6 +20,7 @@ import com.greedy.mokkoji.db.user.repository.UserRepository;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.message.FailMessage;
+import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import com.greedy.mokkoji.enums.user.UserRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -88,6 +89,7 @@ class ClubServiceTest {
                 .content("testContent1")
                 .recruitStart(LocalDateTime.of(2025, 1, 1, 12, 0))
                 .recruitEnd(LocalDateTime.of(2025, 3, 30, 12, 0))
+                .isAlwaysRecruiting(false)
                 .build();
 
         club2 = Club.builder()
@@ -181,6 +183,9 @@ class ClubServiceTest {
         final Long userId = 1L;
         final Long clubId = club1.getId();
 
+        final LocalDateTime createdAt = LocalDateTime.of(2026, 1, 1, 0, 0);
+        ReflectionTestUtils.setField(recruitment1, "createdAt", createdAt);
+
         BDDMockito.given(clubRepository.findById(clubId)).willReturn(Optional.ofNullable(club1));
         BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(clubId)).willReturn(Optional.ofNullable(recruitment1));
         BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, clubId)).willReturn(true);
@@ -201,6 +206,14 @@ class ClubServiceTest {
         assertThat(response.isFavorite()).isEqualTo(true);
         assertThat(response.instagram()).isEqualTo("testInstagramURL1");
         assertThat(response.recruitPost()).isEqualTo("testContent1");
+        assertThat(response.status())
+            .isEqualTo(RecruitStatus.from(
+                recruitment1.isAlwaysRecruiting(),
+                recruitment1.getRecruitStart(),
+                recruitment1.getRecruitEnd()
+            ));
+        assertThat(response.createdAt()).isEqualTo(createdAt);
+        assertThat(response.isAlwaysRecruiting()).isEqualTo(false);
 
         verify(clubRepository, times(1)).findById(anyLong());
         verify(recruitmentRepository, times(1)).findTopByClubIdOrderByCreatedAtDesc(anyLong());


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #356 

## 👷 **작업한 내용**
동아리 상세 조회 시 모집글 관련 정보를 함께 응답합니다.
모집글이 없는 동아리의 경우, 프론트에서 해당 API를 사용해 정보를 보여주도록 합의하였습니다.
추가된 필드는 다음과 같습니다.
- 모집글 생성일
- 모집 상태
- 상시모집 여부

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
