### PR TITLE
Fix: 모집글 미존재 시 예외 대신 빈 응답 반환

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -27,18 +27,17 @@ import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.message.FailMessage;
 import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
 import com.greedy.mokkoji.enums.user.UserRole;
-import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -153,43 +152,15 @@ public class RecruitmentService {
     @Transactional
     public RecentRecruitmentOfClubResponse getRecentRecruitmentOfClub(final Long clubId, final Long userId) {
 
-        Optional<Recruitment> recentRecruitment = recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(clubId);
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB));
 
-        Recruitment recruitment = recentRecruitment.orElseGet(() ->
-                recruitmentRepository.findTopByClubIdAndIsAlwaysRecruitingOrderByCreatedAtDesc(clubId, true)
-                        .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUNT_RECRUITMENT))
-        );
+        Boolean isFavorite = isFavorite(userId, clubId);
 
-        Club club = recruitment.getClub();
-
-        List<RecruitmentImage> recruitmentImages = recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(
-                recruitment.getId());
-
-        List<String> imageUrls = recruitmentImages.stream()
-                .map(image -> appDataS3Client.getPublicUrl(image.getImage()))
-                .toList();
-
-        Boolean isFavorite = isFavorite(userId, club.getId());
-
-        return RecentRecruitmentOfClubResponse.of(
-                recruitment.getId(),
-                recruitment.getTitle(),
-                club.getName(),
-                appDataS3Client.getPublicUrl(club.getLogo()),
-                club.getId(),
-                recruitment.getContent(),
-                recruitment.getRecruitStart(),
-                recruitment.getRecruitEnd(),
-                RecruitStatus.from(recruitment.isAlwaysRecruiting(), recruitment.getRecruitStart(),
-                        recruitment.getRecruitEnd()),
-                recruitment.getCreatedAt(),
-                imageUrls,
-                recruitment.getRecruitForm(),
-                isFavorite,
-                club.getInstagram(),
-                club.getClubCategory(),
-                recruitment.isAlwaysRecruiting()
-        );
+        Optional<Recruitment> recentRecruitmentOptional = findRecentRecruitmentOrAlwaysRecruiting(clubId);
+        return recentRecruitmentOptional
+                .map(recruitment -> toResponse(club, recruitment, isFavorite))
+                .orElseGet(() -> emptyResponse(club, isFavorite));
     }
 
     @Transactional
@@ -328,6 +299,70 @@ public class RecruitmentService {
         return favoriteRepository.existsByUserIdAndClubId(userId, clubId);
     }
 
+    private Optional<Recruitment> findRecentRecruitmentOrAlwaysRecruiting(final Long clubId) {
+        return recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(clubId)
+                .or(() -> recruitmentRepository
+                        .findTopByClubIdAndIsAlwaysRecruitingOrderByCreatedAtDesc(clubId, true));
+    }
+
+    private RecentRecruitmentOfClubResponse toResponse(
+            final Club club,
+            final Recruitment recruitment,
+            final Boolean isFavorite
+    ) {
+
+        List<String> imageUrls = recruitmentImageRepository
+                .findByRecruitmentIdOrderByCreatedAtAsc(recruitment.getId())
+                .stream()
+                .map(image -> appDataS3Client.getPublicUrl(image.getImage()))
+                .toList();
+
+        return RecentRecruitmentOfClubResponse.of(
+                recruitment.getId(),
+                recruitment.getTitle(),
+                club.getName(),
+                appDataS3Client.getPublicUrl(club.getLogo()),
+                club.getId(),
+                recruitment.getContent(),
+                recruitment.getRecruitStart(),
+                recruitment.getRecruitEnd(),
+                RecruitStatus.from(
+                        recruitment.isAlwaysRecruiting(),
+                        recruitment.getRecruitStart(),
+                        recruitment.getRecruitEnd()
+                ),
+                recruitment.getCreatedAt(),
+                imageUrls,
+                recruitment.getRecruitForm(),
+                isFavorite,
+                club.getInstagram(),
+                club.getClubCategory(),
+                recruitment.isAlwaysRecruiting()
+        );
+    }
+
+    private RecentRecruitmentOfClubResponse emptyResponse(final Club club,
+                                                          final Boolean isFavorite) {
+        return RecentRecruitmentOfClubResponse.of(
+                null,                                     // recruitmentId
+                null,                                         // recruitmentTitle
+                club.getName(),
+                appDataS3Client.getPublicUrl(club.getLogo()),
+                club.getId(),
+                null,                                 // recruitmentContent
+                null,                                         // recruitStart
+                null,                                         // recruitEnd
+                null,                                         // recruitStatus
+                null,                                         // recruitmentCreatedAt
+                List.of(),                                    // imageUrls
+                null,                                         // recruitForm
+                isFavorite,
+                club.getInstagram(),
+                club.getClubCategory(),
+                false                                         // isAlwaysRecruiting
+        );
+    }
+
     private List<RecruitmentPreviewResponse> mapToRecruitmentResponses(Long userId,
                                                                        List<Recruitment> filteredRecruitments) {
         return filteredRecruitments.stream()
@@ -366,7 +401,9 @@ public class RecruitmentService {
         Comparator<RecruitmentPreviewResponse> comparator =
                 Comparator.comparing(
                                 (RecruitmentPreviewResponse response) ->
-                                        RecruitStatus.from(response.isAlwaysRecruiting(), response.recruitStart(), response.recruitEnd()).getPriority()
+                                        RecruitStatus.from(response.isAlwaysRecruiting(), response.recruitStart(),
+                                                        response.recruitEnd())
+                                                .getPriority()
                         )
                         .thenComparing(RecruitmentPreviewResponse::recruitEnd,
                                 Comparator.nullsLast(LocalDateTime::compareTo));

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -300,9 +300,7 @@ public class RecruitmentService {
     }
 
     private Optional<Recruitment> findRecentRecruitmentOrAlwaysRecruiting(final Long clubId) {
-        return recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(clubId)
-                .or(() -> recruitmentRepository
-                        .findTopByClubIdAndIsAlwaysRecruitingOrderByCreatedAtDesc(clubId, true));
+        return recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(clubId);
     }
 
     private RecentRecruitmentOfClubResponse toResponse(

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepository.java
@@ -29,6 +29,4 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long>,
     List<Recruitment> findAllByClubId(final Long id);
 
     Optional<Recruitment> findTopByClubIdOrderByCreatedAtDesc(Long clubId);
-
-    Optional<Recruitment> findTopByClubIdAndIsAlwaysRecruitingOrderByCreatedAtDesc(Long clubId, boolean isAlwaysRecruiting);
 }

--- a/src/test/java/com/greedy/mokkoji/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/recruitment/controller/RecruitmentControllerTest.java
@@ -341,6 +341,42 @@ public class RecruitmentControllerTest extends ControllerTest {
     }
 
     @Test
+    @DisplayName("동아리의 모집글이 없는 경우 모집글 관련 필드는 null 혹은 빈 값으로 응답한다.")
+    void getRecentRecruitmentOfClub_whenNoRecruitment_shouldReturnNullRecruitmentFields() {
+        // given
+        club = clubRepository.save(Fixture.createClub());
+        User normalUser = userRepository.save(Fixture.createUserWithRole(UserRole.NORMAL));
+        String authorizationForBearer = authorizationForBearerAccessToken(normalUser);
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .when().get(prefixUrl + "/recruitments/club/recent/{clubId}", club.getId())
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        RecentRecruitmentOfClubResponse recentRecruitmentOfClubResponse = getDataFromResponse(response, RecentRecruitmentOfClubResponse.class);
+
+        assertThat(recentRecruitmentOfClubResponse.clubId()).isEqualTo(club.getId());
+        assertThat(recentRecruitmentOfClubResponse.clubName()).isEqualTo(club.getName());
+
+        assertThat(recentRecruitmentOfClubResponse.id()).isNull();
+        assertThat(recentRecruitmentOfClubResponse.title()).isNull();
+        assertThat(recentRecruitmentOfClubResponse.content()).isNull();
+        assertThat(recentRecruitmentOfClubResponse.recruitStart()).isNull();
+        assertThat(recentRecruitmentOfClubResponse.recruitEnd()).isNull();
+        assertThat(recentRecruitmentOfClubResponse.status()).isNull();
+        assertThat(recentRecruitmentOfClubResponse.createdAt()).isNull();
+        assertThat(recentRecruitmentOfClubResponse.recruitForm()).isNull();
+        assertThat(recentRecruitmentOfClubResponse.isAlwaysRecruiting()).isFalse();
+        assertThat(recentRecruitmentOfClubResponse.imageUrls()).isEmpty();
+    }
+
+    @Test
     @DisplayName("동아리의 최신 모집글을 조회한다.")
     void getRecentRecruitmentOfClub() {
         // given

--- a/src/test/java/com/greedy/mokkoji/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/recruitment/service/RecruitmentServiceTest.java
@@ -46,6 +46,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
@@ -92,16 +93,16 @@ public class RecruitmentServiceTest {
                 .build();
         ReflectionTestUtils.setField(club, "id", 1L);
 
-        BDDMockito.given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
-        BDDMockito.given(clubRepository.findById(1L)).willReturn(Optional.of(club));
-        BDDMockito.given(recruitmentRepository.save(any(Recruitment.class)))
+        given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
+        given(clubRepository.findById(1L)).willReturn(Optional.of(club));
+        given(recruitmentRepository.save(any(Recruitment.class)))
                 .willAnswer(inv -> {
                     Recruitment recruitment = inv.getArgument(0);
                     ReflectionTestUtils.setField(recruitment, "id", 1L);
                     return recruitment;
                 });
 
-        BDDMockito.given(appDataS3Client.getPresignedPutUrl(any())).willReturn("putUrl");
+        given(appDataS3Client.getPresignedPutUrl(any())).willReturn("putUrl");
 
         // when
         CreateRecruitmentResponse createRecruitmentResponse = recruitmentService.createRecruitment(
@@ -134,7 +135,7 @@ public class RecruitmentServiceTest {
         ReflectionTestUtils.setField(normalUser, "id", 1L);
         ReflectionTestUtils.setField(normalUser, "role", UserRole.NORMAL);
 
-        BDDMockito.given(userRepository.findById(1L)).willReturn(Optional.of(normalUser));
+        given(userRepository.findById(1L)).willReturn(Optional.of(normalUser));
 
         // when, then
         Assertions.assertThatThrownBy(() -> recruitmentService.createRecruitment(
@@ -153,8 +154,8 @@ public class RecruitmentServiceTest {
         ReflectionTestUtils.setField(adminUser, "id", 1L);
         ReflectionTestUtils.setField(adminUser, "role", UserRole.CLUB_MASTER);
 
-        BDDMockito.given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
-        BDDMockito.given(clubRepository.findById(999L)).willReturn(Optional.empty());
+        given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
+        given(clubRepository.findById(999L)).willReturn(Optional.empty());
 
         // when, then
         Assertions.assertThatThrownBy(() -> recruitmentService.createRecruitment(
@@ -199,11 +200,11 @@ public class RecruitmentServiceTest {
         RecruitmentImage oldImage2 = RecruitmentImage.builder().recruitment(recruitment).image("오래된 그리디 모집글 이미지2.jpg")
                 .build();
 
-        BDDMockito.given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
-        BDDMockito.given(recruitmentRepository.findById(1L)).willReturn(Optional.of(recruitment));
-        BDDMockito.given(recruitmentImageRepository.findByRecruitmentId(1L)).willReturn(List.of(oldImage1, oldImage2));
-        BDDMockito.given(appDataS3Client.getPresignedDeleteUrl(any())).willReturn("deleteUrl");
-        BDDMockito.given(appDataS3Client.getPresignedPutUrl(any())).willReturn("putUrl");
+        given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
+        given(recruitmentRepository.findById(1L)).willReturn(Optional.of(recruitment));
+        given(recruitmentImageRepository.findByRecruitmentId(1L)).willReturn(List.of(oldImage1, oldImage2));
+        given(appDataS3Client.getPresignedDeleteUrl(any())).willReturn("deleteUrl");
+        given(appDataS3Client.getPresignedPutUrl(any())).willReturn("putUrl");
 
         // when
         UpdateRecruitmentResponse updateRecruitmentResponse = recruitmentService.updateRecruitment(
@@ -237,8 +238,8 @@ public class RecruitmentServiceTest {
         ReflectionTestUtils.setField(adminUser, "id", 1L);
         ReflectionTestUtils.setField(adminUser, "role", UserRole.CLUB_ADMIN);
 
-        BDDMockito.given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
-        BDDMockito.given(recruitmentRepository.findById(999L)).willReturn(Optional.empty());
+        given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
+        given(recruitmentRepository.findById(999L)).willReturn(Optional.empty());
 
         // when, then
         Assertions.assertThatThrownBy(() -> recruitmentService.updateRecruitment(
@@ -268,10 +269,10 @@ public class RecruitmentServiceTest {
                 .image("그리디 모집글 이미지.jpg")
                 .build();
 
-        BDDMockito.given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
-        BDDMockito.given(recruitmentRepository.findById(1L)).willReturn(Optional.of(recruitment));
-        BDDMockito.given(recruitmentImageRepository.findByRecruitmentId(1L)).willReturn(List.of(recruitmentImage));
-        BDDMockito.given(appDataS3Client.getPresignedDeleteUrl(any())).willReturn("deleteUrl");
+        given(userRepository.findById(1L)).willReturn(Optional.of(adminUser));
+        given(recruitmentRepository.findById(1L)).willReturn(Optional.of(recruitment));
+        given(recruitmentImageRepository.findByRecruitmentId(1L)).willReturn(List.of(recruitmentImage));
+        given(appDataS3Client.getPresignedDeleteUrl(any())).willReturn("deleteUrl");
 
         // when
         DeleteRecruitmentResponse result = recruitmentService.deleteRecruitment(1L, 1L);
@@ -328,7 +329,7 @@ public class RecruitmentServiceTest {
                 .image("그리디 모집글 이미지.jpg")
                 .build();
 
-        BDDMockito.given(recruitmentRepository.findAllByClubId(1L))
+        given(recruitmentRepository.findAllByClubId(1L))
                 .willReturn(List.of(olderRecruitment, newerRecruitment));
 
         // when
@@ -393,12 +394,12 @@ public class RecruitmentServiceTest {
                 .image("새 그리디 모집글 이미지.jpg")
                 .build();
 
-        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(1L))
+        given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(1L))
                 .willReturn(Optional.of(newerRecruitment));
-        BDDMockito.given(recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(2L))
+        given(recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(2L))
                 .willReturn(List.of(newerImage));
-        BDDMockito.given(appDataS3Client.getPublicUrl(any())).willAnswer(invocation -> invocation.getArgument(0));
-        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(1L, 1L)).willReturn(true);
+        given(appDataS3Client.getPublicUrl(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(favoriteRepository.existsByUserIdAndClubId(1L, 1L)).willReturn(true);
 
         // when
         RecentRecruitmentOfClubResponse recentRecruitmentOfClubResponse = recruitmentService.getRecentRecruitmentOfClub(
@@ -413,8 +414,8 @@ public class RecruitmentServiceTest {
     }
 
     @Test
-    @DisplayName("동아리 최신 모집글이 없으면 상시모집 글을 조회한다.")
-    void getRecentRecruitmentOfClub_fallbackToAlwaysRecruiting() {
+    @DisplayName("동아리 최신 모집글이 없으면 모집글 관련 필드는 null 혹은 빈 값으로 반환한다.")
+    void getRecentRecruitmentOfClub_whenNoRecruitment_shouldReturnEmptyResponse() {
         // given
         Club club = Club.builder()
                 .name("그리디")
@@ -426,30 +427,32 @@ public class RecruitmentServiceTest {
                 .build();
         ReflectionTestUtils.setField(club, "id", 1L);
 
-        Recruitment alwaysRecruitment = Recruitment.builder()
-                .club(club)
-                .title("그리디 상시 모집 제목")
-                .content("그리디 상시 모집 내용")
-                .recruitForm("그리디 상시 모집 링크")
-                .isAlwaysRecruiting(true)
-                .build();
-        ReflectionTestUtils.setField(alwaysRecruitment, "id", 1L);
-        ReflectionTestUtils.setField(alwaysRecruitment, "createdAt", LocalDateTime.of(2026, 1, 1, 0, 0));
 
-        BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(1L)).willReturn(Optional.empty());
-        BDDMockito.given(recruitmentRepository.findTopByClubIdAndIsAlwaysRecruitingOrderByCreatedAtDesc(1L, true))
-                .willReturn(Optional.of(alwaysRecruitment));
-        BDDMockito.given(recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(1L)).willReturn(List.of());
-        BDDMockito.given(appDataS3Client.getPublicUrl(any())).willAnswer(invocation -> invocation.getArgument(0));
-        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(1L, 1L)).willReturn(false);
+        given(clubRepository.findById(1L)).willReturn(Optional.of(club));
+        given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(1L)).willReturn(Optional.empty());
+        given(favoriteRepository.existsByUserIdAndClubId(1L, 1L)).willReturn(false);
+        given(appDataS3Client.getPublicUrl(any())).willAnswer(invocation -> invocation.getArgument(0));
 
         // when
-        RecentRecruitmentOfClubResponse recentRecruitmentOfClubResponse = recruitmentService.getRecentRecruitmentOfClub(
-                1L, 1L);
+        RecentRecruitmentOfClubResponse response =
+                recruitmentService.getRecentRecruitmentOfClub(1L, 1L);
 
         // then
-        assertThat(recentRecruitmentOfClubResponse.id()).isEqualTo(1L);
-        assertThat(recentRecruitmentOfClubResponse.isAlwaysRecruiting()).isTrue();
+        assertThat(response.clubId()).isEqualTo(1L);
+        assertThat(response.clubName()).isEqualTo("그리디");
+
+        assertThat(response.id()).isNull();
+        assertThat(response.title()).isNull();
+        assertThat(response.content()).isNull();
+        assertThat(response.recruitStart()).isNull();
+        assertThat(response.recruitEnd()).isNull();
+        assertThat(response.status()).isNull();
+        assertThat(response.createdAt()).isNull();
+        assertThat(response.recruitForm()).isNull();
+        assertThat(response.imageUrls()).isNotNull();
+        assertThat(response.imageUrls()).isEmpty();
+        assertThat(response.isAlwaysRecruiting()).isFalse();
+        assertThat(response.isFavorite()).isFalse();
     }
 
     @Test
@@ -480,11 +483,11 @@ public class RecruitmentServiceTest {
         RecruitmentImage recruitmentImage = RecruitmentImage.builder().recruitment(recruitment).image("그리디 모집글 이미지.jpg")
                 .build();
 
-        BDDMockito.given(recruitmentRepository.findRecruitmentById(1L)).willReturn(Optional.of(recruitment));
-        BDDMockito.given(recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(1L))
+        given(recruitmentRepository.findRecruitmentById(1L)).willReturn(Optional.of(recruitment));
+        given(recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(1L))
                 .willReturn(List.of(recruitmentImage));
-        BDDMockito.given(appDataS3Client.getPublicUrl(any())).willAnswer(invocation -> invocation.getArgument(0));
-        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(1L, 1L)).willReturn(true);
+        given(appDataS3Client.getPublicUrl(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(favoriteRepository.existsByUserIdAndClubId(1L, 1L)).willReturn(true);
 
         // when
         SpecificRecruitmentResponse specificRecruitmentResponse = recruitmentService.getSpecificRecruitment(1L, 1L);
@@ -603,21 +606,21 @@ public class RecruitmentServiceTest {
                 6
         );
 
-        BDDMockito.given(recruitmentRepository.findRecruitments(
+        given(recruitmentRepository.findRecruitments(
                         filteringByAffiliation,
                         filteringByCategory,
                         pageable
                 ))
                 .willReturn(page);
 
-        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, 1L)).willReturn(true);
-        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, 2L)).willReturn(false);
-        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, 3L)).willReturn(false);
-        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, 4L)).willReturn(false);
-        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, 5L)).willReturn(false);
-        BDDMockito.given(favoriteRepository.existsByUserIdAndClubId(userId, 6L)).willReturn(false);
+        given(favoriteRepository.existsByUserIdAndClubId(userId, 1L)).willReturn(true);
+        given(favoriteRepository.existsByUserIdAndClubId(userId, 2L)).willReturn(false);
+        given(favoriteRepository.existsByUserIdAndClubId(userId, 3L)).willReturn(false);
+        given(favoriteRepository.existsByUserIdAndClubId(userId, 4L)).willReturn(false);
+        given(favoriteRepository.existsByUserIdAndClubId(userId, 5L)).willReturn(false);
+        given(favoriteRepository.existsByUserIdAndClubId(userId, 6L)).willReturn(false);
 
-        BDDMockito.given(appDataS3Client.getPublicUrl(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(appDataS3Client.getPublicUrl(any())).willAnswer(invocation -> invocation.getArgument(0));
 
         // when
         AllRecruitmentResponse allRecruitmentResponse = recruitmentService.getAllRecruitment(


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #361 

## 👷 **작업한 내용**
회의에서 합의한 내용에 따라 다음과 같은 작업을 진행했습니다.
[기존] 특정 동아리의 최신 모집글 조회 API에서 모집글이 존재하지 않을 시 404 예외를 던져 응답을 하였습니다.
[변경] 특정 동아리의 모집글이 존재하지 않는 경우 예외를 던지지 않고, 모집글 관련 필드에 null 혹은 빈 값으로 응답을 내려 프론트에서 요구한 요구사항을 처리하였습니다.

+ 로직 수정에 따른 테스트 코드도 추가하였습니다~!

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
