### PR TITLE
Feat: 학교 엔티티 추가 및 기존 엔티티들과 연관관계 정의

### DIFF
--- a/src/main/java/com/greedy/mokkoji/db/university/entity/University.java
+++ b/src/main/java/com/greedy/mokkoji/db/university/entity/University.java
@@ -1,0 +1,38 @@
+package com.greedy.mokkoji.db.university.entity;
+
+import com.greedy.mokkoji.db.BaseTime;
+import com.greedy.mokkoji.enums.university.UniversityCode;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "university")
+public class University extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", columnDefinition = "bigint", nullable = false)
+    private Long id;
+
+    @Column(name = "name", columnDefinition = "varchar(100)", nullable = false)
+    private String name;
+
+    @Column(name = "code", columnDefinition = "varchar(50)", nullable = false, unique = true)
+    @Enumerated(EnumType.STRING)
+    private UniversityCode code;
+
+    @Column(name = "logo", columnDefinition = "text")
+    private String logo;
+
+    @Builder
+    public University(String name, UniversityCode code, String logo) {
+        this.name = name;
+        this.code = code;
+        this.logo = logo;
+    }
+}

--- a/src/main/java/com/greedy/mokkoji/db/university/repository/UniversityRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/university/repository/UniversityRepository.java
@@ -1,0 +1,11 @@
+package com.greedy.mokkoji.db.university.repository;
+
+import com.greedy.mokkoji.db.university.entity.University;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface UniversityRepository extends JpaRepository<University, Long> {
+
+}

--- a/src/main/java/com/greedy/mokkoji/db/user/entity/User.java
+++ b/src/main/java/com/greedy/mokkoji/db/user/entity/User.java
@@ -1,5 +1,7 @@
 package com.greedy.mokkoji.db.user.entity;
 
+import com.greedy.mokkoji.db.BaseTime;
+import com.greedy.mokkoji.db.university.entity.University;
 import com.greedy.mokkoji.enums.user.UserRole;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -11,44 +13,41 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "`user`")
-public class User {
+public class User extends BaseTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", columnDefinition = "bigint", nullable = false)
     private Long id;
 
-    @Column(name = "student_id", columnDefinition = "varchar(20)", nullable = true)
-    private String studentId;
+    @JoinColumn(name = "university_id", columnDefinition = "bigint", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private University university;
 
-    @Column(name = "name", columnDefinition = "varchar(50)", nullable = true)
+    @Column(name = "kakao_id", columnDefinition = "varchar(50)", nullable = false, unique = true)
+    private String kakaoId;
+
+    @Column(name = "name", columnDefinition = "varchar(50)")
     private String name;
 
-    @Column(name = "department", columnDefinition = "varchar(50)", nullable = true)
-    private String department;
-
-    @Column(name = "grade", columnDefinition = "varchar(10)", nullable = true)
-    private String grade;
-
-    @Column(name = "email", columnDefinition = "varchar(50)", nullable = true)
+    @Column(name = "email", columnDefinition = "varchar(50)")
     private String email;
-
-    @Column(name = "role", columnDefinition = "varchar(50)", nullable = true)
-    @Enumerated(EnumType.STRING)
-    private UserRole role;
 
     @Column(name = "is_email_on", columnDefinition = "BOOLEAN", nullable = false)
     private boolean isEmailOn;
 
+    @Column(name = "role", columnDefinition = "varchar(50)", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
+
     @Builder
-    public User(String studentId, String name, String department, String grade, String email, UserRole role, boolean isEmailOn) {
-        this.studentId = studentId;
+    public User(University university, String kakaoId, String name, String email, boolean isEmailOn, UserRole role) {
+        this.university = university;
+        this.kakaoId = kakaoId;
         this.name = name;
-        this.department = department;
-        this.grade = grade;
         this.email = email;
-        this.role = role;
         this.isEmailOn = isEmailOn;
+        this.role = role;
     }
 
     public void updateEmail(String email) {

--- a/src/main/java/com/greedy/mokkoji/enums/university/UniversityCode.java
+++ b/src/main/java/com/greedy/mokkoji/enums/university/UniversityCode.java
@@ -1,0 +1,15 @@
+package com.greedy.mokkoji.enums.university;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UniversityCode {
+    SEJONG("세종대학교"),
+    KONKUK("건국대학교"),
+    HANYANG("한양대학교"),
+    NO_CHOSEN("선택 안 함");
+
+    private final String universityName;
+}

--- a/src/main/java/com/greedy/mokkoji/enums/university/UniversityCode.java
+++ b/src/main/java/com/greedy/mokkoji/enums/university/UniversityCode.java
@@ -6,10 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum UniversityCode {
-    SEJONG("세종대학교"),
-    KONKUK("건국대학교"),
-    HANYANG("한양대학교"),
-    NO_CHOSEN("선택 안 함");
-
-    private final String universityName;
+    SEJONG,
+    KONKUK,
+    HANYANG,
+    NO_CHOSEN;
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #385 

## 👷 **작업한 내용**
1. 교외 확장 기능을 위한 `University` 엔티티를 추가했습니다.
2. 학교 정보를 식별하기 위한 `UniversityCode` enum을 추가했습니다.
    회의 내용을 기반으로 서비스 하기로 결정한 대학교 몇 개만 추가해놓았습니다.

>   `SEJONG`
>   `KONKUK`
>   `HANYANG`
>   `NO_CHOSEN`

3. `UniversityRepository`를 추가했습니다.
4. 최종 DB 설계안을 바탕으로 `User` 엔티티와 `University` 엔티티 간 연관관계를 정의했습니다.
5. 카카오 로그인 구조에 맞춰 `User` 엔티티를 수정했습니다.

>   a. `kakaoId` 필드 추가
>   b. 기존 학번, 학과, 학년 관련 필드 제거
>   c. `BaseTime` 상속 추가

## 🚨 **참고 사항**
- 이번 PR은 교외 확장 기능 적용을 위한 공통 엔티티 및 연관관계 정의 작업입니다.
- 실제 DB 스키마 변경은 추후 API 작업 시 최종 설계안에 맞춰 반영할 예정입니다. 
   아직 엔티티 작업 밖에 안 한 거라, 지금 해놓으면 에러가 발생할텐데 그럼에도 지금 반영해놓는 게 좋을지? 반영 시점에 대한 의견 부탁드립니다!!