### PR TITLE
Feat: Club 엔티티 University 연관관계 추가 및 Repository university 필터링 추가

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/club/controller/ClubController.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/controller/ClubController.java
@@ -14,12 +14,21 @@ import com.greedy.mokkoji.api.club.service.ClubService;
 import com.greedy.mokkoji.common.response.APISuccessResponse;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
+import com.greedy.mokkoji.enums.university.UniversityCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,6 +52,7 @@ public class ClubController implements ClubControllerSwagger {
     public ResponseEntity<APISuccessResponse<ClubsPaginationResponse>> getClubs(
             @Authentication final AuthCredential authCredential,
             @ModelAttribute(value = "clubSearchCond") final ClubSearchCond clubSearchCond,
+            @RequestParam(value = "universityCode") final UniversityCode universityCode,
             @RequestParam(value = "page") final int page,
             @RequestParam(value = "size") final int size
     ) {
@@ -51,6 +61,7 @@ public class ClubController implements ClubControllerSwagger {
                 HttpStatus.OK,
                 clubService.findClubsByConditions(
                         authCredential.userId(),
+                        universityCode,
                         clubSearchCond.keyword(),
                         clubSearchCond.category(),
                         clubSearchCond.affiliation(),
@@ -63,6 +74,7 @@ public class ClubController implements ClubControllerSwagger {
     @GetMapping
     public ResponseEntity<APISuccessResponse<AllClubsResponse>> getAllClubs(
             @Authentication final AuthCredential authCredential,
+            @RequestParam(value = "universityCode") final UniversityCode universityCode,
             @RequestParam(value = "keyword", required = false) final String keyword,
             @RequestParam(value = "affiliation", required = false) final ClubAffiliation affiliation,
             @RequestParam(value = "category", required = false) final ClubCategory category,
@@ -72,7 +84,7 @@ public class ClubController implements ClubControllerSwagger {
         final Pageable pageable = PageRequest.of(page - 1, size);
         return APISuccessResponse.of(
                 HttpStatus.OK,
-                clubService.getAllClubs(authCredential.userId(), keyword, affiliation, category, pageable)
+                clubService.getAllClubs(authCredential.userId(), universityCode, keyword, affiliation, category, pageable)
         );
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/club/controller/ClubController.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/controller/ClubController.java
@@ -99,7 +99,8 @@ public class ClubController implements ClubControllerSwagger {
                 clubCreateRequest.name(),
                 clubCreateRequest.category(),
                 clubCreateRequest.affiliation(),
-                clubCreateRequest.clubMasterStudentId()
+                clubCreateRequest.clubMasterStudentId(),
+                clubCreateRequest.universityCode()
         );
         return APISuccessResponse.of(HttpStatus.CREATED, null);
     }

--- a/src/main/java/com/greedy/mokkoji/api/club/controller/ClubControllerSwagger.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/controller/ClubControllerSwagger.java
@@ -12,6 +12,7 @@ import com.greedy.mokkoji.api.club.dto.response.allClubs.AllClubsResponse;
 import com.greedy.mokkoji.common.response.APISuccessResponse;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
+import com.greedy.mokkoji.enums.university.UniversityCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -41,6 +42,7 @@ public interface ClubControllerSwagger {
     ResponseEntity<APISuccessResponse<ClubsPaginationResponse>> getClubs(
             @Parameter(hidden = true) AuthCredential authCredential,
             @Parameter(name = "clubSearchCond", description = "검색 조건") ClubSearchCond clubSearchCond,
+            @Parameter(name = "universityCode", description = "대학교 코드") UniversityCode universityCode,
             @Parameter(name = "page", description = "페이지 번호") int page,
             @Parameter(name = "size", description = "페이지 크기") int size
     );
@@ -84,6 +86,7 @@ public interface ClubControllerSwagger {
     @ApiResponse(responseCode = "200", description = "조회 성공")
     ResponseEntity<APISuccessResponse<AllClubsResponse>> getAllClubs(
             @Parameter(hidden = true) AuthCredential authCredential,
+            @Parameter(name = "universityCode", description = "대학교 코드") UniversityCode universityCode,
             @Parameter(name = "keyword", description = "검색 키워드") String keyword,
             @Parameter(name = "affiliation") ClubAffiliation affiliation,
             @Parameter(name = "category") ClubCategory category,

--- a/src/main/java/com/greedy/mokkoji/api/club/dto/request/ClubCreateRequest.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/request/ClubCreateRequest.java
@@ -2,12 +2,14 @@ package com.greedy.mokkoji.api.club.dto.request;
 
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
+import com.greedy.mokkoji.enums.university.UniversityCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record ClubCreateRequest(
         @Schema(example = "그리디") String name,
         @Schema(example = "ACADEMIC_CULTURAL") ClubCategory category,
         @Schema(example = "DEPARTMENT_CLUB") ClubAffiliation affiliation,
-        @Schema(example = "12345678") String clubMasterStudentId
+        @Schema(example = "12345678") String clubMasterStudentId,
+        @Schema(example = "SEJONG") UniversityCode universityCode
 ) {
 }

--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubResponse.java
@@ -3,6 +3,7 @@ package com.greedy.mokkoji.api.club.dto.response;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
+import com.greedy.mokkoji.enums.university.UniversityCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -21,7 +22,9 @@ public record ClubResponse(
         @Schema(example = "false") Boolean isAlwaysRecruiting,
         @Schema(example = "OPEN") RecruitStatus recruitStatus,
         @Schema(example = "https://mokkoji-app-data.s3.ap-northeast-2.amazonaws.com/club-logo/1/greedy_{UUID}.jpg") String logo,
-        @Schema(example = "true") Boolean isFavorite
+        @Schema(example = "true") Boolean isFavorite,
+        @Schema(example = "세종대학교") String universityName,
+        @Schema(example = "SEJONG") UniversityCode universityCode
 ) {
     public static ClubResponse of(
             final Long id,
@@ -34,7 +37,9 @@ public record ClubResponse(
             final Boolean isAlwaysRecruiting,
             final RecruitStatus recruitStatus,
             final String logo,
-            final Boolean isFavorite) {
+            final Boolean isFavorite,
+            final String universityName,
+            final UniversityCode universityCode) {
 
         return ClubResponse.builder()
                 .id(id)
@@ -48,6 +53,8 @@ public record ClubResponse(
                 .recruitStatus(recruitStatus)
                 .logo(logo)
                 .isFavorite(isFavorite)
+                .universityName(universityName)
+                .universityCode(universityCode)
                 .build();
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/ClubResponse.java
@@ -3,7 +3,6 @@ package com.greedy.mokkoji.api.club.dto.response;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
-import com.greedy.mokkoji.enums.university.UniversityCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -23,8 +22,7 @@ public record ClubResponse(
         @Schema(example = "OPEN") RecruitStatus recruitStatus,
         @Schema(example = "https://mokkoji-app-data.s3.ap-northeast-2.amazonaws.com/club-logo/1/greedy_{UUID}.jpg") String logo,
         @Schema(example = "true") Boolean isFavorite,
-        @Schema(example = "세종대학교") String universityName,
-        @Schema(example = "SEJONG") UniversityCode universityCode
+        @Schema(example = "세종대학교") String universityName
 ) {
     public static ClubResponse of(
             final Long id,
@@ -38,8 +36,7 @@ public record ClubResponse(
             final RecruitStatus recruitStatus,
             final String logo,
             final Boolean isFavorite,
-            final String universityName,
-            final UniversityCode universityCode) {
+            final String universityName) {
 
         return ClubResponse.builder()
                 .id(id)
@@ -54,7 +51,6 @@ public record ClubResponse(
                 .logo(logo)
                 .isFavorite(isFavorite)
                 .universityName(universityName)
-                .universityCode(universityCode)
                 .build();
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/ClubWithLatestRecruitment.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/ClubWithLatestRecruitment.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record ClubWithLatestRecruitment(
         @Schema(example = "1") Long id,
         @Schema(example = "그리디") String name,
+        @Schema(example = "세종대학교") String universityName,
         @Schema(example = "세종대 최고의 코딩 동아리") String description,
         @Schema(example = "https://mokkoji-app-data.s3.ap-northeast-2.amazonaws.com/club-logo/1/greedy_{UUID}.jpg") String logo,
         LatestRecruitmentInfo latestRecruitmentInfo

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -1,7 +1,15 @@
 package com.greedy.mokkoji.api.club.service;
 
-import com.greedy.mokkoji.api.club.dto.response.*;
-import com.greedy.mokkoji.api.club.dto.response.allClubs.*;
+import com.greedy.mokkoji.api.club.dto.response.ClubDetailResponse;
+import com.greedy.mokkoji.api.club.dto.response.ClubManageDetailResponse;
+import com.greedy.mokkoji.api.club.dto.response.ClubResponse;
+import com.greedy.mokkoji.api.club.dto.response.ClubUpdateResponse;
+import com.greedy.mokkoji.api.club.dto.response.ClubsPaginationResponse;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.AllClubsResponse;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.ClubPreviewResponse;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.ClubWithLatestRecruitment;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.LatestRecruitmentInfo;
+import com.greedy.mokkoji.api.club.dto.response.allClubs.RecruitmentPreviewResponse;
 import com.greedy.mokkoji.api.external.AppDataS3Client;
 import com.greedy.mokkoji.api.pagination.dto.PageResponse;
 import com.greedy.mokkoji.common.exception.MokkojiException;
@@ -16,6 +24,7 @@ import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.message.FailMessage;
 import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
+import com.greedy.mokkoji.enums.university.UniversityCode;
 import com.greedy.mokkoji.enums.user.UserRole;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,7 +34,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -71,14 +84,16 @@ public class ClubService {
     }
 
     @Transactional(readOnly = true)
-    public ClubsPaginationResponse findClubsByConditions(final Long userId,
-                                                         final String keyword,
-                                                         final ClubCategory category,
-                                                         final ClubAffiliation affiliation,
-                                                         final RecruitStatus status,
-                                                         final Pageable pageable) {
+    public ClubsPaginationResponse findClubsByConditions(
+            final Long userId,
+            final UniversityCode universityCode,
+            final String keyword,
+            final ClubCategory category,
+            final ClubAffiliation affiliation,
+            final RecruitStatus status,
+            final Pageable pageable) {
 
-        final Page<Club> clubPage = clubRepository.findClubsWithLatestRecruitment(keyword, category, affiliation, status, pageable);
+        final Page<Club> clubPage = clubRepository.findClubsWithLatestRecruitment(universityCode, keyword, category, affiliation, status, pageable);
         final List<Club> clubs = clubPage.getContent();
         final List<ClubResponse> clubResponses = mapToClubResponses(userId, clubs);
 
@@ -90,12 +105,13 @@ public class ClubService {
     @Transactional(readOnly = true)
     public AllClubsResponse getAllClubs(
             final Long userId,
+            final UniversityCode universityCode,
             final String keyword,
             final ClubAffiliation affiliation,
             final ClubCategory category,
             final Pageable pageable
     ) {
-        List<ClubWithLatestRecruitment> clubs = clubRepository.findAllClubsWithLatestRecruitment(keyword, affiliation, category);
+        List<ClubWithLatestRecruitment> clubs = clubRepository.findAllClubsWithLatestRecruitment(universityCode, keyword, affiliation, category);
 
         Set<Long> favoriteClubIds = loadFavoriteClubIds(userId);
 

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -285,7 +285,9 @@ public class ClubService {
                             recruitment != null ? recruitment.isAlwaysRecruiting() : null,
                             calculateRecruitStatus(recruitment),
                             appDataS3Client.getPublicUrl(club.getLogo()),
-                            isFavorite);
+                            isFavorite,
+                            club.getUniversity().getName(),
+                            club.getUniversity().getCode());
                 })
                 .sorted(getFavoriteComparator())
                 .toList();

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -286,8 +286,7 @@ public class ClubService {
                             calculateRecruitStatus(recruitment),
                             appDataS3Client.getPublicUrl(club.getLogo()),
                             isFavorite,
-                            club.getUniversity().getName(),
-                            club.getUniversity().getCode());
+                            club.getUniversity().getName());
                 })
                 .sorted(getFavoriteComparator())
                 .toList();

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -18,6 +18,8 @@ import com.greedy.mokkoji.db.club.repository.ClubRepository;
 import com.greedy.mokkoji.db.favorite.repository.FavoriteRepository;
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.db.recruitment.repository.RecruitmentRepository;
+import com.greedy.mokkoji.db.university.entity.University;
+import com.greedy.mokkoji.db.university.repository.UniversityRepository;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.db.user.repository.UserRepository;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
@@ -49,6 +51,7 @@ public class ClubService {
     private final RecruitmentRepository recruitmentRepository;
     private final FavoriteRepository favoriteRepository;
     private final UserRepository userRepository;
+    private final UniversityRepository universityRepository;
     private final AppDataS3Client appDataS3Client;
 
     private static PageResponse createPageResponse(Pageable pageable, int totalElements) {
@@ -127,9 +130,12 @@ public class ClubService {
 
     @Transactional
     public void createClub(final Long userId, final String name, final ClubCategory category,
-                           final ClubAffiliation affiliation, final String clubMasterStudentId) {
+                           final ClubAffiliation affiliation, final String clubMasterStudentId,
+                           final UniversityCode universityCode) {
         validateClubRegistrar(userId);
         String validStudentId = getValidClubMasterStudentId(clubMasterStudentId);
+        University university = universityRepository.findByCode(universityCode)
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_UNIVERSITY));
 
         clubRepository.save(
                 Club.builder()
@@ -137,6 +143,7 @@ public class ClubService {
                         .clubCategory(category)
                         .clubAffiliation(affiliation)
                         .clubMasterStudentId(validStudentId)
+                        .university(university)
                         .build()
         );
     }

--- a/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
+++ b/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
@@ -76,7 +76,9 @@ public class FavoriteService {
                             recruitment != null ? recruitment.isAlwaysRecruiting() : null,
                             calculateRecruitStatus(recruitment),
                             appDataS3Client.getPublicUrl(club.getLogo()),
-                            true
+                            true,
+                            club.getUniversity().getName(),
+                            club.getUniversity().getCode()
                     );
                 }).toList();
 

--- a/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
+++ b/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
@@ -57,6 +57,7 @@ public class FavoriteService {
     @Transactional(readOnly = true)
     public ClubsPaginationResponse findFavoriteClubs(final Long userId, final Pageable pageable) {
         final Page<Favorite> favoritePage = favoriteRepository.findByUserId(userId, pageable);
+        final User user = getUserById(userId);
 
         final List<Favorite> favorites = favoritePage.getContent();
         List<ClubResponse> clubResponses = favorites.stream()
@@ -64,7 +65,6 @@ public class FavoriteService {
                     final Club club = favorite.getClub();
                     Recruitment recruitment = recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(club.getId())
                             .orElse(null);
-
                     return ClubResponse.of(
                             club.getId(),
                             club.getName(),
@@ -77,8 +77,7 @@ public class FavoriteService {
                             calculateRecruitStatus(recruitment),
                             appDataS3Client.getPublicUrl(club.getLogo()),
                             true,
-                            club.getUniversity().getName(),
-                            club.getUniversity().getCode()
+                            user.getUniversity() == null ? club.getUniversity().getName() : null
                     );
                 }).toList();
 

--- a/src/main/java/com/greedy/mokkoji/db/club/entity/Club.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/entity/Club.java
@@ -1,6 +1,7 @@
 package com.greedy.mokkoji.db.club.entity;
 
 import com.greedy.mokkoji.db.BaseTime;
+import com.greedy.mokkoji.db.university.entity.University;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
 import jakarta.persistence.*;
@@ -19,6 +20,10 @@ public class Club extends BaseTime {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", columnDefinition = "bigint", nullable = false)
     private Long id;
+
+    @JoinColumn(name = "university_id", columnDefinition = "bigint", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private University university;
 
     @Column(name = "name", columnDefinition = "varchar(50)", nullable = false)
     private String name;
@@ -46,6 +51,7 @@ public class Club extends BaseTime {
     @Builder
     public Club(
             final String name,
+            final University university,
             final ClubCategory clubCategory,
             final ClubAffiliation clubAffiliation,
             final String description,
@@ -54,6 +60,7 @@ public class Club extends BaseTime {
             final String clubMasterStudentId
     ) {
         this.name = name;
+        this.university = university;
         this.clubCategory = clubCategory;
         this.clubAffiliation = clubAffiliation;
         this.description = description;

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryCustom.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryCustom.java
@@ -5,6 +5,7 @@ import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
+import com.greedy.mokkoji.enums.university.UniversityCode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -12,16 +13,18 @@ import java.util.List;
 
 public interface ClubRepositoryCustom {
     Page<Club> findClubsWithLatestRecruitment(
+            final UniversityCode universityCode,
             final String keyword,
             final ClubCategory category,
             final ClubAffiliation affiliation,
             final RecruitStatus status,
             final Pageable pageable
-    );
+            );
 
     List<ClubWithLatestRecruitment> findAllClubsWithLatestRecruitment(
+            final UniversityCode universityCode,
             final String keyword,
             final ClubAffiliation affiliation,
             final ClubCategory category
-    );
+            );
 }

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
@@ -7,8 +7,13 @@ import com.greedy.mokkoji.db.recruitment.entity.QRecruitment;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.recruitment.RecruitStatus;
+import com.greedy.mokkoji.enums.university.UniversityCode;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.*;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -33,11 +38,13 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Club> findClubsWithLatestRecruitment(final String keyword,
-                                                     final ClubCategory category,
-                                                     final ClubAffiliation affiliation,
-                                                     final RecruitStatus status,
-                                                     final Pageable pageable) {
+    public Page<Club> findClubsWithLatestRecruitment(
+            final UniversityCode universityCode,
+            final String keyword,
+            final ClubCategory category,
+            final ClubAffiliation affiliation,
+            final RecruitStatus status,
+            final Pageable pageable) {
 
         final LocalDateTime now = LocalDateTime.now();
 
@@ -47,7 +54,8 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
                         likeClubName(keyword),
                         equalCategory(category),
                         equalAffiliation(affiliation),
-                        filterByRecruitStatus(status, now)
+                        filterByRecruitStatus(status, now),
+                        equalUniversityCode(universityCode)
                 )
                 .orderBy(
                         // TODO:: 정렬 방식: 페이지 마다 다른 시간을 넘겨주는 문제(원자성을 잃을 수 있기에) 이야기 해봐야됨
@@ -67,7 +75,8 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
                                 likeClubName(keyword),
                                 equalCategory(category),
                                 equalAffiliation(affiliation),
-                                filterByRecruitStatus(status, now)
+                                filterByRecruitStatus(status, now),
+                                equalUniversityCode(universityCode)
                         )
                         .fetchOne()
         ).orElse(0L);
@@ -76,7 +85,11 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
     }
 
     @Override
-    public List<ClubWithLatestRecruitment> findAllClubsWithLatestRecruitment(final String keyword, final ClubAffiliation affiliation, final ClubCategory category) {
+    public List<ClubWithLatestRecruitment> findAllClubsWithLatestRecruitment(
+            final UniversityCode universityCode,
+            final String keyword,
+            final ClubAffiliation affiliation,
+            final ClubCategory category) {
         QRecruitment subRecruitment = new QRecruitment("subRecruitment");
         QRecruitment subRecruitment2 = new QRecruitment("subRecruitment2");
 
@@ -86,6 +99,7 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
                                 ClubWithLatestRecruitment.class,
                                 club.id,
                                 club.name,
+                                club.university.name,
                                 club.description,
                                 club.logo,
                                 Projections.constructor(
@@ -117,6 +131,7 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
                 )
                 .where(
                         likeClubName(keyword),
+                        equalUniversityCode(universityCode),
                         equalAffiliation(affiliation),
                         equalCategory(category)
                 )
@@ -128,6 +143,13 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
             return club.name.like("%" + keyword + "%")
                     .or(club.description.like("%" + keyword + "%"))
                     .or(recruitment.content.like("%" + keyword + "%"));
+        }
+        return null;
+    }
+
+    private BooleanExpression equalUniversityCode(final UniversityCode universityCode) {
+        if (universityCode != null) {
+            return club.university.code.eq(universityCode);
         }
         return null;
     }

--- a/src/main/java/com/greedy/mokkoji/db/university/repository/UniversityRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/university/repository/UniversityRepository.java
@@ -1,11 +1,14 @@
 package com.greedy.mokkoji.db.university.repository;
 
 import com.greedy.mokkoji.db.university.entity.University;
+import com.greedy.mokkoji.enums.university.UniversityCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 
 @Repository
 public interface UniversityRepository extends JpaRepository<University, Long> {
 
+    Optional<University> findByCode(UniversityCode code);
 }

--- a/src/main/java/com/greedy/mokkoji/db/user/entity/User.java
+++ b/src/main/java/com/greedy/mokkoji/db/user/entity/User.java
@@ -20,7 +20,7 @@ public class User extends BaseTime {
     @Column(name = "id", columnDefinition = "bigint", nullable = false)
     private Long id;
 
-    @JoinColumn(name = "university_id", columnDefinition = "bigint", nullable = false)
+    @JoinColumn(name = "university_id", columnDefinition = "bigint")
     @ManyToOne(fetch = FetchType.LAZY)
     private University university;
 

--- a/src/main/java/com/greedy/mokkoji/enums/message/FailMessage.java
+++ b/src/main/java/com/greedy/mokkoji/enums/message/FailMessage.java
@@ -36,6 +36,7 @@ public enum FailMessage {
     NOT_FOUND_FAVORITE(HttpStatus.NOT_FOUND, 40404, "즐겨찾기 한 동아리를 찾을 수 없습니다."),
     NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, 40405, "댓글을 찾을 수 없습니다."),
     NOT_FOUNT_RECRUITMENT(HttpStatus.NOT_FOUND, 40406, "모집글을 찾을 수 없습니다."),
+    NOT_FOUND_UNIVERSITY(HttpStatus.NOT_FOUND, 40407, "학교를 찾을 수 없습니다."),
 
     //405
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, 40500, "잘못된 HTTP 메소드 요청입니다."),

--- a/src/main/java/com/greedy/mokkoji/enums/university/UniversityCode.java
+++ b/src/main/java/com/greedy/mokkoji/enums/university/UniversityCode.java
@@ -8,6 +8,5 @@ import lombok.Getter;
 public enum UniversityCode {
     SEJONG,
     KONKUK,
-    HANYANG,
-    NO_CHOSEN;
+    HANYANG;
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #387 

## 👷 **작업한 내용**
 1. Club 엔티티에 University @ManyToOne 연관관계를 추가했습니다.
    nullable = false로 설정하여 동아리는 반드시 학교에 속하도록 했습니다.
    빌더에 university 파라미터를 추가했습니다.

  2. 동아리 조회 시 학교 기준 필터링 로직을 추가했습니다.
     ClubRepositoryCustom의 두 메서드에 universityCode 파라미터를 추가했습니다.
     ClubRepositoryImpl에 equalUniversityCode 조건을 구현하여 학교별 동아리 조회가 가능하도록 했습니다.
     동아리 목록 조회 응답 DTO에 university name 필드를 추가했습니다.

## 🚨 **참고 사항**
 혹시 구현 부분에서 빠트린 부분 있으면 알려주세요.
