### PR TITLE
Fix: 동아리 수정 시 동아리 id 응답 필드 추가

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubUpdateResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubUpdateResponse.java
@@ -5,10 +5,11 @@ import lombok.Builder;
 
 @Builder
 public record ClubUpdateResponse(
+        @Schema(example = "1") Long id,
         @Schema(example = "https://mokkoji-app-data.s3.ap-northeast-2.amazonaws.com/club-logo/1/greedy_logo_{UUID}.jpg") String updateLogo,
         @Schema(example = "https://mokkoji-app-data.s3.ap-northeast-2.amazonaws.com/club-logo/1/old_logo_{UUID}.jpg") String deleteLogo
 ) {
-    public static ClubUpdateResponse of(String updateLogo, String deleteLogo) {
-        return new ClubUpdateResponse(updateLogo, deleteLogo);
+    public static ClubUpdateResponse of(Long id, String updateLogo, String deleteLogo) {
+        return new ClubUpdateResponse(id, updateLogo, deleteLogo);
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -170,7 +170,7 @@ public class ClubService {
         String updateLogo = generatePresignedPutUrl(newLogoKey);
         String deleteLogo = generatePresignedDeleteUrl(newLogoKey, oldLogoKey);
 
-        return ClubUpdateResponse.of(updateLogo, deleteLogo);
+        return ClubUpdateResponse.of(clubId, updateLogo, deleteLogo);
     }
 
     private Set<Long> loadFavoriteClubIds(Long userId) {

--- a/src/test/java/com/greedy/mokkoji/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/club/controller/ClubControllerTest.java
@@ -296,6 +296,7 @@ public class ClubControllerTest extends ControllerTest {
         ClubUpdateResponse actual = getDataFromResponse(response, ClubUpdateResponse.class);
 
         assertThat(statusCode).isEqualTo(HttpStatus.OK.value());
+        assertThat(actual.id()).isEqualTo(managedClub.getId());
         assertThat(actual.updateLogo()).isEqualTo("presignedPutUrl");
         assertThat(actual.deleteLogo()).isEqualTo("presignedDeleteUrl");
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #363 

## 👷 **작업한 내용**
동아리 수정 시 해당 동아리로 리다이렉트 하기 위해
동아리 수정 API에 동아리 id 필드를 추가하였습니다.
응답 포맷 변경에 따라 테스트 코드도 수정하였습니다~!

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
