### PR TITLE
Feat: 마이페이지 댓글 조회 기능 구현

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/comment/controller/CommentController.java
+++ b/src/main/java/com/greedy/mokkoji/api/comment/controller/CommentController.java
@@ -5,6 +5,7 @@ import com.greedy.mokkoji.api.auth.controller.argumentResolver.Authentication;
 import com.greedy.mokkoji.api.comment.dto.request.CommentCreateRequest;
 import com.greedy.mokkoji.api.comment.dto.request.CommentUpdateRequest;
 import com.greedy.mokkoji.api.comment.dto.response.CommentListResponse;
+import com.greedy.mokkoji.api.comment.dto.response.MyCommentListResponse;
 import com.greedy.mokkoji.api.comment.service.CommentService;
 import com.greedy.mokkoji.common.response.APISuccessResponse;
 import jakarta.validation.Valid;
@@ -43,6 +44,16 @@ public class CommentController implements CommentControllerSwagger {
         return APISuccessResponse.of(
                 HttpStatus.OK,
                 commentService.getComments(authCredential.userId(), clubId)
+        );
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<APISuccessResponse<MyCommentListResponse>> getAllMyComments(
+            @Authentication final AuthCredential authCredential
+    ) {
+        return APISuccessResponse.of(
+                HttpStatus.OK,
+                commentService.getAllMyComments(authCredential.userId())
         );
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/comment/controller/CommentControllerSwagger.java
+++ b/src/main/java/com/greedy/mokkoji/api/comment/controller/CommentControllerSwagger.java
@@ -4,6 +4,7 @@ import com.greedy.mokkoji.api.auth.controller.argumentResolver.AuthCredential;
 import com.greedy.mokkoji.api.comment.dto.request.CommentCreateRequest;
 import com.greedy.mokkoji.api.comment.dto.request.CommentUpdateRequest;
 import com.greedy.mokkoji.api.comment.dto.response.CommentListResponse;
+import com.greedy.mokkoji.api.comment.dto.response.MyCommentListResponse;
 import com.greedy.mokkoji.common.response.APISuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -42,6 +43,15 @@ public interface CommentControllerSwagger {
     )
     ResponseEntity<APISuccessResponse<CommentListResponse>> getComments(
             @Parameter(name = "clubId", description = "조회할 동아리 ID", in = ParameterIn.PATH) Long clubId,
+            @Parameter(hidden = true) AuthCredential authCredential
+    );
+
+    @Operation(
+            summary = "마이페이지 댓글 목록 조회 API",
+            security = @SecurityRequirement(name = "JWT")
+    )
+    @ApiResponse(responseCode = "200", description = "마이페이지 댓글 목록 조회 성공")
+    ResponseEntity<APISuccessResponse<MyCommentListResponse>> getAllMyComments(
             @Parameter(hidden = true) AuthCredential authCredential
     );
 

--- a/src/main/java/com/greedy/mokkoji/api/comment/dto/response/MyCommentListResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/comment/dto/response/MyCommentListResponse.java
@@ -1,0 +1,11 @@
+package com.greedy.mokkoji.api.comment.dto.response;
+
+import java.util.List;
+
+public record MyCommentListResponse(
+        List<MyCommentResponse> comments
+) {
+    public static MyCommentListResponse of(final List<MyCommentResponse> comments) {
+        return new MyCommentListResponse(comments);
+    }
+}

--- a/src/main/java/com/greedy/mokkoji/api/comment/dto/response/MyCommentResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/comment/dto/response/MyCommentResponse.java
@@ -1,0 +1,17 @@
+package com.greedy.mokkoji.api.comment.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record MyCommentResponse(
+        @Schema(example = "1") Long commentId,
+        @Schema(example = "1") Long clubId,
+        @Schema(example = "그리디") String name,
+        @Schema(example = "개발 생태계에 선한 영향력을") String description,
+        @Schema(example = "2025-08-22T00:00:00") LocalDateTime createdAt
+) {
+    public static MyCommentResponse of(final Long commentId, final Long clubId, final String name, final String description, final LocalDateTime createdAt) {
+        return new MyCommentResponse(commentId, clubId, name, description, createdAt);
+    }
+}

--- a/src/main/java/com/greedy/mokkoji/api/comment/service/CommentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/comment/service/CommentService.java
@@ -2,6 +2,8 @@ package com.greedy.mokkoji.api.comment.service;
 
 import com.greedy.mokkoji.api.comment.dto.response.CommentListResponse;
 import com.greedy.mokkoji.api.comment.dto.response.CommentResponse;
+import com.greedy.mokkoji.api.comment.dto.response.MyCommentListResponse;
+import com.greedy.mokkoji.api.comment.dto.response.MyCommentResponse;
 import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.club.repository.ClubRepository;
@@ -70,6 +72,27 @@ public class CommentService {
                                 !comment.getCreatedAt().equals(comment.getUpdatedAt()) ? comment.getUpdatedAt() : comment.getCreatedAt(),
                                 isCommentWriter(userId, comment)
                         )).toList()
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public MyCommentListResponse getAllMyComments(final Long userId) {
+        final User user = userRepository.findById(userId).orElseThrow(
+                () -> new MokkojiException(FailMessage.NOT_FOUND_USER)
+        );
+
+        final List<Comment> myComments = commentRepository.findAllByUser(user);
+
+        return MyCommentListResponse.of(
+                myComments.stream()
+                        .map(comment -> MyCommentResponse.of(
+                                comment.getId(),
+                                comment.getClub().getId(),
+                                comment.getClub().getName(),
+                                comment.getClub().getDescription(),
+                                comment.getCreatedAt()
+                        ))
+                        .toList()
         );
     }
 

--- a/src/main/java/com/greedy/mokkoji/db/comment/repository/CommentRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/comment/repository/CommentRepository.java
@@ -10,5 +10,7 @@ import java.util.List;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByClub(final Club club);
 
+    List<Comment> findAllByUser(final User user);
+
     boolean existsByClubAndUser(final Club club, final User user);
 }

--- a/src/main/java/com/greedy/mokkoji/db/comment/repository/CommentRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/comment/repository/CommentRepository.java
@@ -4,12 +4,14 @@ import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.comment.entity.Comment;
 import com.greedy.mokkoji.db.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByClub(final Club club);
 
+    @Query("SELECT c FROM Comment c JOIN FETCH c.club WHERE c.user = :user")
     List<Comment> findAllByUser(final User user);
 
     boolean existsByClubAndUser(final Club club, final User user);

--- a/src/test/java/com/greedy/mokkoji/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/comment/controller/CommentControllerTest.java
@@ -4,6 +4,8 @@ import com.greedy.mokkoji.api.comment.dto.request.CommentCreateRequest;
 import com.greedy.mokkoji.api.comment.dto.request.CommentUpdateRequest;
 import com.greedy.mokkoji.api.comment.dto.response.CommentListResponse;
 import com.greedy.mokkoji.api.comment.dto.response.CommentResponse;
+import com.greedy.mokkoji.api.comment.dto.response.MyCommentListResponse;
+import com.greedy.mokkoji.api.comment.dto.response.MyCommentResponse;
 import com.greedy.mokkoji.common.ControllerTest;
 import com.greedy.mokkoji.common.fixture.Fixture;
 import com.greedy.mokkoji.common.response.APIErrorResponse;
@@ -30,6 +32,7 @@ public class CommentControllerTest extends ControllerTest {
     private User user;
     private User anotherUser;
     private Club club;
+    private Club anotherClub;
 
     @BeforeEach
     void setUp() {
@@ -45,6 +48,7 @@ public class CommentControllerTest extends ControllerTest {
         user = userRepository.save(Fixture.createUser());
         anotherUser = userRepository.save(Fixture.createAnotherUser());
         club = clubRepository.save(Fixture.createClub());
+        anotherClub = clubRepository.save(Fixture.createAnotherClub());
     }
 
     @Test
@@ -154,6 +158,53 @@ public class CommentControllerTest extends ControllerTest {
                 .containsExactlyInAnyOrder(
                         Tuple.tuple("좋은 동아리입니다", 5.0, true),
                         Tuple.tuple("추천합니다", 4.0, false)
+                );
+    }
+
+    @Test
+    @DisplayName("자신이 작성한 동아리의 댓글 목록을 조회할 수 있다.")
+    void getAllMyComments() {
+        //given
+        final Comment comment1 = Comment.builder()
+                .user(user)
+                .club(club)
+                .rate(5.0)
+                .content("좋은 동아리입니다")
+                .build();
+        final Comment comment2 = Comment.builder()
+                .user(user)
+                .club(anotherClub)
+                .rate(4.0)
+                .content("추천합니다")
+                .build();
+        commentRepository.save(comment1);
+        commentRepository.save(comment2);
+
+        String authorizationForBearer = authorizationForBearerAccessToken(user);
+
+        //when
+        final ExtractableResponse<Response> response = given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .when().get(prefixUrl + "/comments/my")
+
+                .then().log().all()
+                .extract();
+
+        //then
+        final int statusCode = response.statusCode();
+        final MyCommentListResponse actual = getDataFromResponse(response, MyCommentListResponse.class);
+
+        assertThat(statusCode).isEqualTo(HttpStatus.OK.value());
+        assertThat(actual.comments()).hasSize(2);
+        assertThat(actual.comments())
+                .extracting(
+                        MyCommentResponse::name,
+                        MyCommentResponse::description
+                )
+                .containsExactlyInAnyOrder(
+                        Tuple.tuple(club.getName(), club.getDescription()),
+                        Tuple.tuple(anotherClub.getName(), anotherClub.getDescription())
                 );
     }
 

--- a/src/test/java/com/greedy/mokkoji/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/comment/service/CommentServiceTest.java
@@ -1,6 +1,7 @@
 package com.greedy.mokkoji.comment.service;
 
 import com.greedy.mokkoji.api.comment.dto.response.CommentListResponse;
+import com.greedy.mokkoji.api.comment.dto.response.MyCommentListResponse;
 import com.greedy.mokkoji.api.comment.service.CommentService;
 import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.db.club.entity.Club;
@@ -161,6 +162,59 @@ public class CommentServiceTest {
 
         BDDMockito.verify(clubRepository, times(1)).findById(clubId);
         BDDMockito.verify(commentRepository, times(1)).findAllByClub(club);
+    }
+
+    @Test
+    @DisplayName("자신이 작성한 댓글 목록을 조회한다")
+    void getAllMyComments() {
+        //given
+        final Long userId = 1L;
+        final Long clubId1 = 1L;
+        final Long clubId2 = 2L;
+
+        final User user = User.builder().build();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        final Club club1 = Club.builder().build();
+        ReflectionTestUtils.setField(club1, "id", clubId1);
+
+        final Club club2 = Club.builder().build();
+        ReflectionTestUtils.setField(club2, "id", clubId2);
+
+        final Comment comment1 = Comment.builder()
+                .user(user)
+                .club(club1)
+                .rate(5.0)
+                .content("좋은 동아리입니다")
+                .build();
+        ReflectionTestUtils.setField(comment1, "id", 1L);
+        ReflectionTestUtils.setField(comment1, "createdAt", LocalDateTime.of(2025, 11, 1, 10, 0));
+        ReflectionTestUtils.setField(comment1, "updatedAt", LocalDateTime.of(2025, 11, 1, 10, 0));
+
+        final Comment comment2 = Comment.builder()
+                .user(user)
+                .club(club2)
+                .rate(4.0)
+                .content("추천합니다")
+                .build();
+        ReflectionTestUtils.setField(comment2, "id", 2L);
+        ReflectionTestUtils.setField(comment2, "createdAt", LocalDateTime.of(2025, 11, 2, 10, 0));
+        ReflectionTestUtils.setField(comment2, "updatedAt", LocalDateTime.of(2025, 11, 2, 10, 0));
+
+        BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        BDDMockito.given(commentRepository.findAllByUser(user)).willReturn(List.of(comment1, comment2));
+
+        //when
+        MyCommentListResponse response = commentService.getAllMyComments(userId);
+
+        //then
+        assertThat(response.comments()).hasSize(2);
+        assertThat(response.comments())
+                .extracting("commentId")
+                .containsExactlyInAnyOrder(1L, 2L);
+
+        BDDMockito.verify(userRepository, times(1)).findById(userId);
+        BDDMockito.verify(commentRepository, times(1)).findAllByUser(user);
     }
 
     @Test

--- a/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
+++ b/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
@@ -60,6 +60,18 @@ public class Fixture {
                 .build();
     }
 
+    public static Club createAnotherClub() {
+        return Club.builder()
+                .name("En#")
+                .clubCategory(ClubCategory.ACADEMIC_CULTURAL)
+                .clubAffiliation(ClubAffiliation.DEPARTMENT_CLUB)
+                .logo(FIXTURE_CLUB_LOGO)
+                .description("커리큘럼이 체계적인 코딩 동아리")
+                .instagram("www.En#.com")
+                .clubMasterStudentId("56785678")
+                .build();
+    }
+
     public static Club createClubWithCategoryAndAffiliation(ClubCategory category, ClubAffiliation affiliation) {
         return Club.builder()
                 .name("그리디")


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #379 

## 👷 **작업한 내용**
1. 마이페이지에서 사용자가 작성한 댓글 목록을 조회할 수 있는 API를 구현하였습니다.
2. 해당 API에 대한 스웨거를 적용했습니다.
3. 해당 API에 대한 Controller 및 Service 테스트 코드를 작성했습니다.

---
디자이너 및 프론트분과 합의된 표시 정보는 다음과 같습니다.
- 댓글ID
- 동아리ID
- 동아리 소개글
- 댓글 작성일
혹시 더 필요하다고 생각되시는 정보나 추가 의견이 있으시다면 코멘트 달아주시면 논의 후 반영해보겠습니다~!

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
