### PR TITLE
Feat: 관리자 로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    implementation 'org.springframework.security:spring-security-crypto'
+
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/src/main/java/com/greedy/mokkoji/api/admin/controller/AdminController.java
+++ b/src/main/java/com/greedy/mokkoji/api/admin/controller/AdminController.java
@@ -1,0 +1,30 @@
+package com.greedy.mokkoji.api.admin.controller;
+
+import com.greedy.mokkoji.api.admin.dto.request.AdminLoginRequest;
+import com.greedy.mokkoji.api.admin.dto.response.AdminLoginResponse;
+import com.greedy.mokkoji.api.admin.service.AdminAuthService;
+import com.greedy.mokkoji.common.response.APISuccessResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("${api.prefix}/admin")
+public class AdminController implements AdminControllerSwagger {
+
+    private final AdminAuthService adminAuthService;
+
+    @PostMapping("/auth/login")
+    public ResponseEntity<APISuccessResponse<AdminLoginResponse>> login(
+            @RequestBody @Valid final AdminLoginRequest request
+    ) {
+        final AdminLoginResponse response = adminAuthService.login(request.loginId(), request.password());
+        return APISuccessResponse.of(HttpStatus.OK, response);
+    }
+}

--- a/src/main/java/com/greedy/mokkoji/api/admin/controller/AdminControllerSwagger.java
+++ b/src/main/java/com/greedy/mokkoji/api/admin/controller/AdminControllerSwagger.java
@@ -1,0 +1,28 @@
+package com.greedy.mokkoji.api.admin.controller;
+
+import com.greedy.mokkoji.api.admin.dto.request.AdminLoginRequest;
+import com.greedy.mokkoji.api.admin.dto.response.AdminLoginResponse;
+import com.greedy.mokkoji.common.response.APISuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Admin Controller", description = "관리자 관련 API")
+public interface AdminControllerSwagger {
+
+    @Operation(
+            summary = "관리자 로그인 API",
+            description = "총동연·그리디 개발자 전용 로그인입니다. 카카오 로그인과는 별도 엔드포인트로 운영됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "관리자 로그인 성공"),
+            @ApiResponse(responseCode = "401", description = "아이디 또는 비밀번호 불일치"),
+            @ApiResponse(responseCode = "404", description = "등록되지 않은 계정")
+    })
+    ResponseEntity<APISuccessResponse<AdminLoginResponse>> login(
+            @Parameter(name = "request", description = "관리자 로그인 요청 본문") AdminLoginRequest request
+    );
+}

--- a/src/main/java/com/greedy/mokkoji/api/admin/dto/request/AdminLoginRequest.java
+++ b/src/main/java/com/greedy/mokkoji/api/admin/dto/request/AdminLoginRequest.java
@@ -1,0 +1,15 @@
+package com.greedy.mokkoji.api.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminLoginRequest(
+        @Schema(example = "clubmaster@konkuk.ac.kr")
+        @NotBlank(message = "아이디 입력은 필수입니다.")
+        String loginId,
+
+        @Schema(example = "임시비밀번호123!")
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {
+}

--- a/src/main/java/com/greedy/mokkoji/api/admin/dto/response/AdminLoginResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/admin/dto/response/AdminLoginResponse.java
@@ -1,0 +1,17 @@
+package com.greedy.mokkoji.api.admin.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record AdminLoginResponse(
+        @Schema(example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...") String accessToken,
+        @Schema(example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...") String refreshToken
+) {
+    public static AdminLoginResponse of(final String accessToken, final String refreshToken) {
+        return AdminLoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/greedy/mokkoji/api/admin/service/AdminAuthService.java
+++ b/src/main/java/com/greedy/mokkoji/api/admin/service/AdminAuthService.java
@@ -21,7 +21,7 @@ public class AdminAuthService {
     private final PasswordEncoder passwordEncoder;
     private final TokenService tokenService;
 
-    @Transactional(readOnly = true)
+    @Transactional
     public AdminLoginResponse login(final String loginId, final String password) {
         final Admin admin = adminRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new MokkojiException(FailMessage.UNAUTHORIZED_ADMIN_LOGIN));

--- a/src/main/java/com/greedy/mokkoji/api/admin/service/AdminAuthService.java
+++ b/src/main/java/com/greedy/mokkoji/api/admin/service/AdminAuthService.java
@@ -24,7 +24,7 @@ public class AdminAuthService {
     @Transactional(readOnly = true)
     public AdminLoginResponse login(final String loginId, final String password) {
         final Admin admin = adminRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_ADMIN));
+                .orElseThrow(() -> new MokkojiException(FailMessage.UNAUTHORIZED_ADMIN_LOGIN));
 
         if (!passwordEncoder.matches(password, admin.getPassword())) {
             throw new MokkojiException(FailMessage.UNAUTHORIZED_ADMIN_LOGIN);

--- a/src/main/java/com/greedy/mokkoji/api/admin/service/AdminAuthService.java
+++ b/src/main/java/com/greedy/mokkoji/api/admin/service/AdminAuthService.java
@@ -1,0 +1,36 @@
+package com.greedy.mokkoji.api.admin.service;
+
+import com.greedy.mokkoji.api.admin.dto.response.AdminLoginResponse;
+import com.greedy.mokkoji.api.auth.dto.TokenPair;
+import com.greedy.mokkoji.api.user.service.TokenService;
+import com.greedy.mokkoji.common.exception.MokkojiException;
+import com.greedy.mokkoji.db.admin.entity.Admin;
+import com.greedy.mokkoji.db.admin.repository.AdminRepository;
+import com.greedy.mokkoji.enums.auth.AuthRole;
+import com.greedy.mokkoji.enums.message.FailMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminAuthService {
+
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final TokenService tokenService;
+
+    @Transactional(readOnly = true)
+    public AdminLoginResponse login(final String loginId, final String password) {
+        final Admin admin = adminRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_ADMIN));
+
+        if (!passwordEncoder.matches(password, admin.getPassword())) {
+            throw new MokkojiException(FailMessage.UNAUTHORIZED_ADMIN_LOGIN);
+        }
+
+        final TokenPair tokenPair = tokenService.issueTokens(AuthRole.ADMIN, admin.getId());
+        return AdminLoginResponse.of(tokenPair.accessToken(), tokenPair.refreshToken());
+    }
+}

--- a/src/main/java/com/greedy/mokkoji/api/auth/dto/TokenPair.java
+++ b/src/main/java/com/greedy/mokkoji/api/auth/dto/TokenPair.java
@@ -1,0 +1,7 @@
+package com.greedy.mokkoji.api.auth.dto;
+
+public record TokenPair(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
@@ -45,8 +45,7 @@ public class UserController implements UserControllerSwagger {
     public ResponseEntity<APISuccessResponse<Void>> logout(
             @Authentication AuthCredential authCredential
     ) {
-        final Long userId = authCredential.userId();
-        userService.logOut(userId);
+        userService.logOut(authCredential.authRole(), authCredential.userId());
         return APISuccessResponse.of(HttpStatus.OK, null);
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
@@ -45,7 +45,7 @@ public class UserController implements UserControllerSwagger {
     public ResponseEntity<APISuccessResponse<Void>> logout(
             @Authentication AuthCredential authCredential
     ) {
-        userService.logOut(authCredential.authRole(), authCredential.userId());
+        userService.logout(authCredential.authRole(), authCredential.userId());
         return APISuccessResponse.of(HttpStatus.OK, null);
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/user/service/TokenService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/TokenService.java
@@ -1,8 +1,8 @@
 package com.greedy.mokkoji.api.user.service;
 
 import com.greedy.mokkoji.api.auth.controller.argumentResolver.AuthCredential;
+import com.greedy.mokkoji.api.auth.dto.TokenPair;
 import com.greedy.mokkoji.api.jwt.JwtUtil;
-import com.greedy.mokkoji.api.user.dto.resopnse.LoginResponse;
 import com.greedy.mokkoji.db.user.repository.RedisRepository;
 import com.greedy.mokkoji.enums.auth.AuthRole;
 import lombok.RequiredArgsConstructor;
@@ -13,26 +13,41 @@ import org.springframework.stereotype.Service;
 public class TokenService {
 
     private static final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 14; // 14일
+    private static final String REFRESH_TOKEN_KEY_PREFIX = "refreshToken";
+    private static final String KEY_DELIMITER = ":";
+
     private final RedisRepository redisRepository;
     private final JwtUtil jwtUtil;
 
-    public LoginResponse generateToken(final AuthRole authRole, final Long userId, final boolean isNewUser) {
+    public TokenPair issueTokens(final AuthRole authRole, final Long userId) {
         final AuthCredential credential = new AuthCredential(authRole, userId);
         final String accessToken = jwtUtil.generateAccessToken(credential);
         final String refreshToken = jwtUtil.generateRefreshToken(credential);
-        saveRefreshToken(userId, refreshToken);
-        return LoginResponse.of(accessToken, refreshToken, isNewUser);
+        saveRefreshToken(authRole, userId, refreshToken);
+        return new TokenPair(accessToken, refreshToken);
     }
 
-    private void saveRefreshToken(Long userId, String refreshToken) {
-        redisRepository.save("refreshToken" + userId, refreshToken, REFRESH_TOKEN_EXPIRATION);
+    private void saveRefreshToken(final AuthRole authRole, final Long userId, final String refreshToken) {
+        redisRepository.save(
+                refreshTokenKey(authRole, userId),
+                refreshToken,
+                REFRESH_TOKEN_EXPIRATION
+        );
     }
 
-    public String getRefreshToken(Long userId) {
-        return redisRepository.find("refreshToken" + userId);
+    public String getRefreshToken(final AuthRole authRole, final Long userId) {
+        return redisRepository.find(refreshTokenKey(authRole, userId));
     }
 
-    public void deleteRefreshToken(Long userId) {
-        redisRepository.delete("refreshToken" + userId);
+    public void deleteRefreshToken(final AuthRole authRole, final Long userId) {
+        redisRepository.delete(refreshTokenKey(authRole, userId));
+    }
+
+    private String refreshTokenKey(final AuthRole authRole, final Long userId) {
+        return REFRESH_TOKEN_KEY_PREFIX
+                + KEY_DELIMITER
+                + authRole.name()
+                + KEY_DELIMITER
+                + userId;
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -89,7 +89,7 @@ public class UserService {
     }
 
     @Transactional
-    public void logOut(final AuthRole authRole, final Long userId) {
+    public void logout(final AuthRole authRole, final Long userId) {
         tokenService.deleteRefreshToken(authRole, userId);
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.greedy.mokkoji.api.user.service;
 
 import com.greedy.mokkoji.api.auth.controller.argumentResolver.AuthCredential;
+import com.greedy.mokkoji.api.auth.dto.TokenPair;
 import com.greedy.mokkoji.api.jwt.JwtUtil;
 import com.greedy.mokkoji.api.user.dto.resopnse.LoginResponse;
 import com.greedy.mokkoji.api.user.dto.resopnse.UserManageClubResponse;
@@ -51,7 +52,8 @@ public class UserService {
                 )
         );
 
-        return tokenService.generateToken(AuthRole.USER, user.getId(), isNewUser);
+        final TokenPair tokenPair = tokenService.issueTokens(AuthRole.USER, user.getId());
+        return LoginResponse.of(tokenPair.accessToken(), tokenPair.refreshToken(), isNewUser);
     }
 
     @Transactional
@@ -59,7 +61,7 @@ public class UserService {
         final AuthCredential credential = jwtUtil.getCredentialFromToken(refreshToken);
         final Long userId = credential.userId();
 
-        String storedRefreshToken = tokenService.getRefreshToken(userId);
+        String storedRefreshToken = tokenService.getRefreshToken(credential.authRole(), userId);
         if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
             throw new MokkojiException(FailMessage.UNAUTHORIZED);
         }
@@ -87,8 +89,8 @@ public class UserService {
     }
 
     @Transactional
-    public void logOut(final Long userId) {
-        tokenService.deleteRefreshToken(userId);
+    public void logOut(final AuthRole authRole, final Long userId) {
+        tokenService.deleteRefreshToken(authRole, userId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/greedy/mokkoji/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/greedy/mokkoji/config/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.greedy.mokkoji.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/greedy/mokkoji/config/WebConfig.java
+++ b/src/main/java/com/greedy/mokkoji/config/WebConfig.java
@@ -20,6 +20,7 @@ public class WebConfig implements WebMvcConfigurer {
     private final Set<String> excludedPaths = Set.of(
             "/users/auth/kakao",
             "/users/auth/refresh",
+            "/admin/auth/login",
             "/clubs/**",
             "/recruitments/**",
             "/comments/**",

--- a/src/main/java/com/greedy/mokkoji/db/admin/repository/AdminRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/admin/repository/AdminRepository.java
@@ -3,5 +3,9 @@ package com.greedy.mokkoji.db.admin.repository;
 import com.greedy.mokkoji.db.admin.entity.Admin;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+    Optional<Admin> findByLoginId(String loginId);
 }

--- a/src/main/java/com/greedy/mokkoji/enums/message/FailMessage.java
+++ b/src/main/java/com/greedy/mokkoji/enums/message/FailMessage.java
@@ -20,6 +20,7 @@ public enum FailMessage {
     UNAUTHORIZED_EXPIRED(HttpStatus.UNAUTHORIZED, 40101, "토큰 기간이 만료 되었습니다."),
     UNAUTHORIZED_EMPTY_HEADER(HttpStatus.UNAUTHORIZED, 40102, "인증 정보가 없습니다."),
     UNAUTHORIZED_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 40103, "토큰의 정보가 올바르지 않습니다."),
+    UNAUTHORIZED_ADMIN_LOGIN(HttpStatus.UNAUTHORIZED, 40104, "이메일 또는 비밀번호가 올바르지 않습니다."),
 
     //403
     FORBIDDEN(HttpStatus.FORBIDDEN, 40300, "권한이 없습니다."),

--- a/src/test/java/com/greedy/mokkoji/admin/service/AdminAuthServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/admin/service/AdminAuthServiceTest.java
@@ -1,0 +1,104 @@
+package com.greedy.mokkoji.admin.service;
+
+import com.greedy.mokkoji.api.admin.dto.response.AdminLoginResponse;
+import com.greedy.mokkoji.api.admin.service.AdminAuthService;
+import com.greedy.mokkoji.api.auth.dto.TokenPair;
+import com.greedy.mokkoji.api.user.service.TokenService;
+import com.greedy.mokkoji.common.exception.MokkojiException;
+import com.greedy.mokkoji.common.fixture.Fixture;
+import com.greedy.mokkoji.db.admin.entity.Admin;
+import com.greedy.mokkoji.db.admin.repository.AdminRepository;
+import com.greedy.mokkoji.enums.auth.AuthRole;
+import com.greedy.mokkoji.enums.message.FailMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("관리자 로그인 서비스 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class AdminAuthServiceTest {
+
+    @InjectMocks
+    private AdminAuthService adminAuthService;
+
+    @Mock
+    private AdminRepository adminRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private TokenService tokenService;
+
+    @Test
+    @DisplayName("아이디와 비밀번호가 일치하면 토큰을 발급한다.")
+    void login_success() {
+        //given
+        final String rawPassword = "rawPassword123!";
+        final Admin admin = Fixture.createAdmin();
+        ReflectionTestUtils.setField(admin, "id", 1L);
+
+        given(adminRepository.findByLoginId(admin.getLoginId())).willReturn(Optional.of(admin));
+        given(passwordEncoder.matches(rawPassword, admin.getPassword())).willReturn(true);
+        given(tokenService.issueTokens(AuthRole.ADMIN, 1L)).willReturn(new TokenPair("access", "refresh"));
+
+        //when
+        final AdminLoginResponse response = adminAuthService.login(admin.getLoginId(), rawPassword);
+
+        //then
+        assertThat(response.accessToken()).isEqualTo("access");
+        assertThat(response.refreshToken()).isEqualTo("refresh");
+        verify(tokenService, times(1)).issueTokens(AuthRole.ADMIN, 1L);
+    }
+
+    @Test
+    @DisplayName("등록되지 않은 계정이면 NOT_FOUND 예외를 던진다.")
+    void login_notFoundEmail() {
+        //given
+        final String loginId = "unknown@konkuk.ac.kr";
+        given(adminRepository.findByLoginId(loginId)).willReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> adminAuthService.login(loginId, "rawPassword123!"))
+                .isInstanceOf(MokkojiException.class)
+                .hasMessage(FailMessage.NOT_FOUND_ADMIN.getMessage());
+
+        verifyNoInteractions(tokenService);
+    }
+
+    @Test
+    @DisplayName("비밀번호가 일치하지 않으면 UNAUTHORIZED 예외를 던진다.")
+    void login_wrongPassword() {
+        //given
+        final String rawPassword = "wrongPassword";
+        final Admin admin = Fixture.createAdmin();
+        ReflectionTestUtils.setField(admin, "id", 1L);
+
+        given(adminRepository.findByLoginId(admin.getLoginId())).willReturn(Optional.of(admin));
+        given(passwordEncoder.matches(rawPassword, admin.getPassword())).willReturn(false);
+
+        //when & then
+        assertThatThrownBy(() -> adminAuthService.login(admin.getLoginId(), rawPassword))
+                .isInstanceOf(MokkojiException.class)
+                .hasMessage(FailMessage.UNAUTHORIZED_ADMIN_LOGIN.getMessage());
+
+        verifyNoInteractions(tokenService);
+    }
+}

--- a/src/test/java/com/greedy/mokkoji/admin/service/AdminAuthServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/admin/service/AdminAuthServiceTest.java
@@ -69,7 +69,7 @@ class AdminAuthServiceTest {
     }
 
     @Test
-    @DisplayName("등록되지 않은 계정이면 NOT_FOUND 예외를 던진다.")
+    @DisplayName("등록되지 않은 계정이면 로그인 예외를 던진다.")
     void login_notFoundEmail() {
         //given
         final String loginId = "unknown@konkuk.ac.kr";
@@ -78,7 +78,7 @@ class AdminAuthServiceTest {
         //when & then
         assertThatThrownBy(() -> adminAuthService.login(loginId, "rawPassword123!"))
                 .isInstanceOf(MokkojiException.class)
-                .hasMessage(FailMessage.NOT_FOUND_ADMIN.getMessage());
+                .hasMessage(FailMessage.UNAUTHORIZED_ADMIN_LOGIN.getMessage());
 
         verifyNoInteractions(tokenService);
     }

--- a/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
+++ b/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
@@ -1,10 +1,12 @@
 package com.greedy.mokkoji.common.fixture;
 
+import com.greedy.mokkoji.db.admin.entity.Admin;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.favorite.entity.Favorite;
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.db.university.entity.University;
 import com.greedy.mokkoji.db.user.entity.User;
+import com.greedy.mokkoji.enums.admin.AdminRole;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
 import com.greedy.mokkoji.enums.university.UniversityCode;
@@ -53,6 +55,14 @@ public class Fixture {
                 .email("모꼬지@test.com")
                 .isEmailOn(true)
                 .role(role)
+                .build();
+    }
+
+    public static Admin createAdmin() {
+        return Admin.builder()
+                .loginId("admin@konkuk.ac.kr")
+                .password("encodedPassword")
+                .role(AdminRole.MOKKOJI_ADMIN)
                 .build();
     }
 

--- a/src/test/java/com/greedy/mokkoji/user/controller/UserControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/controller/UserControllerTest.java
@@ -1,5 +1,6 @@
 package com.greedy.mokkoji.user.controller;
 
+import com.greedy.mokkoji.api.auth.dto.TokenPair;
 import com.greedy.mokkoji.api.user.dto.request.UpdateUserInformationRequest;
 import com.greedy.mokkoji.api.user.dto.request.kakao.KakaoSocialLoginRequest;
 import com.greedy.mokkoji.api.user.dto.resopnse.*;
@@ -62,7 +63,7 @@ public class UserControllerTest extends ControllerTest {
                 .thenReturn(new KakaoUserInfoResponse(user.getKakaoId(), null));
 
         final LoginResponse expected = LoginResponse.of("accessToken", "refreshToken", false);
-        when(tokenService.generateToken(eq(AuthRole.USER), any(), anyBoolean())).thenReturn(expected);
+        when(tokenService.issueTokens(eq(AuthRole.USER), any())).thenReturn(new TokenPair("accessToken", "refreshToken"));
 
         final KakaoSocialLoginRequest request = new KakaoSocialLoginRequest(code);
 
@@ -87,7 +88,7 @@ public class UserControllerTest extends ControllerTest {
         // given
         final String bearerToken = authorizationForBearerRefreshToken(user);
         final String refreshToken = bearerToken.substring("bearer".length()).trim();
-        when(tokenService.getRefreshToken(any())).thenReturn(refreshToken);
+        when(tokenService.getRefreshToken(any(), any())).thenReturn(refreshToken);
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().ifValidationFails()
@@ -108,7 +109,7 @@ public class UserControllerTest extends ControllerTest {
     @DisplayName("로그아웃 성공 여부를 검증한다.")
     void logout() {
         // given
-        doNothing().when(tokenService).deleteRefreshToken(any());
+        doNothing().when(tokenService).deleteRefreshToken(any(), any());
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().ifValidationFails()

--- a/src/test/java/com/greedy/mokkoji/user/service/TokenServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/service/TokenServiceTest.java
@@ -1,8 +1,8 @@
 package com.greedy.mokkoji.user.service;
 
 import com.greedy.mokkoji.api.auth.controller.argumentResolver.AuthCredential;
+import com.greedy.mokkoji.api.auth.dto.TokenPair;
 import com.greedy.mokkoji.api.jwt.JwtUtil;
-import com.greedy.mokkoji.api.user.dto.resopnse.LoginResponse;
 import com.greedy.mokkoji.api.user.service.TokenService;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.db.user.repository.RedisRepository;
@@ -38,7 +38,7 @@ public class TokenServiceTest {
 
     @Test
     @DisplayName("로그인 시 토큰을 발급 받을 수 있다")
-    void generateToken() {
+    void issueTokens() {
         // given
         final User expected = User.builder()
                 .name("세종")
@@ -51,15 +51,15 @@ public class TokenServiceTest {
         doNothing().when(redisRepository).save(anyString(), anyString(), anyLong());
 
         // when
-        LoginResponse loginResponse = tokenService.generateToken(AuthRole.USER, expected.getId(), false);
+        TokenPair tokenPair = tokenService.issueTokens(AuthRole.USER, expected.getId());
 
         // then
-        assertThat(loginResponse).isNotNull();
-        assertThat(loginResponse.accessToken()).isNotBlank();
-        assertThat(loginResponse.refreshToken()).isNotBlank();
+        assertThat(tokenPair).isNotNull();
+        assertThat(tokenPair.accessToken()).isNotBlank();
+        assertThat(tokenPair.refreshToken()).isNotBlank();
 
         BDDMockito.verify(redisRepository, times(1))
-                .save(eq("refreshToken" + expected.getId()), eq("mockRefreshToken"), anyLong());
+                .save(eq("refreshToken:USER:" + expected.getId()), eq("mockRefreshToken"), anyLong());
     }
 
     @Test
@@ -77,17 +77,17 @@ public class TokenServiceTest {
         when(jwtUtil.generateRefreshToken(any(AuthCredential.class))).thenReturn("mockRefreshToken");
         doNothing().when(redisRepository).save(anyString(), anyString(), anyLong());
 
-        tokenService.generateToken(AuthRole.USER, userId, false);
+        tokenService.issueTokens(AuthRole.USER, userId);
 
         //when
-        tokenService.deleteRefreshToken(userId);
+        tokenService.deleteRefreshToken(AuthRole.USER, userId);
 
         //then
-        assertThat(tokenService.getRefreshToken(user.getId())).isNull();
+        assertThat(tokenService.getRefreshToken(AuthRole.USER, user.getId())).isNull();
 
         BDDMockito.verify(redisRepository, times(1))
-                .save(eq("refreshToken" + userId), eq("mockRefreshToken"), anyLong());
+                .save(eq("refreshToken:USER:" + userId), eq("mockRefreshToken"), anyLong());
         BDDMockito.verify(redisRepository, times(1))
-                .delete("refreshToken" + userId);
+                .delete("refreshToken:USER:" + userId);
     }
 }

--- a/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
@@ -2,6 +2,7 @@ package com.greedy.mokkoji.user.service;
 
 import com.greedy.mokkoji.api.auth.controller.argumentResolver.AuthCredential;
 import com.greedy.mokkoji.api.jwt.JwtUtil;
+import com.greedy.mokkoji.api.auth.dto.TokenPair;
 import com.greedy.mokkoji.api.user.dto.resopnse.LoginResponse;
 import com.greedy.mokkoji.api.user.dto.resopnse.UserManageClubResponse;
 import com.greedy.mokkoji.api.user.dto.resopnse.UserManageClubsResponse;
@@ -80,8 +81,8 @@ public class UserServiceTest {
         BDDMockito.given(kakaoSocialLoginService.login(code))
                 .willReturn(new KakaoUserInfoResponse(kakaoId, null));
         BDDMockito.given(userRepository.findByKakaoId(kakaoId)).willReturn(Optional.of(existingUser));
-        BDDMockito.given(tokenService.generateToken(AuthRole.USER, existingUser.getId(), false))
-                .willReturn(expected);
+        BDDMockito.given(tokenService.issueTokens(AuthRole.USER, existingUser.getId()))
+                .willReturn(new TokenPair("accessToken", "refreshToken"));
 
         // when
         final LoginResponse actual = userService.kakaoLogin(code);
@@ -108,7 +109,8 @@ public class UserServiceTest {
             ReflectionTestUtils.setField(saved, "id", 1L);
             return saved;
         });
-        BDDMockito.given(tokenService.generateToken(AuthRole.USER, 1L, true)).willReturn(expected);
+        BDDMockito.given(tokenService.issueTokens(AuthRole.USER, 1L))
+                .willReturn(new TokenPair("accessToken", "refreshToken"));
 
         // when
         final LoginResponse actual = userService.kakaoLogin(code);
@@ -128,7 +130,7 @@ public class UserServiceTest {
         AuthCredential credential = new AuthCredential(AuthRole.USER, userId);
 
         when(jwtUtil.getCredentialFromToken(refreshToken)).thenReturn(credential);
-        when(tokenService.getRefreshToken(userId)).thenReturn(refreshToken);
+        when(tokenService.getRefreshToken(AuthRole.USER, userId)).thenReturn(refreshToken);
         when(jwtUtil.generateAccessToken(credential)).thenReturn(newAccessToken);
 
         // when
@@ -147,7 +149,7 @@ public class UserServiceTest {
         AuthCredential credential = new AuthCredential(AuthRole.USER, userId);
 
         when(jwtUtil.getCredentialFromToken(invalidRefreshToken)).thenReturn(credential);
-        when(tokenService.getRefreshToken(userId)).thenReturn("differentStoredToken");
+        when(tokenService.getRefreshToken(AuthRole.USER, userId)).thenReturn("differentStoredToken");
 
         // when & then
         assertThatThrownBy(() -> userService.refreshAccessToken(invalidRefreshToken))


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #401 

## 👷 **작업한 내용**
### 1. 관리자 로그인 API 구현

관리자 로그인 API를 추가했습니다.

관리자 아이디와 비밀번호를 입력받고,  
등록된 관리자 계정인지 확인한 뒤 비밀번호가 일치하면 `accessToken`과 `refreshToken`을 발급하도록 구현했습니다.

관리자 로그인은 기존 카카오 로그인과는 별도의 플로우로 동작하도록 분리했습니다.

### 2. 토큰 발급 책임 분리

**[기존 코드에서 문제점이라고 생각하는 부분]**

기존 `TokenService`에서 토큰을 발급하면서 동시에 카카오 로그인 응답 DTO인 `LoginResponse`를 생성하고 있었습니다.
하지만 `TokenService`가 `isNewUser`와 같은 카카오 로그인 전용 필드까지 알 필요는 없다고 판단했습니다.

또한 기존 구조를 유지한다면,  
관리자 로그인 구현 과정에서  관리자 로그인 응답에 맞는 별도 토큰 발급 메서드를 추가해야 하는 문제가 생길 수 있다고 생각했습니다.
이후 다른 로그인 방식이 추가된다면 확장성에 불리한 구조라고 판단했고, 책임분리 하는 방향에 대해 고민해보았습니당

**[개선한 방법]**

따라서 `TokenService`는 `accessToken`과 `refreshToken` 발급 및 `refreshToken` 저장 책임만 가지도록 수정하고,  
로그인 응답 생성은 각 서비스에서 담당하도록 분리했습니다.
이를 위해 `accessToken`과 `refreshToken`을 담는 공통 DTO인 `TokenPair`를 추가했습니다.

### 3. Role 기반 `Refresh Token` 관리 적용

기존에는 `refreshToken`을 `userId` 기준으로만 저장하고 있었습니다.

하지만 이제 일반 사용자와 관리자를 `AuthRole` 기반으로 구분하기 때문에,  
`refreshToken` 저장/조회/삭제 시에도 `AuthRole + userId` 기준으로 관리하도록 수정했습니다.

이를 통해 일반 사용자와 관리자의 id가 동일한 경우에도 `refreshToken key`가 충돌하지 않도록 개선했습니다.

---

**[기존 key 형식]**

> `refreshToken{userId}`

**[변경 후 key 형식]**

> `refreshToken:{AuthRole}:{userId}`

또한 로그아웃과 `accessToken` 재발급 시에도 
토큰에 포함된 `AuthRole`을 기준으로 `refreshToken`을 조회하거나 삭제하도록 수정했습니다.

### 4. 테스트 코드 추가 및 수정
관리자 로그인 서비스 테스트를 추가했습니다.
또한 `TokenService`의 토큰 발급 책임 분리와 Role 기반 refreshToken key 적용에 따른 기존 유저 관련 테스트도 함께 수정했습니다.

## 🚨 **참고 사항**
1. 해당 작업은 카카오 로그인 API 구현 브랜치에서 이어서 작업한 내용입니다.
카카오 로그인 재도입 이후 변경된 인증 구조를 기반으로 관리자 로그인 API를 추가했습니다.

2. `TokenService` 책임 분리 관련
이번 작업에서 `TokenService`가 특정 로그인 응답 DTO에 의존하지 않도록 수정했습니다.
일반 사용자 로그인에서는 `LoginResponse`를,  관리자 로그인에서는 `AdminLoginResponse`를 각각의 서비스에서 생성하도록 분리했습니다.
이를 통해 이후 로그인 타입이 추가되더라도 `TokenService`에는 별도 응답 DTO별 메서드를 추가하지 않고,  공통 토큰 발급 로직만 재사용할 수 있도록 개선했습니다.

이 개선안에 대해 어떻게 생각하시는지 의견 들어보고싶습니당 

3. Refresh Token key 변경
`refreshToken key`가 기존 `refreshToken{userId}` 형식에서 `refreshToken:{AuthRole}:{userId}` 형식으로 변경되었습니다.
관리자 로그인과 일반 사용자 로그인이 함께 존재하게 되면서,  role 기준으로 `refreshToken`을 구분하는 것이 더 안전하다고 판단했습니다.

이 부분도 어떻게 생각하시는지 궁금합니다!
