### PR TITLE
Feat: 카카오 사용자 정보 응답에 닉네임 정보 추가

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
@@ -65,6 +65,7 @@ public class UserController implements UserControllerSwagger {
         final Long userId = authCredential.userId();
         userService.updateUserInformation(
                 userId,
+                updateUserInformationRequest.name(),
                 updateUserInformationRequest.email(),
                 updateUserInformationRequest.isEmailOn(),
                 updateUserInformationRequest.universityCode()

--- a/src/main/java/com/greedy/mokkoji/api/user/dto/request/UpdateUserInformationRequest.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/dto/request/UpdateUserInformationRequest.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Pattern;
 
 public record UpdateUserInformationRequest(
+        @Schema(example = "모꼬지") String name,
         @Schema(example = "user@sejong.ac.kr")
         @Pattern(
                 regexp = "(^$)|(^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$)",

--- a/src/main/java/com/greedy/mokkoji/api/user/dto/resopnse/kakao/KakaoAccountResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/dto/resopnse/kakao/KakaoAccountResponse.java
@@ -4,11 +4,10 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record KakaoUserInfoResponse(
-        String id,
-        KakaoAccountResponse kakaoAccount
+public record KakaoAccountResponse(
+        KakaoProfileResponse profile
 ) {
     public String nickname() {
-        return kakaoAccount == null ? null : kakaoAccount.nickname();
+        return profile == null ? null : profile.nickname();
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/user/dto/resopnse/kakao/KakaoProfileResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/dto/resopnse/kakao/KakaoProfileResponse.java
@@ -4,11 +4,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record KakaoUserInfoResponse(
-        String id,
-        KakaoAccountResponse kakaoAccount
+public record KakaoProfileResponse(
+        String nickname
 ) {
-    public String nickname() {
-        return kakaoAccount == null ? null : kakaoAccount.nickname();
-    }
 }

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -43,6 +43,7 @@ public class UserService {
     public LoginResponse kakaoLogin(final String code) {
         final KakaoUserInfoResponse kakaoUserInfo = kakaoSocialLoginService.login(code);
         final String kakaoId = kakaoUserInfo.id();
+        final String name = kakaoUserInfo.nickname();
 
         final Optional<User> existingUser = userRepository.findByKakaoId(kakaoId);
         final boolean isNewUser = existingUser.isEmpty();
@@ -50,6 +51,7 @@ public class UserService {
                 () -> userRepository.save(
                         User.builder()
                                 .kakaoId(kakaoId)
+                                .name(name)
                                 .isEmailOn(true)
                                 .role(UserRole.NORMAL)
                                 .build()

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -76,8 +76,12 @@ public class UserService {
     }
 
     @Transactional
-    public void updateUserInformation(Long userId, String email, Boolean isEmailOn, UniversityCode universityCode) {
+    public void updateUserInformation(Long userId, String name, String email, Boolean isEmailOn, UniversityCode universityCode) {
         User user = findUser(userId);
+
+        if (name != null) {
+            user.updateName(name.isBlank() ? null : name);
+        }
 
         if (email != null) {
             user.updateEmail(email.isBlank() ? null : email);

--- a/src/main/java/com/greedy/mokkoji/db/user/entity/User.java
+++ b/src/main/java/com/greedy/mokkoji/db/user/entity/User.java
@@ -51,6 +51,10 @@ public class User extends BaseTime {
         this.role = role;
     }
 
+    public void updateName(String name) {
+        this.name = name;
+    }
+
     public void updateEmail(String email) {
         this.email = email;
     }

--- a/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
+++ b/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
@@ -70,6 +70,13 @@ public class Fixture {
         );
     }
 
+    public static KakaoUserInfoResponse createKakaoUserInfoResponseWithoutNickname(final String kakaoId) {
+        return new KakaoUserInfoResponse(
+                kakaoId,
+                new KakaoAccountResponse(null)
+        );
+    }
+
     public static Admin createAdmin() {
         return Admin.builder()
                 .loginId("admin@konkuk.ac.kr")

--- a/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
+++ b/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
@@ -1,5 +1,8 @@
 package com.greedy.mokkoji.common.fixture;
 
+import com.greedy.mokkoji.api.user.dto.resopnse.kakao.KakaoAccountResponse;
+import com.greedy.mokkoji.api.user.dto.resopnse.kakao.KakaoProfileResponse;
+import com.greedy.mokkoji.api.user.dto.resopnse.kakao.KakaoUserInfoResponse;
 import com.greedy.mokkoji.db.admin.entity.Admin;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.favorite.entity.Favorite;
@@ -56,6 +59,15 @@ public class Fixture {
                 .isEmailOn(true)
                 .role(role)
                 .build();
+    }
+
+    public static KakaoUserInfoResponse createKakaoUserInfoResponse(final String kakaoId, final String nickname) {
+        return new KakaoUserInfoResponse(
+                kakaoId,
+                new KakaoAccountResponse(
+                        new KakaoProfileResponse(nickname)
+                )
+        );
     }
 
     public static Admin createAdmin() {

--- a/src/test/java/com/greedy/mokkoji/user/controller/UserControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/controller/UserControllerTest.java
@@ -153,7 +153,7 @@ public class UserControllerTest extends ControllerTest {
         // given
         final String authorizationForBearer = authorizationForBearerAccessToken(user);
         final String updatedEmail = "updatedEmail@test.com";
-        final UpdateUserInformationRequest updateUserInformationRequest = new UpdateUserInformationRequest(updatedEmail, null, null);
+        final UpdateUserInformationRequest updateUserInformationRequest = new UpdateUserInformationRequest(null, updatedEmail, null, null);
 
         // when
         final ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -176,7 +176,7 @@ public class UserControllerTest extends ControllerTest {
         // given
         final String authorizationForBearer = authorizationForBearerAccessToken(user);
         final String invalidUpdatedEmail = "updatedEmail.com";
-        final UpdateUserInformationRequest updateUserInformationRequest = new UpdateUserInformationRequest(invalidUpdatedEmail, null, null);
+        final UpdateUserInformationRequest updateUserInformationRequest = new UpdateUserInformationRequest(null, invalidUpdatedEmail, null, null);
 
         // when
         final ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -200,7 +200,7 @@ public class UserControllerTest extends ControllerTest {
         universityRepository.save(Fixture.createUniversity());
         final String authorizationForBearer = authorizationForBearerAccessToken(user);
         final UpdateUserInformationRequest updateUserInformationRequest =
-                new UpdateUserInformationRequest(null, null, UniversityCode.SEJONG);
+                new UpdateUserInformationRequest(null, null, null, UniversityCode.SEJONG);
 
         // when
         RestAssured.given().log().all()
@@ -230,7 +230,7 @@ public class UserControllerTest extends ControllerTest {
         // given
         final String authorizationForBearer = authorizationForBearerAccessToken(user);
         final UpdateUserInformationRequest updateUserInformationRequest =
-                new UpdateUserInformationRequest(null, null, UniversityCode.KONKUK);
+                new UpdateUserInformationRequest(null, null, null, UniversityCode.KONKUK);
 
         // when
         final ExtractableResponse<Response> response = RestAssured.given().log().all()

--- a/src/test/java/com/greedy/mokkoji/user/controller/UserControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/controller/UserControllerTest.java
@@ -4,7 +4,6 @@ import com.greedy.mokkoji.api.auth.dto.TokenPair;
 import com.greedy.mokkoji.api.user.dto.request.UpdateUserInformationRequest;
 import com.greedy.mokkoji.api.user.dto.request.kakao.KakaoSocialLoginRequest;
 import com.greedy.mokkoji.api.user.dto.resopnse.*;
-import com.greedy.mokkoji.api.user.dto.resopnse.kakao.KakaoUserInfoResponse;
 import com.greedy.mokkoji.api.user.service.kakao.KakaoSocialLoginService;
 import com.greedy.mokkoji.common.ControllerTest;
 import com.greedy.mokkoji.common.fixture.Fixture;
@@ -61,7 +60,7 @@ public class UserControllerTest extends ControllerTest {
         //given
         final String code = "authorizationCode";
         when(kakaoSocialLoginService.login(code))
-                .thenReturn(new KakaoUserInfoResponse(user.getKakaoId()));
+                .thenReturn(Fixture.createKakaoUserInfoResponse(user.getKakaoId(), user.getName()));
 
         final LoginResponse expected = LoginResponse.of("accessToken", "refreshToken", false);
         when(tokenService.issueTokens(eq(AuthRole.USER), any())).thenReturn(new TokenPair("accessToken", "refreshToken"));

--- a/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
@@ -7,11 +7,11 @@ import com.greedy.mokkoji.api.user.dto.resopnse.LoginResponse;
 import com.greedy.mokkoji.api.user.dto.resopnse.UserManageClubResponse;
 import com.greedy.mokkoji.api.user.dto.resopnse.UserManageClubsResponse;
 import com.greedy.mokkoji.api.user.dto.resopnse.UserRoleResponse;
-import com.greedy.mokkoji.api.user.dto.resopnse.kakao.KakaoUserInfoResponse;
 import com.greedy.mokkoji.api.user.service.TokenService;
 import com.greedy.mokkoji.api.user.service.UserService;
 import com.greedy.mokkoji.api.user.service.kakao.KakaoSocialLoginService;
 import com.greedy.mokkoji.common.exception.MokkojiException;
+import com.greedy.mokkoji.common.fixture.Fixture;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.club.repository.ClubRepository;
 import com.greedy.mokkoji.db.university.entity.University;
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -76,7 +77,7 @@ public class UserServiceTest {
         final String kakaoId = "kakao-12341234";
 
         final User existingUser = User.builder()
-                .name("세종")
+                .name("모꼬지")
                 .kakaoId(kakaoId)
                 .role(UserRole.NORMAL)
                 .build();
@@ -85,7 +86,7 @@ public class UserServiceTest {
         final LoginResponse expected = LoginResponse.of("accessToken", "refreshToken", false);
 
         BDDMockito.given(kakaoSocialLoginService.login(code))
-                .willReturn(new KakaoUserInfoResponse(kakaoId));
+                .willReturn(Fixture.createKakaoUserInfoResponse(kakaoId, "모꼬지"));
         BDDMockito.given(userRepository.findByKakaoId(kakaoId)).willReturn(Optional.of(existingUser));
         BDDMockito.given(tokenService.issueTokens(AuthRole.USER, existingUser.getId()))
                 .willReturn(new TokenPair("accessToken", "refreshToken"));
@@ -104,11 +105,12 @@ public class UserServiceTest {
         // given
         final String code = "authCode";
         final String kakaoId = "kakao-99999999";
+        final String nickname = "모꼬지";
 
         final LoginResponse expected = LoginResponse.of("accessToken", "refreshToken", true);
 
         BDDMockito.given(kakaoSocialLoginService.login(code))
-                .willReturn(new KakaoUserInfoResponse(kakaoId));
+                .willReturn(Fixture.createKakaoUserInfoResponse(kakaoId, nickname));
         BDDMockito.given(userRepository.findByKakaoId(kakaoId)).willReturn(Optional.empty());
         BDDMockito.given(userRepository.save(any())).willAnswer(invocation -> {
             User saved = invocation.getArgument(0);
@@ -123,7 +125,10 @@ public class UserServiceTest {
 
         // then
         assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
-        BDDMockito.verify(userRepository, BDDMockito.times(1)).save(any());
+
+        final ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        BDDMockito.verify(userRepository, BDDMockito.times(1)).save(userCaptor.capture());
+        assertThat(userCaptor.getValue().getName()).isEqualTo(nickname);
     }
 
     @Test
@@ -168,7 +173,7 @@ public class UserServiceTest {
     void updateEmail() {
         // given
         final User user = User.builder()
-                .name("세종")
+                .name("모꼬지")
                 .kakaoId("kakao-12341234")
                 .email("origin@email.com")
                 .build();
@@ -187,7 +192,7 @@ public class UserServiceTest {
     void updateUniversity() {
         // given
         final User user = User.builder()
-                .name("세종")
+                .name("모꼬지")
                 .kakaoId("kakao-12341234")
                 .build();
         final University konkuk = University.builder()
@@ -210,7 +215,7 @@ public class UserServiceTest {
     void updateUniversityNotFound() {
         // given
         final User user = User.builder()
-                .name("세종")
+                .name("모꼬지")
                 .kakaoId("kakao-12341234")
                 .build();
 
@@ -230,7 +235,7 @@ public class UserServiceTest {
         Long userId = 1L;
 
         User user = User.builder()
-                .name("세종")
+                .name("모꼬지")
                 .kakaoId("kakao-12341234")
                 .role(UserRole.CLUB_MASTER)
                 .build();

--- a/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
@@ -132,6 +132,37 @@ public class UserServiceTest {
     }
 
     @Test
+    @DisplayName("카카오 정보 제공 미동의 시 이름 없이 신규 가입된다.")
+    void kakaoLoginNewUserWithoutNicknameConsent() {
+        // given
+        final String code = "authCode";
+        final String kakaoId = "kakao-00000000";
+
+        final LoginResponse expected = LoginResponse.of("accessToken", "refreshToken", true);
+
+        BDDMockito.given(kakaoSocialLoginService.login(code))
+                .willReturn(Fixture.createKakaoUserInfoResponseWithoutNickname(kakaoId));
+        BDDMockito.given(userRepository.findByKakaoId(kakaoId)).willReturn(Optional.empty());
+        BDDMockito.given(userRepository.save(any())).willAnswer(invocation -> {
+            User saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 1L);
+            return saved;
+        });
+        BDDMockito.given(tokenService.issueTokens(AuthRole.USER, 1L))
+                .willReturn(new TokenPair("accessToken", "refreshToken"));
+
+        // when
+        final LoginResponse actual = userService.kakaoLogin(code);
+
+        // then
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+
+        final ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        BDDMockito.verify(userRepository, BDDMockito.times(1)).save(userCaptor.capture());
+        assertThat(userCaptor.getValue().getName()).isNull();
+    }
+
+    @Test
     @DisplayName("AccessToken을 재발급 받을 수 있다.")
     void refreshAccessToken() {
         // given
@@ -181,10 +212,28 @@ public class UserServiceTest {
         when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
 
         // when
-        userService.updateUserInformation(1L, "updated@email.com", null, null);
+        userService.updateUserInformation(1L, null, "updated@email.com", null, null);
 
         // then
         assertThat(user.getEmail()).isEqualTo("updated@email.com");
+    }
+
+    @Test
+    @DisplayName("사용자의 이름 정보를 업데이트 할 수 있다.")
+    void updateName() {
+        // given
+        final User user = User.builder()
+                .name("모꼬지")
+                .kakaoId("kakao-12341234")
+                .build();
+
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+
+        // when
+        userService.updateUserInformation(1L, "변경된이름", null, null, null);
+
+        // then
+        assertThat(user.getName()).isEqualTo("변경된이름");
     }
 
     @Test
@@ -204,7 +253,7 @@ public class UserServiceTest {
         when(universityRepository.findByCode(UniversityCode.KONKUK)).thenReturn(Optional.of(konkuk));
 
         // when
-        userService.updateUserInformation(1L, null, null, UniversityCode.KONKUK);
+        userService.updateUserInformation(1L, null, null, null, UniversityCode.KONKUK);
 
         // then
         assertThat(user.getUniversity()).isEqualTo(konkuk);
@@ -223,7 +272,7 @@ public class UserServiceTest {
         when(universityRepository.findByCode(UniversityCode.KONKUK)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> userService.updateUserInformation(1L, null, null, UniversityCode.KONKUK))
+        assertThatThrownBy(() -> userService.updateUserInformation(1L, null, null, null, UniversityCode.KONKUK))
                 .isInstanceOf(MokkojiException.class)
                 .hasMessage(FailMessage.NOT_FOUND_UNIVERSITY.getMessage());
     }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #416 

## 👷 **작업한 내용**
최근 논의된 사항에 따라, 카카오 로그인 시 사용자 닉네임 정보를 활용할 수 있도록 추가했습니다.
- 신규 가입 시 카카오에서 제공되는 사용자 정보를 기반으로 이름을 저장하도록 변경했습니다.
- 사용자 정보 수정 API에서 이름 정보를 함께 수정할 수 있도록 했습니다!
- 변경된 사용자 정보 처리 흐름에 맞춰 관련 테스트를 수정 및 추가했습니다.

### [검증]
https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=모꼬지_클라이언트_아이디&redirect_uri=모꼬지_redirect_uri&scope=profile_nickname

> [주의] scope=profile_nickname 이걸 꼭 포함해야 정보 제공 동의 화면이 뜹니다!

다음 URL로 로그인 하여, 포스트맨으로 검증했습니다. 다음과 같이 이름이 잘 들어오는 것을 확인했습니다~!
<img width="139" height="75" alt="스크린샷 2026-05-30 오후 7 55 16" src="https://github.com/user-attachments/assets/624e5686-3e97-48ac-93df-4a3dcf063b3c" />


## 🚨 **참고 사항**
카카오 사용자 정보 제공 동의 여부에 따라 이름 정보가 없을 수 있는 케이스도 함께 고려했습니다.
꼼꼼히 봐주시면 감사하겠습니다 ~

