### PR TITLE
Feat: 사용자 정보 수정 및 정보 조회 API 수정

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
@@ -8,7 +8,6 @@ import com.greedy.mokkoji.api.user.dto.request.kakao.KakaoSocialLoginRequest;
 import com.greedy.mokkoji.api.user.dto.resopnse.*;
 import com.greedy.mokkoji.api.user.service.UserService;
 import com.greedy.mokkoji.common.response.APISuccessResponse;
-import com.greedy.mokkoji.db.user.entity.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -55,8 +54,7 @@ public class UserController implements UserControllerSwagger {
             @Authentication AuthCredential authCredential
     ) {
         final Long userId = authCredential.userId();
-        final User user = userService.findUser(userId);
-        final UserInformationResponse userInformationResponse = UserInformationResponse.of(user);
+        final UserInformationResponse userInformationResponse = userService.getUserInformation(userId);
         return APISuccessResponse.of(HttpStatus.OK, userInformationResponse);
     }
 
@@ -66,7 +64,12 @@ public class UserController implements UserControllerSwagger {
             @RequestBody @Valid UpdateUserInformationRequest updateUserInformationRequest
     ) {
         final Long userId = authCredential.userId();
-        userService.updateUserInformation(userId, updateUserInformationRequest.email(), updateUserInformationRequest.isEmailOn());
+        userService.updateUserInformation(
+                userId,
+                updateUserInformationRequest.email(),
+                updateUserInformationRequest.isEmailOn(),
+                updateUserInformationRequest.universityCode()
+        );
         return APISuccessResponse.of(HttpStatus.OK, null);
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/user/dto/request/UpdateUserInformationRequest.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/dto/request/UpdateUserInformationRequest.java
@@ -1,5 +1,6 @@
 package com.greedy.mokkoji.api.user.dto.request;
 
+import com.greedy.mokkoji.enums.university.UniversityCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Pattern;
 
@@ -10,8 +11,8 @@ public record UpdateUserInformationRequest(
                 message = "유효하지 않은 이메일 형식입니다."
         )
         String email,
-        @Schema(example = "false")
-        Boolean isEmailOn
+        @Schema(example = "false") Boolean isEmailOn,
+        @Schema(example = "SEJONG", description = "학교 코드") UniversityCode universityCode
 ) {
 
 }

--- a/src/main/java/com/greedy/mokkoji/api/user/dto/resopnse/UserInformationResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/dto/resopnse/UserInformationResponse.java
@@ -1,14 +1,30 @@
 package com.greedy.mokkoji.api.user.dto.resopnse;
 
+import com.greedy.mokkoji.db.university.entity.University;
 import com.greedy.mokkoji.db.user.entity.User;
-import lombok.Builder;
+import com.greedy.mokkoji.enums.university.UniversityCode;
+import com.greedy.mokkoji.enums.user.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-@Builder
 public record UserInformationResponse(
-        User user) {
-    public static UserInformationResponse of(User user) {
-        return UserInformationResponse.builder()
-                .user(user)
-                .build();
+        @Schema(example = "1") Long id,
+        @Schema(example = "모꼬지") String name,
+        @Schema(example = "user@sejong.ac.kr") String email,
+        @Schema(example = "NORMAL") UserRole role,
+        @Schema(example = "true") boolean emailOn,
+        @Schema(example = "KONKUK", description = "학교 미선택 시 null") UniversityCode universityCode
+) {
+    public static UserInformationResponse of(final User user) {
+        final University university = user.getUniversity();
+        final UniversityCode universityCode = university == null ? null : university.getCode();
+
+        return new UserInformationResponse(
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                user.getRole(),
+                user.isEmailOn(),
+                universityCode
+        );
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.greedy.mokkoji.api.user.service;
 import com.greedy.mokkoji.api.auth.controller.argumentResolver.AuthCredential;
 import com.greedy.mokkoji.api.jwt.JwtUtil;
 import com.greedy.mokkoji.api.user.dto.resopnse.LoginResponse;
+import com.greedy.mokkoji.api.user.dto.resopnse.UserInformationResponse;
 import com.greedy.mokkoji.api.user.dto.resopnse.UserManageClubResponse;
 import com.greedy.mokkoji.api.user.dto.resopnse.UserManageClubsResponse;
 import com.greedy.mokkoji.api.user.dto.resopnse.UserRoleResponse;
@@ -10,10 +11,13 @@ import com.greedy.mokkoji.api.user.dto.resopnse.kakao.KakaoUserInfoResponse;
 import com.greedy.mokkoji.api.user.service.kakao.KakaoSocialLoginService;
 import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.db.club.repository.ClubRepository;
+import com.greedy.mokkoji.db.university.entity.University;
+import com.greedy.mokkoji.db.university.repository.UniversityRepository;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.db.user.repository.UserRepository;
 import com.greedy.mokkoji.enums.auth.AuthRole;
 import com.greedy.mokkoji.enums.message.FailMessage;
+import com.greedy.mokkoji.enums.university.UniversityCode;
 import com.greedy.mokkoji.enums.user.UserRole;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +34,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final ClubRepository clubRepository;
+    private final UniversityRepository universityRepository;
     private final JwtUtil jwtUtil;
     private final TokenService tokenService;
     private final KakaoSocialLoginService kakaoSocialLoginService;
@@ -67,7 +72,7 @@ public class UserService {
     }
 
     @Transactional
-    public void updateUserInformation(Long userId, String email, Boolean isEmailOn) {
+    public void updateUserInformation(Long userId, String email, Boolean isEmailOn, UniversityCode universityCode) {
         User user = findUser(userId);
 
         if (email != null) {
@@ -77,12 +82,23 @@ public class UserService {
         if (isEmailOn != null) {
             user.updateEmailOn(isEmailOn);
         }
+
+        if (universityCode != null) {
+            University university = findUniversity(universityCode);
+            user.updateUniversity(university);
+        }
     }
 
     @Transactional(readOnly = true)
     public User findUser(final Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+    }
+
+    @Transactional(readOnly = true)
+    public UserInformationResponse getUserInformation(final Long userId) {
+        final User user = findUser(userId);
+        return UserInformationResponse.of(user);
     }
 
     @Transactional
@@ -109,5 +125,10 @@ public class UserService {
                 .toList();
 
         return UserManageClubsResponse.of(clubs);
+    }
+
+    private University findUniversity(final UniversityCode universityCode) {
+        return universityRepository.findByCode(universityCode)
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_UNIVERSITY));
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -84,7 +84,7 @@ public class UserService {
         }
 
         if (universityCode != null) {
-            University university = findUniversity(universityCode);
+            University university = findUniversityOrThrow(universityCode);
             user.updateUniversity(university);
         }
     }
@@ -127,7 +127,7 @@ public class UserService {
         return UserManageClubsResponse.of(clubs);
     }
 
-    private University findUniversity(final UniversityCode universityCode) {
+    private University findUniversityOrThrow(final UniversityCode universityCode) {
         return universityRepository.findByCode(universityCode)
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_UNIVERSITY));
     }

--- a/src/main/java/com/greedy/mokkoji/db/user/entity/User.java
+++ b/src/main/java/com/greedy/mokkoji/db/user/entity/User.java
@@ -55,6 +55,8 @@ public class User extends BaseTime {
         this.email = email;
     }
 
+    public void updateUniversity(University university) {this.university = university;}
+
     public void updateRole(UserRole newRole) {
         this.role = newRole;
     }

--- a/src/test/java/com/greedy/mokkoji/user/controller/UserControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/controller/UserControllerTest.java
@@ -11,6 +11,7 @@ import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.university.entity.University;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.enums.auth.AuthRole;
+import com.greedy.mokkoji.enums.university.UniversityCode;
 import com.greedy.mokkoji.enums.user.UserRole;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -152,7 +153,7 @@ public class UserControllerTest extends ControllerTest {
         // given
         final String authorizationForBearer = authorizationForBearerAccessToken(user);
         final String updatedEmail = "updatedEmail@test.com";
-        final UpdateUserInformationRequest updateUserInformationRequest = new UpdateUserInformationRequest(updatedEmail, null);
+        final UpdateUserInformationRequest updateUserInformationRequest = new UpdateUserInformationRequest(updatedEmail, null, null);
 
         // when
         final ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -175,7 +176,7 @@ public class UserControllerTest extends ControllerTest {
         // given
         final String authorizationForBearer = authorizationForBearerAccessToken(user);
         final String invalidUpdatedEmail = "updatedEmail.com";
-        final UpdateUserInformationRequest updateUserInformationRequest = new UpdateUserInformationRequest(invalidUpdatedEmail, null);
+        final UpdateUserInformationRequest updateUserInformationRequest = new UpdateUserInformationRequest(invalidUpdatedEmail, null, null);
 
         // when
         final ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -190,6 +191,58 @@ public class UserControllerTest extends ControllerTest {
 
         // then
         assertThat(statusCode).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @DisplayName("사용자 소속 학교 업데이트 성공 여부를 검증한다.")
+    void updateUserInfoWithUniversity() {
+        // given
+        universityRepository.save(Fixture.createUniversity());
+        final String authorizationForBearer = authorizationForBearerAccessToken(user);
+        final UpdateUserInformationRequest updateUserInformationRequest =
+                new UpdateUserInformationRequest(null, null, UniversityCode.SEJONG);
+
+        // when
+        RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .body(updateUserInformationRequest)
+                .when().patch(prefixUrl + "/users")
+                .then().log().all()
+                .statusCode(HttpStatus.OK.value());
+
+        final ExtractableResponse<Response> getResponse = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .when().get(prefixUrl + "/users")
+                .then().log().all()
+                .extract();
+
+        final UserInformationResponse actual = getDataFromResponse(getResponse, UserInformationResponse.class);
+
+        // then
+        assertThat(actual.universityCode()).isEqualTo(UniversityCode.SEJONG);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 학교 코드로 변경 시 404를 반환한다.")
+    void updateUserInfoWithNotFoundUniversity() {
+        // given
+        final String authorizationForBearer = authorizationForBearerAccessToken(user);
+        final UpdateUserInformationRequest updateUserInformationRequest =
+                new UpdateUserInformationRequest(null, null, UniversityCode.KONKUK);
+
+        // when
+        final ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", authorizationForBearer)
+                .body(updateUserInformationRequest)
+                .when().patch(prefixUrl + "/users")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
     }
 
     @Test

--- a/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
@@ -13,10 +13,13 @@ import com.greedy.mokkoji.api.user.service.kakao.KakaoSocialLoginService;
 import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.club.repository.ClubRepository;
+import com.greedy.mokkoji.db.university.entity.University;
+import com.greedy.mokkoji.db.university.repository.UniversityRepository;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.db.user.repository.UserRepository;
 import com.greedy.mokkoji.enums.auth.AuthRole;
 import com.greedy.mokkoji.enums.message.FailMessage;
+import com.greedy.mokkoji.enums.university.UniversityCode;
 import com.greedy.mokkoji.enums.user.UserRole;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -60,6 +63,9 @@ public class UserServiceTest {
 
     @Mock
     JwtUtil jwtUtil;
+
+    @Mock
+    UniversityRepository universityRepository;
 
     @Test
     @DisplayName("기존 사용자가 카카오 로그인 시 기존 유저로 토큰을 발급한다.")
@@ -156,7 +162,7 @@ public class UserServiceTest {
     }
 
     @Test
-    @DisplayName("User의 이메일 정보를 업데이트 할 수 있다.")
+    @DisplayName("사용자의 이메일 정보를 업데이트 할 수 있다.")
     void updateEmail() {
         // given
         final User user = User.builder()
@@ -168,10 +174,51 @@ public class UserServiceTest {
         when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
 
         // when
-        userService.updateUserInformation(1L, "updated@email.com", null);
+        userService.updateUserInformation(1L, "updated@email.com", null, null);
 
         // then
         assertThat(user.getEmail()).isEqualTo("updated@email.com");
+    }
+
+    @Test
+    @DisplayName("사용자의 소속 학교를 업데이트 할 수 있다")
+    void updateUniversity() {
+        // given
+        final User user = User.builder()
+                .name("세종")
+                .kakaoId("kakao-12341234")
+                .build();
+        final University konkuk = University.builder()
+                .name("건국대학교")
+                .code(UniversityCode.KONKUK)
+                .build();
+
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+        when(universityRepository.findByCode(UniversityCode.KONKUK)).thenReturn(Optional.of(konkuk));
+
+        // when
+        userService.updateUserInformation(1L, null, null, UniversityCode.KONKUK);
+
+        // then
+        assertThat(user.getUniversity()).isEqualTo(konkuk);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 학교 코드로 변경 시 예외가 발생한다.")
+    void updateUniversityNotFound() {
+        // given
+        final User user = User.builder()
+                .name("세종")
+                .kakaoId("kakao-12341234")
+                .build();
+
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+        when(universityRepository.findByCode(UniversityCode.KONKUK)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateUserInformation(1L, null, null, UniversityCode.KONKUK))
+                .isInstanceOf(MokkojiException.class)
+                .hasMessage(FailMessage.NOT_FOUND_UNIVERSITY.getMessage());
     }
 
     @Test


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #410 

## 👷 **작업한 내용**
교외 확장 기능으로 인해 다음 두 API 스펙에 변경 사항이 발생합니다.

- 사용자 정보 수정 API

> 사용자는 자신의 학교 정보를 수정할 수 있어야 합니다. => 편입으로 인해 학교가 바뀐 경우 등

- 사용자 정보 조회 API

> 사용자의 학교 정보를 조회할 수 있어야 합니다.

따라서, 기존 API에서 요청 및 응답 스펙만 간단히 수정하였습니다.

## 🚨 **참고 사항**
-
