### PR TITLE
Feat: 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/comment/service/CommentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/comment/service/CommentService.java
@@ -97,7 +97,7 @@ public class CommentService {
     }
 
     private boolean isCommentWriter(final Long userId, final Comment comment) {
-        if (userId == null) {
+        if (userId == null || comment.getUser() == null) {
             return false;
         }
         return comment.getUser().getId().equals(userId);

--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
@@ -73,6 +73,14 @@ public class UserController implements UserControllerSwagger {
         return APISuccessResponse.of(HttpStatus.OK, null);
     }
 
+    @DeleteMapping
+    public ResponseEntity<APISuccessResponse<Void>> withdraw(
+            @Authentication AuthCredential authCredential
+    ) {
+        userService.withdraw(authCredential.authRole(), authCredential.userId());
+        return APISuccessResponse.of(HttpStatus.OK, null);
+    }
+
     @GetMapping("/roles")
     public ResponseEntity<APISuccessResponse<UserRoleResponse>> getUserRole(
             @Authentication AuthCredential authCredential

--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
@@ -74,10 +74,10 @@ public class UserController implements UserControllerSwagger {
     }
 
     @DeleteMapping
-    public ResponseEntity<APISuccessResponse<Void>> withdraw(
+    public ResponseEntity<APISuccessResponse<Void>> deleteUser(
             @Authentication AuthCredential authCredential
     ) {
-        userService.withdraw(authCredential.authRole(), authCredential.userId());
+        userService.deleteUser(authCredential.authRole(), authCredential.userId());
         return APISuccessResponse.of(HttpStatus.OK, null);
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserControllerSwagger.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserControllerSwagger.java
@@ -77,7 +77,7 @@ public interface UserControllerSwagger {
             security = {@SecurityRequirement(name = "JWT")}
     )
     @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공")
-    ResponseEntity<APISuccessResponse<Void>> withdraw(
+    ResponseEntity<APISuccessResponse<Void>> deleteUser(
             @Parameter(hidden = true) AuthCredential authCredential
     );
 

--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserControllerSwagger.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserControllerSwagger.java
@@ -70,6 +70,17 @@ public interface UserControllerSwagger {
     );
 
     @Operation(
+            summary = "회원 탈퇴 API",
+            description = "회원과 회원의 연관 데이터(즐겨찾기, 댓글, 동아리/동아리장 신청 내역 등)를 삭제합니다. "
+                    + "탈퇴 회원이 동아리장인 경우 해당 동아리의 동아리장은 해제됩니다.",
+            security = {@SecurityRequirement(name = "JWT")}
+    )
+    @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공")
+    ResponseEntity<APISuccessResponse<Void>> withdraw(
+            @Parameter(hidden = true) AuthCredential authCredential
+    );
+
+    @Operation(
             summary = "사용자 권한 조회 API",
             security = {@SecurityRequirement(name = "JWT")}
     )

--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserControllerSwagger.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserControllerSwagger.java
@@ -71,7 +71,7 @@ public interface UserControllerSwagger {
 
     @Operation(
             summary = "회원 탈퇴 API",
-            description = "회원과 회원의 연관 데이터(즐겨찾기, 댓글, 동아리/동아리장 신청 내역 등)를 삭제합니다. "
+            description = "회원과 회원의 연관 데이터를 삭제합니다. 댓글은 삭제하지 않습니다."
                     + "탈퇴 회원이 동아리장인 경우 해당 동아리의 동아리장은 해제됩니다.",
             security = {@SecurityRequirement(name = "JWT")}
     )

--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserControllerSwagger.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserControllerSwagger.java
@@ -71,8 +71,9 @@ public interface UserControllerSwagger {
 
     @Operation(
             summary = "회원 탈퇴 API",
-            description = "회원과 회원의 연관 데이터를 삭제합니다. 댓글은 삭제하지 않습니다."
-                    + "탈퇴 회원이 동아리장인 경우 해당 동아리의 동아리장은 해제됩니다.",
+            description = "회원과 회원의 연관 데이터를 삭제합니다.\n"
+                    + "* 댓글은 삭제하지 않습니다.\n"
+                    + "* 탈퇴 회원이 동아리장인 경우 해당 동아리의 동아리장은 해제됩니다.",
             security = {@SecurityRequirement(name = "JWT")}
     )
     @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공")

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -121,7 +121,7 @@ public class UserService {
     }
 
     @Transactional
-    public void withdraw(final AuthRole authRole, final Long userId) {
+    public void deleteUser(final AuthRole authRole, final Long userId) {
         final User user = findUser(userId);
 
         clubRepository.findByMaster_Id(userId)

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -8,6 +8,11 @@ import com.greedy.mokkoji.api.user.dto.resopnse.kakao.KakaoUserInfoResponse;
 import com.greedy.mokkoji.api.user.service.kakao.KakaoSocialLoginService;
 import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.db.club.repository.ClubRepository;
+import com.greedy.mokkoji.db.clubapplication.repository.ClubApplicationRepository;
+import com.greedy.mokkoji.db.clubmaster.repository.ClubMasterApplicationRepository;
+import com.greedy.mokkoji.db.clubmaster.repository.ClubMasterTransferRepository;
+import com.greedy.mokkoji.db.comment.repository.CommentRepository;
+import com.greedy.mokkoji.db.favorite.repository.FavoriteRepository;
 import com.greedy.mokkoji.db.university.entity.University;
 import com.greedy.mokkoji.db.university.repository.UniversityRepository;
 import com.greedy.mokkoji.db.user.entity.User;
@@ -32,6 +37,11 @@ public class UserService {
     private final UserRepository userRepository;
     private final ClubRepository clubRepository;
     private final UniversityRepository universityRepository;
+    private final FavoriteRepository favoriteRepository;
+    private final CommentRepository commentRepository;
+    private final ClubApplicationRepository clubApplicationRepository;
+    private final ClubMasterApplicationRepository clubMasterApplicationRepository;
+    private final ClubMasterTransferRepository clubMasterTransferRepository;
     private final JwtUtil jwtUtil;
     private final TokenService tokenService;
     private final KakaoSocialLoginService kakaoSocialLoginService;
@@ -108,6 +118,24 @@ public class UserService {
     @Transactional
     public void logout(final AuthRole authRole, final Long userId) {
         tokenService.deleteRefreshToken(authRole, userId);
+    }
+
+    @Transactional
+    public void withdraw(final AuthRole authRole, final Long userId) {
+        final User user = findUser(userId);
+
+        clubRepository.findByMaster_Id(userId)
+                .forEach(club -> club.updateMaster(null));
+
+        favoriteRepository.deleteByUserId(userId);
+        commentRepository.deleteByUserId(userId);
+        clubApplicationRepository.deleteByApplicantId(userId);
+        clubMasterApplicationRepository.deleteByUserId(userId);
+        clubMasterTransferRepository.deleteByPreviousMasterId(userId);
+
+        tokenService.deleteRefreshToken(authRole, userId);
+
+        userRepository.delete(user);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -128,7 +128,7 @@ public class UserService {
                 .forEach(club -> club.updateMaster(null));
 
         favoriteRepository.deleteByUserId(userId);
-        commentRepository.deleteByUserId(userId);
+        commentRepository.detachUserByUserId(userId);
         clubApplicationRepository.deleteByApplicantId(userId);
         clubMasterApplicationRepository.deleteByUserId(userId);
         clubMasterTransferRepository.deleteByPreviousMasterId(userId);

--- a/src/main/java/com/greedy/mokkoji/db/clubapplication/repository/ClubApplicationRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubapplication/repository/ClubApplicationRepository.java
@@ -15,4 +15,6 @@ public interface ClubApplicationRepository extends JpaRepository<ClubApplication
     boolean existsByApplicantAndUniversityAndStatusNot(User applicant, University university, ApplicationStatus status);
 
     List<ClubApplication> findByApplicant(User applicant);
+
+    void deleteByApplicantId(final Long applicantId);
 }

--- a/src/main/java/com/greedy/mokkoji/db/clubmaster/repository/ClubMasterApplicationRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubmaster/repository/ClubMasterApplicationRepository.java
@@ -18,4 +18,6 @@ public interface ClubMasterApplicationRepository extends JpaRepository<ClubMaste
     Page<ClubMasterApplication> findAllByOrderByCreatedAtAsc(Pageable pageable);
 
     boolean existsByUserAndUniversityAndStatusNot(User user, University university, ApplicationStatus status);
+
+    void deleteByUserId(final Long userId);
 }

--- a/src/main/java/com/greedy/mokkoji/db/clubmaster/repository/ClubMasterTransferRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubmaster/repository/ClubMasterTransferRepository.java
@@ -4,4 +4,6 @@ import com.greedy.mokkoji.db.clubmaster.entity.ClubMasterTransfer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClubMasterTransferRepository extends JpaRepository<ClubMasterTransfer, Long> {
+
+    void deleteByPreviousMasterId(final Long previousMasterId);
 }

--- a/src/main/java/com/greedy/mokkoji/db/comment/entity/Comment.java
+++ b/src/main/java/com/greedy/mokkoji/db/comment/entity/Comment.java
@@ -30,7 +30,7 @@ public class Comment extends BaseTime {
     @ManyToOne(fetch = FetchType.LAZY)
     private Club club;
 
-    @JoinColumn(name = "user_id", columnDefinition = "bigint", nullable = false)
+    @JoinColumn(name = "user_id", columnDefinition = "bigint")
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 

--- a/src/main/java/com/greedy/mokkoji/db/comment/repository/CommentRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/comment/repository/CommentRepository.java
@@ -4,6 +4,7 @@ import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.comment.entity.Comment;
 import com.greedy.mokkoji.db.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
@@ -16,5 +17,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     boolean existsByClubAndUser(final Club club, final User user);
 
-    void deleteByUserId(final Long userId);
+    @Modifying
+    @Query("UPDATE Comment c SET c.user = null WHERE c.user.id = :userId")
+    void detachUserByUserId(final Long userId);
 }

--- a/src/main/java/com/greedy/mokkoji/db/comment/repository/CommentRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/comment/repository/CommentRepository.java
@@ -15,4 +15,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByUser(final User user);
 
     boolean existsByClubAndUser(final Club club, final User user);
+
+    void deleteByUserId(final Long userId);
 }

--- a/src/main/java/com/greedy/mokkoji/db/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/favorite/repository/FavoriteRepository.java
@@ -28,4 +28,6 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
     @Query("SELECT f.club.id FROM Favorite f WHERE f.user.id = :userId")
     List<Long> findClubIdsByUserId(@Param("userId") Long userId);
+
+    void deleteByUserId(final Long userId);
 }

--- a/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
@@ -14,6 +14,11 @@ import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.common.fixture.Fixture;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.club.repository.ClubRepository;
+import com.greedy.mokkoji.db.clubapplication.repository.ClubApplicationRepository;
+import com.greedy.mokkoji.db.clubmaster.repository.ClubMasterApplicationRepository;
+import com.greedy.mokkoji.db.clubmaster.repository.ClubMasterTransferRepository;
+import com.greedy.mokkoji.db.comment.repository.CommentRepository;
+import com.greedy.mokkoji.db.favorite.repository.FavoriteRepository;
 import com.greedy.mokkoji.db.university.entity.University;
 import com.greedy.mokkoji.db.university.repository.UniversityRepository;
 import com.greedy.mokkoji.db.user.entity.User;
@@ -59,6 +64,21 @@ public class UserServiceTest {
 
     @Mock
     ClubRepository clubRepository;
+
+    @Mock
+    FavoriteRepository favoriteRepository;
+
+    @Mock
+    CommentRepository commentRepository;
+
+    @Mock
+    ClubApplicationRepository clubApplicationRepository;
+
+    @Mock
+    ClubMasterApplicationRepository clubMasterApplicationRepository;
+
+    @Mock
+    ClubMasterTransferRepository clubMasterTransferRepository;
 
     @Mock
     KakaoSocialLoginService kakaoSocialLoginService;
@@ -299,6 +319,75 @@ public class UserServiceTest {
     }
 
     @Test
+    @DisplayName("회원 탈퇴 시 연관 데이터를 삭제하고 RefreshToken을 제거한 뒤 유저를 삭제한다.")
+    void withdraw() {
+        // given
+        final Long userId = 1L;
+        final User user = User.builder()
+                .name("모꼬지")
+                .kakaoId("kakao-12341234")
+                .role(UserRole.NORMAL)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(clubRepository.findByMaster_Id(userId)).thenReturn(List.of());
+
+        // when
+        userService.withdraw(AuthRole.USER, userId);
+
+        // then
+        BDDMockito.verify(favoriteRepository).deleteByUserId(userId);
+        BDDMockito.verify(commentRepository).deleteByUserId(userId);
+        BDDMockito.verify(clubApplicationRepository).deleteByApplicantId(userId);
+        BDDMockito.verify(clubMasterApplicationRepository).deleteByUserId(userId);
+        BDDMockito.verify(clubMasterTransferRepository).deleteByPreviousMasterId(userId);
+        BDDMockito.verify(tokenService).deleteRefreshToken(AuthRole.USER, userId);
+        BDDMockito.verify(userRepository).delete(user);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 시 동아리장으로 등록된 동아리의 동아리장은 해제된다.")
+    void withdrawReleasesClubMaster() {
+        // given
+        final Long userId = 1L;
+        final User user = User.builder()
+                .name("모꼬지")
+                .kakaoId("kakao-12341234")
+                .role(UserRole.CLUB_MASTER)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        final Club club = Club.builder().name("그리디").master(user).build();
+        ReflectionTestUtils.setField(club, "id", 1L);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(clubRepository.findByMaster_Id(userId)).thenReturn(List.of(club));
+
+        // when
+        userService.withdraw(AuthRole.USER, userId);
+
+        // then
+        assertThat(club.getMaster()).isNull();
+        BDDMockito.verify(userRepository).delete(user);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저가 탈퇴를 시도하면 예외가 발생한다.")
+    void withdrawNotFoundUser() {
+        // given
+        final Long userId = 1L;
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.withdraw(AuthRole.USER, userId))
+                .isInstanceOf(MokkojiException.class)
+                .hasMessage(FailMessage.NOT_FOUND_USER.getMessage());
+
+        BDDMockito.verify(userRepository, BDDMockito.never()).delete(any());
+    }
+
+    @Test
     @DisplayName("사용자가 회장으로 관리 중인 동아리를 조회할 수 있다.")
     void getUserManageClubs() {
         // given
@@ -318,7 +407,7 @@ public class UserServiceTest {
         ReflectionTestUtils.setField(club2, "id", 2L);
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(clubRepository.findByMasterId(userId)).thenReturn(List.of(club1, club2));
+        when(clubRepository.findByMaster_Id(userId)).thenReturn(List.of(club1, club2));
 
         UserManageClubsResponse expectedResponse = new UserManageClubsResponse(
                 List.of(

--- a/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
@@ -319,7 +319,7 @@ public class UserServiceTest {
     }
 
     @Test
-    @DisplayName("회원 탈퇴 시 연관 데이터를 삭제하고 RefreshToken을 제거한 뒤 유저를 삭제한다.")
+    @DisplayName("회원 탈퇴 시 댓글은 작성자만 해제하고 나머지 연관 데이터를 삭제한 뒤 유저를 삭제한다.")
     void withdraw() {
         // given
         final Long userId = 1L;
@@ -338,7 +338,7 @@ public class UserServiceTest {
 
         // then
         BDDMockito.verify(favoriteRepository).deleteByUserId(userId);
-        BDDMockito.verify(commentRepository).deleteByUserId(userId);
+        BDDMockito.verify(commentRepository).detachUserByUserId(userId);
         BDDMockito.verify(clubApplicationRepository).deleteByApplicantId(userId);
         BDDMockito.verify(clubMasterApplicationRepository).deleteByUserId(userId);
         BDDMockito.verify(clubMasterTransferRepository).deleteByPreviousMasterId(userId);

--- a/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
@@ -320,7 +320,7 @@ public class UserServiceTest {
 
     @Test
     @DisplayName("회원 탈퇴 시 댓글은 작성자만 해제하고 나머지 연관 데이터를 삭제한 뒤 유저를 삭제한다.")
-    void withdraw() {
+    void deleteUser() {
         // given
         final Long userId = 1L;
         final User user = User.builder()
@@ -334,7 +334,7 @@ public class UserServiceTest {
         when(clubRepository.findByMaster_Id(userId)).thenReturn(List.of());
 
         // when
-        userService.withdraw(AuthRole.USER, userId);
+        userService.deleteUser(AuthRole.USER, userId);
 
         // then
         BDDMockito.verify(favoriteRepository).deleteByUserId(userId);
@@ -348,7 +348,7 @@ public class UserServiceTest {
 
     @Test
     @DisplayName("회원 탈퇴 시 동아리장으로 등록된 동아리의 동아리장은 해제된다.")
-    void withdrawReleasesClubMaster() {
+    void deleteUserReleasesClubMaster() {
         // given
         final Long userId = 1L;
         final User user = User.builder()
@@ -365,7 +365,7 @@ public class UserServiceTest {
         when(clubRepository.findByMaster_Id(userId)).thenReturn(List.of(club));
 
         // when
-        userService.withdraw(AuthRole.USER, userId);
+        userService.deleteUser(AuthRole.USER, userId);
 
         // then
         assertThat(club.getMaster()).isNull();
@@ -374,13 +374,13 @@ public class UserServiceTest {
 
     @Test
     @DisplayName("존재하지 않는 유저가 탈퇴를 시도하면 예외가 발생한다.")
-    void withdrawNotFoundUser() {
+    void deleteUserNotFoundUser() {
         // given
         final Long userId = 1L;
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> userService.withdraw(AuthRole.USER, userId))
+        assertThatThrownBy(() -> userService.deleteUser(AuthRole.USER, userId))
                 .isInstanceOf(MokkojiException.class)
                 .hasMessage(FailMessage.NOT_FOUND_USER.getMessage());
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #421 

## 👷 작업한 내용
회원이 직접 서비스를 탈퇴할 수 있도록 회원 탈퇴 API를 추가했습니다.

탈퇴는 회원만 지우는 것이 아니라 회원과 연관된 데이터까지 함께 정리되어야 하므로, 아래 순서대로 구현했습니다.

### 1. 연관 데이터 삭제
회원과 연관된 즐겨찾기, 동아리 생성 신청, 동아리장 신청, 동아리장 위임 내역을 먼저 삭제하도록 했습니다. 
이를 위해 각 엔티티의 `Repository`에 회원 기준 삭제 메서드를 추가했습니다.
=> `User`를 참조하는 외래키가 `NOT NULL`이라, 연관 데이터를 남겨둔 채로는 회원을 삭제할 수 없기 때문입니다.

### 2. 댓글은 삭제하지 않고 작성자만 해제
논의된 대로, 탈퇴해도 회원이 작성한 댓글은 보존하고 댓글의 작성자(user) 참조만 비우도록 했습니다.
  - `Comment.user `조인 컬럼이 null을 허용하도록 변경했습니다.
  - `CommentRepository`에 작성자를 null로 만드는 UPDATE 메서드(`detachUserByUserId`)를 추가하고, 기존 삭제 메서드는 제거했습니다.
  - 작성자가 없는(=탈퇴한) 댓글을 조회할 때 NPE가 나지 않도록 `isCommentWriter`에 null 방어 로직을 추가했습니다. 
  => 작성자가 없는 댓글은 수정/삭제가 불가능합니다.

### 2. 동아리장 자동 해제
탈퇴하려는 회원이 어떤 동아리의 동아리장인 경우, 해당 동아리의 master를 비운(null) 뒤 탈퇴를 진행하도록 했습니다.
=> 동아리 자체는 그대로 보존되고 동아리장 자리만 공석이 됩니다. 
이미 동아리장 위임 기능이 있어, 추후 위임/재지정 정책과도 자연스럽게 이어질 수 있다고 생각했습니다.

### 3. 토큰 및 회원 삭제
연관 데이터를 정리한 뒤 `Redis`에 저장된 `RefreshToken`을 제거하고, 마지막으로 회원을 삭제하도록 했습니다.

### 4. 테스트
정상 탈퇴, 동아리장 자동 해제, 존재하지 않는 회원이 탈퇴를 시도하는 예외 케이스에 대해 서비스 테스트를 추가했습니다.

## [검증]
로컬에서 회원과 연관된 데이터 및 `RefreshToken`을 미리 만들어두고 회원 탈퇴 API를 호출해 검증했습니다.
호출 결과, 연관 데이터들이 모두 삭제되었고 회원도 정상적으로 삭제되었으며 동아리는 보존된 채 master_id만 null로 해제되는 것을 확인했습니다.
댓글은 삭제되지 않고 `user_id`만 `null`로 해제되어 그대로 남았고, `RefreshToken` 역시 함께 제거되었습니다.

## 🚨 참고 사항
소프트 삭제 방식이 아닌 하드 삭제 방식으로 구현했습니다. 
회원과 연관 데이터를 실제로 제거하기 때문에, 댓글 이외에도 추후 탈퇴한 회원의 흔적을 남겨야 하는 정책이 생긴다면 그 때 별도 논의가 필요할 것 같습니다.

[스키마 관련] Comment.user_id가 nullable로 바뀌었습니다.

