### PR TITLE
Feat : refresh 토큰 오류 파악을 위한 로그 추가

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -78,15 +78,35 @@ public class UserService {
                 });
     }
 
+//    @Transactional
+//    public String refreshAccessToken(String refreshToken) {
+//        final Long userId = jwtUtil.getUserIdFromToken(refreshToken);
+//
+//        String storedRefreshToken = tokenService.getRefreshToken(userId);
+//        if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
+//            throw new MokkojiException(FailMessage.UNAUTHORIZED);
+//        }
+//
+//        return jwtUtil.generateAccessToken(userId);
+//    }
+
     @Transactional
     public String refreshAccessToken(String refreshToken) {
-        final Long userId = jwtUtil.getUserIdFromToken(refreshToken);
-
-        String storedRefreshToken = tokenService.getRefreshToken(userId);
-        if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
+        log.info("refresh token present: {}", refreshToken != null);
+        if (refreshToken == null) {
             throw new MokkojiException(FailMessage.UNAUTHORIZED);
         }
-
+        final Long userId = jwtUtil.getUserIdFromToken(refreshToken);
+        log.warn("userID : {}", userId);
+        String storedRefreshToken = tokenService.getRefreshToken(userId);
+        if (storedRefreshToken == null) {
+            log.warn("no refresh token stored for userId={}", userId);
+            throw new MokkojiException(FailMessage.UNAUTHORIZED);
+        }
+        if (!storedRefreshToken.equals(refreshToken)) {
+            log.warn("refresh token mismatch for userId={}", userId);
+            throw new MokkojiException(FailMessage.UNAUTHORIZED);
+        }
         return jwtUtil.generateAccessToken(userId);
     }
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #358

## 👷 **작업한 내용**
refresh 토큰 오류의 정확한 원인을 파악하기 위해 로그를 추가했습니다.

<img width="500"  alt="Image" src="https://github.com/user-attachments/assets/87d41388-40e7-4b37-b31c-fa5a5a498021" />


로그로 파악할 수 있는 정보는 아래와 같습니다.
1) refresh 토큰 미전달인 경우
2) 서버에 저장된 토큰이 없는 경우
3) refresh 토큰 불일치인 경우

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
