### PR TITLE
Feat: 대학 변경 시 즐겨찾기 삭제 구현

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserControllerSwagger.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserControllerSwagger.java
@@ -60,7 +60,7 @@ public interface UserControllerSwagger {
 
     @Operation(
             summary = "사용자 정보 수정 API",
-            description = "전달된 필드만 수정됩니다.",
+            description = "전달된 필드만 수정됩니다. 대학교가 변경되는 경우 기존 즐겨찾기는 모두 삭제됩니다.",
             security = {@SecurityRequirement(name = "JWT")}
     )
     @ApiResponse(responseCode = "200", description = "사용자 정보 수정 성공")

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -90,10 +90,13 @@ public class UserService {
         }
 
         if (universityCode != null) {
-            University university = findUniversityOrThrow(universityCode);
-            if (user.getUniversity() == null || !user.getUniversity().getId().equals(university.getId())) {
+
+            final University university = findUniversityOrThrow(universityCode);
+
+            if (isDifferentUniversity(user, university)) {
                 favoriteRepository.deleteByUserId(userId);
             }
+
             user.updateUniversity(university);
         }
     }
@@ -139,5 +142,10 @@ public class UserService {
     private University findUniversityOrThrow(final UniversityCode universityCode) {
         return universityRepository.findByCode(universityCode)
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_UNIVERSITY));
+    }
+
+    private boolean isDifferentUniversity(final User user, final University university) {
+        return user.getUniversity() == null
+                || !user.getUniversity().getId().equals(university.getId());
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -8,6 +8,7 @@ import com.greedy.mokkoji.api.user.dto.resopnse.kakao.KakaoUserInfoResponse;
 import com.greedy.mokkoji.api.user.service.kakao.KakaoSocialLoginService;
 import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.db.club.repository.ClubRepository;
+import com.greedy.mokkoji.db.favorite.repository.FavoriteRepository;
 import com.greedy.mokkoji.db.university.entity.University;
 import com.greedy.mokkoji.db.university.repository.UniversityRepository;
 import com.greedy.mokkoji.db.user.entity.User;
@@ -32,6 +33,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final ClubRepository clubRepository;
     private final UniversityRepository universityRepository;
+    private final FavoriteRepository favoriteRepository;
     private final JwtUtil jwtUtil;
     private final TokenService tokenService;
     private final KakaoSocialLoginService kakaoSocialLoginService;
@@ -89,6 +91,9 @@ public class UserService {
 
         if (universityCode != null) {
             University university = findUniversityOrThrow(universityCode);
+            if (user.getUniversity() == null || !user.getUniversity().getId().equals(university.getId())) {
+                favoriteRepository.deleteByUserId(userId);
+            }
             user.updateUniversity(university);
         }
     }

--- a/src/main/java/com/greedy/mokkoji/db/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/favorite/repository/FavoriteRepository.java
@@ -28,4 +28,6 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
     @Query("SELECT f.club.id FROM Favorite f WHERE f.user.id = :userId")
     List<Long> findClubIdsByUserId(@Param("userId") Long userId);
+
+    void deleteByUserId(final Long UserId);
 }

--- a/src/main/java/com/greedy/mokkoji/db/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/favorite/repository/FavoriteRepository.java
@@ -29,5 +29,5 @@ public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     @Query("SELECT f.club.id FROM Favorite f WHERE f.user.id = :userId")
     List<Long> findClubIdsByUserId(@Param("userId") Long userId);
 
-    void deleteByUserId(final Long UserId);
+    void deleteByUserId(final Long userId);
 }

--- a/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
@@ -14,6 +14,7 @@ import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.common.fixture.Fixture;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.club.repository.ClubRepository;
+import com.greedy.mokkoji.db.favorite.repository.FavoriteRepository;
 import com.greedy.mokkoji.db.university.entity.University;
 import com.greedy.mokkoji.db.university.repository.UniversityRepository;
 import com.greedy.mokkoji.db.user.entity.User;
@@ -68,6 +69,9 @@ public class UserServiceTest {
 
     @Mock
     UniversityRepository universityRepository;
+
+    @Mock
+    FavoriteRepository favoriteRepository;
 
     @Test
     @DisplayName("기존 사용자가 카카오 로그인 시 기존 유저로 토큰을 발급한다.")
@@ -296,6 +300,67 @@ public class UserServiceTest {
 
         // then
         assertThat(actualRole.role()).isEqualTo(UserRole.CLUB_MASTER);
+    }
+
+    @Test
+    @DisplayName("대학교가 변경되면 즐겨찾기가 삭제된다.")
+    void updateUniversityDeletesFavorites() {
+        // given
+        final Long userId = 1L;
+        final University sejong = University.builder()
+                .name("세종대학교")
+                .code(UniversityCode.SEJONG)
+                .build();
+        ReflectionTestUtils.setField(sejong, "id", 1L);
+
+        final University konkuk = University.builder()
+                .name("건국대학교")
+                .code(UniversityCode.KONKUK)
+                .build();
+        ReflectionTestUtils.setField(konkuk, "id", 2L);
+
+        final User user = User.builder()
+                .name("모꼬지")
+                .kakaoId("kakao-12341234")
+                .university(sejong)
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(universityRepository.findByCode(UniversityCode.KONKUK)).thenReturn(Optional.of(konkuk));
+
+        // when
+        userService.updateUserInformation(userId, null, null, null, UniversityCode.KONKUK);
+
+        // then
+        BDDMockito.verify(favoriteRepository).deleteByUserId(userId);
+        assertThat(user.getUniversity()).isEqualTo(konkuk);
+    }
+
+    @Test
+    @DisplayName("같은 대학교로 변경하면 즐겨찾기가 삭제되지 않는다.")
+    void updateUniversitySameUniversityDoesNotDeleteFavorites() {
+        // given
+        final Long userId = 1L;
+        final University sejong = University.builder()
+                .name("세종대학교")
+                .code(UniversityCode.SEJONG)
+                .build();
+        ReflectionTestUtils.setField(sejong, "id", 1L);
+
+        final User user = User.builder()
+                .name("모꼬지")
+                .kakaoId("kakao-12341234")
+                .university(sejong)
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(universityRepository.findByCode(UniversityCode.SEJONG)).thenReturn(Optional.of(sejong));
+
+        // when
+        userService.updateUserInformation(userId, null, null, null, UniversityCode.SEJONG);
+
+        // then
+        BDDMockito.verify(favoriteRepository, BDDMockito.never()).deleteByUserId(userId);
     }
 
     @Test


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #423 

## 👷 **작업한 내용**
대학 변경 시 기존 즐겨찾기를 삭제하는 로직을 추가했습니다.
동일한 대학으로 변경하는 경우에는 즐겨찾기가 삭제되지 않도록 구현했습니다

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
