### PR TITLE
Feat/#375 : 이메일 삭제로직 추가

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
@@ -61,7 +61,7 @@ public class UserController implements UserControllerSwagger {
         return APISuccessResponse.of(HttpStatus.OK, userInformationResponse);
     }
 
-    @PutMapping
+    @PatchMapping
     public ResponseEntity<APISuccessResponse<Void>> updateUserInformation(
             @Authentication AuthCredential authCredential,
             @RequestBody @Valid UpdateUserInformationRequest updateUserInformationRequest

--- a/src/main/java/com/greedy/mokkoji/api/user/dto/request/UpdateUserInformationRequest.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/dto/request/UpdateUserInformationRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Pattern;
 public record UpdateUserInformationRequest(
         @Schema(example = "user@sejong.ac.kr")
         @Pattern(
-                regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$",
+                regexp = "(^$)|(^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$)",
                 message = "유효하지 않은 이메일 형식입니다."
         )
         String email,

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -34,49 +34,38 @@ public class UserService {
     @Transactional
     public User login(final String studentId, final String password) {
 
-        final StudentInformationResponse studentInformationResponse = sejongLoginClient.getStudentInformation(studentId,
-                password);
+        final StudentInformationResponse studentInformationResponse = sejongLoginClient.getStudentInformation(studentId, password);
 
         final UserRole role = determineUserRole(studentId);
 
-        return userRepository.findByStudentId(studentId)
-                .map(user -> {
-                    user.updateRole(role);
-                    return user;
-                }).orElseGet(() -> {
-                    final User newUser = User.builder()
-                            .studentId(studentId)
-                            .name(studentInformationResponse.name())
-                            .department(studentInformationResponse.department())
-                            .grade(studentInformationResponse.grade())
-                            .role(role)
-                            .isEmailOn(true)
-                            .build();
+        return userRepository.findByStudentId(studentId).map(user -> {
+            user.updateRole(role);
+            return user;
+        }).orElseGet(() -> {
+            final User newUser = User.builder().studentId(studentId).name(studentInformationResponse.name()).department(studentInformationResponse.department()).grade(studentInformationResponse.grade()).role(role).isEmailOn(true).build();
 
-                    return userRepository.save(newUser);
-                });
+            return userRepository.save(newUser);
+        });
     }
 
     private UserRole determineUserRole(final String studentId) {
-        return userRepository.findByStudentId(studentId)
-                .map(user -> {
-                    if (user.getRole() == UserRole.GREEDY_ADMIN) {
-                        return UserRole.GREEDY_ADMIN;
-                    }
-                    if (user.getRole() == UserRole.CLUB_ADMIN) {
-                        return UserRole.CLUB_ADMIN;
-                    }
-                    if (clubRepository.existsByClubMasterStudentId(studentId)) {
-                        return UserRole.CLUB_MASTER;
-                    }
-                    return UserRole.NORMAL;
-                })
-                .orElseGet(() -> {
-                    if (clubRepository.existsByClubMasterStudentId(studentId)) {
-                        return UserRole.CLUB_MASTER;
-                    }
-                    return UserRole.NORMAL;
-                });
+        return userRepository.findByStudentId(studentId).map(user -> {
+            if (user.getRole() == UserRole.GREEDY_ADMIN) {
+                return UserRole.GREEDY_ADMIN;
+            }
+            if (user.getRole() == UserRole.CLUB_ADMIN) {
+                return UserRole.CLUB_ADMIN;
+            }
+            if (clubRepository.existsByClubMasterStudentId(studentId)) {
+                return UserRole.CLUB_MASTER;
+            }
+            return UserRole.NORMAL;
+        }).orElseGet(() -> {
+            if (clubRepository.existsByClubMasterStudentId(studentId)) {
+                return UserRole.CLUB_MASTER;
+            }
+            return UserRole.NORMAL;
+        });
     }
 
     @Transactional
@@ -95,7 +84,9 @@ public class UserService {
     public void updateUserInformation(Long userId, String email, Boolean isEmailOn) {
         User user = findUser(userId);
 
-        if (email != null) {
+        if (email.equals("")) {
+            user.updateEmail(null);
+        } else if (email != null) {
             user.updateEmail(email);
         }
 
@@ -106,8 +97,7 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public User findUser(final Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+        return userRepository.findById(userId).orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
     }
 
     @Transactional
@@ -117,24 +107,18 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserRoleResponse getUserRole(final Long userId) {
-        final User user = userRepository.findById(userId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+        final User user = userRepository.findById(userId).orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
 
-        return UserRoleResponse.of(
-                user.getRole()
-        );
+        return UserRoleResponse.of(user.getRole());
     }
 
     @Transactional
     public UserManageClubsResponse getUserManageClubs(final Long userId) {
-        final User user = userRepository.findById(userId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+        final User user = userRepository.findById(userId).orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
 
         String studentId = user.getStudentId();
 
-        List<UserManageClubResponse> clubs = clubRepository.findByClubMasterStudentId(studentId).stream()
-                .map(club -> new UserManageClubResponse(club.getId(), club.getName()))
-                .toList();
+        List<UserManageClubResponse> clubs = clubRepository.findByClubMasterStudentId(studentId).stream().map(club -> new UserManageClubResponse(club.getId(), club.getName())).toList();
 
         return UserManageClubsResponse.of(clubs);
     }

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -42,7 +42,14 @@ public class UserService {
             user.updateRole(role);
             return user;
         }).orElseGet(() -> {
-            final User newUser = User.builder().studentId(studentId).name(studentInformationResponse.name()).department(studentInformationResponse.department()).grade(studentInformationResponse.grade()).role(role).isEmailOn(true).build();
+            final User newUser = User.builder()
+                    .studentId(studentId)
+                    .name(studentInformationResponse.name())
+                    .department(studentInformationResponse.department())
+                    .grade(studentInformationResponse.grade())
+                    .role(role)
+                    .isEmailOn(true)
+                    .build();
 
             return userRepository.save(newUser);
         });
@@ -118,7 +125,9 @@ public class UserService {
 
         String studentId = user.getStudentId();
 
-        List<UserManageClubResponse> clubs = clubRepository.findByClubMasterStudentId(studentId).stream().map(club -> new UserManageClubResponse(club.getId(), club.getName())).toList();
+        List<UserManageClubResponse> clubs = clubRepository.findByClubMasterStudentId(studentId).stream()
+                .map(club -> new UserManageClubResponse(club.getId(), club.getName()))
+                .toList();
 
         return UserManageClubsResponse.of(clubs);
     }

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -104,7 +104,8 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public User findUser(final Long userId) {
-        return userRepository.findById(userId).orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
     }
 
     @Transactional
@@ -114,7 +115,8 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserRoleResponse getUserRole(final Long userId) {
-        final User user = userRepository.findById(userId).orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
 
         return UserRoleResponse.of(user.getRole());
     }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #374 

## 👷 **작업한 내용**
기존 방식 :
이메일을 바꿀 때, 이메일 형식이 아닌 값이 들어오면 에러 발생

수정 방식 :
이메일을 바꿀 때, ""과 같은 빈 값이 들어올 경우에는, 에러를 발생시키지 않음

현재 로직 :
`UpdateUserInformationRequest`에
1. email필드가 없을 때 : 이메일은 바뀌지 않음
2. email값이 ""로 들어올 때 : 이메일은 null로 바뀜, 즉 삭제됨
3. email값이 이메일 형식으로 들어올 때 : 이메일 업데이트 됨

## 🚨 **참고 사항**
* 사용자 정보 수정 api에는 PUT 보다는 PATCH 메서드가 더 적절할 거 같아 수정하였습니다.
