### PR TITLE
Fix: 카카오 로그인 이슈 해결  

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
@@ -7,9 +7,11 @@ import com.greedy.mokkoji.api.user.dto.request.UpdateUserInformationRequest;
 import com.greedy.mokkoji.api.user.dto.request.kakao.KakaoSocialLoginRequest;
 import com.greedy.mokkoji.api.user.dto.resopnse.*;
 import com.greedy.mokkoji.api.user.service.UserService;
+import com.greedy.mokkoji.api.user.service.kakao.KakaoRedirectUriResolver;
 import com.greedy.mokkoji.common.response.APISuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,12 +23,15 @@ public class UserController implements UserControllerSwagger {
 
     private final BearerAuthExtractor bearerAuthExtractor;
     private final UserService userService;
+    private final KakaoRedirectUriResolver kakaoRedirectUriResolver;
 
     @PostMapping("/auth/kakao")
     public ResponseEntity<APISuccessResponse<LoginResponse>> kakaoLogin(
+            @RequestHeader(value = HttpHeaders.ORIGIN, required = false) final String origin,
             @RequestBody final KakaoSocialLoginRequest request
     ) {
-        final LoginResponse loginResponse = userService.kakaoLogin(request.code());
+        final String redirectUri = kakaoRedirectUriResolver.resolve(origin);
+        final LoginResponse loginResponse = userService.kakaoLogin(request.code(), redirectUri);
         return APISuccessResponse.of(HttpStatus.OK, loginResponse);
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserControllerSwagger.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserControllerSwagger.java
@@ -18,10 +18,13 @@ public interface UserControllerSwagger {
 
     @Operation(
             summary = "카카오 로그인 API",
-            description = "프론트에서 카카오 OAuth 완료 후 받은 `authorization code`를 전달하여 로그인을 수행합니다. "
+            description = "프론트에서 카카오 OAuth 완료 후 받은 `authorization code`를 전달하여 로그인을 수행합니다.\n"
+                    + "* `redirect_uri`는 요청의 `Origin` 헤더와 서버에 설정된 콜백 경로를 합쳐 동적으로 구성됩니다.\n"
+                    + "* 예: `Origin: http://localhost:3000` → `redirect_uri = http://localhost:3000/api/auth/callback/kakao`\n"
     )
     @ApiResponse(responseCode = "200", description = "카카오 로그인 성공")
     ResponseEntity<APISuccessResponse<LoginResponse>> kakaoLogin(
+            @Parameter(hidden = true) String origin,
             @Parameter(name = "request", description = "카카오 로그인 요청 본문") KakaoSocialLoginRequest request
     );
 

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -46,8 +46,8 @@ public class UserService {
     private final TokenService tokenService;
     private final KakaoSocialLoginService kakaoSocialLoginService;
 
-    public LoginResponse kakaoLogin(final String code) {
-        final KakaoUserInfoResponse kakaoUserInfo = kakaoSocialLoginService.login(code);
+    public LoginResponse kakaoLogin(final String code, final String redirectUri) {
+        final KakaoUserInfoResponse kakaoUserInfo = kakaoSocialLoginService.login(code, redirectUri);
         final String kakaoId = kakaoUserInfo.id();
         final String name = kakaoUserInfo.nickname();
 

--- a/src/main/java/com/greedy/mokkoji/api/user/service/kakao/KakaoRedirectUriResolver.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/kakao/KakaoRedirectUriResolver.java
@@ -1,0 +1,23 @@
+package com.greedy.mokkoji.api.user.service.kakao;
+
+import com.greedy.mokkoji.common.exception.MokkojiException;
+import com.greedy.mokkoji.enums.message.FailMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KakaoRedirectUriResolver {
+
+    private final String callbackPath;
+
+    public KakaoRedirectUriResolver(@Value("${kakao.callback-path}") final String callbackPath) {
+        this.callbackPath = callbackPath;
+    }
+
+    public String resolve(final String origin) {
+        if (origin == null || origin.isBlank()) {
+            throw new MokkojiException(FailMessage.BAD_REQUEST_MISSING_PARAM);
+        }
+        return origin + callbackPath;
+    }
+}

--- a/src/main/java/com/greedy/mokkoji/api/user/service/kakao/KakaoSocialLoginService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/kakao/KakaoSocialLoginService.java
@@ -17,19 +17,17 @@ public class KakaoSocialLoginService {
     private final KakaoUserInfoClient kakaoUserInfoClient;
     @Value("${kakao.client-id}")
     private String kakaoClientId;
-    @Value("${kakao.redirect-uri}")
-    private String kakaoRedirectUri;
     @Value("${kakao.content-type}")
     private String kakaoContentType;
     @Value("${kakao.grant-type}")
     private String kakaoGrantType;
 
-    public KakaoUserInfoResponse login(final String code) {
+    public KakaoUserInfoResponse login(final String code, final String redirectUri) {
         final KakaoAccessTokenResponse kakaoAccessTokenResponse = kakaoAccessTokenClient.kakaoAuth(
                 kakaoContentType,
                 code,
                 kakaoClientId,
-                kakaoRedirectUri,
+                redirectUri,
                 kakaoGrantType
         );
 

--- a/src/test/java/com/greedy/mokkoji/user/controller/UserControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/controller/UserControllerTest.java
@@ -59,7 +59,10 @@ public class UserControllerTest extends ControllerTest {
     void kakaoLoginSuccessful() {
         //given
         final String code = "authorizationCode";
-        when(kakaoSocialLoginService.login(code))
+        final String origin = "http://localhost:3000";
+        final String expectedRedirectUri = origin + "/api/auth/callback/kakao";
+
+        when(kakaoSocialLoginService.login(code, expectedRedirectUri))
                 .thenReturn(Fixture.createKakaoUserInfoResponse(user.getKakaoId(), user.getName()));
 
         final LoginResponse expected = LoginResponse.of("accessToken", "refreshToken", false);
@@ -70,6 +73,7 @@ public class UserControllerTest extends ControllerTest {
         //when
         ExtractableResponse<Response> response = RestAssured.given().log().ifValidationFails()
                 .contentType(ContentType.JSON)
+                .header("Origin", origin)
                 .body(request)
                 .when().post(prefixUrl + "/users/auth/kakao")
                 .then().log().all()
@@ -80,6 +84,21 @@ public class UserControllerTest extends ControllerTest {
 
         //then
         assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("Origin 헤더가 없으면 카카오 로그인은 400 응답을 반환한다.")
+    void kakaoLoginWithoutOrigin() {
+        //given
+        final KakaoSocialLoginRequest request = new KakaoSocialLoginRequest("authorizationCode");
+
+        //when & then
+        RestAssured.given().log().ifValidationFails()
+                .contentType(ContentType.JSON)
+                .body(request)
+                .when().post(prefixUrl + "/users/auth/kakao")
+                .then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 
     @Test

--- a/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
@@ -94,6 +94,7 @@ public class UserServiceTest {
     void kakaoLoginExistingUser() {
         // given
         final String code = "authCode";
+        final String redirectUri = "http://localhost:3000/api/auth/callback/kakao";
         final String kakaoId = "kakao-12341234";
 
         final User existingUser = User.builder()
@@ -105,14 +106,14 @@ public class UserServiceTest {
 
         final LoginResponse expected = LoginResponse.of("accessToken", "refreshToken", false);
 
-        BDDMockito.given(kakaoSocialLoginService.login(code))
+        BDDMockito.given(kakaoSocialLoginService.login(code, redirectUri))
                 .willReturn(Fixture.createKakaoUserInfoResponse(kakaoId, "모꼬지"));
         BDDMockito.given(userRepository.findByKakaoId(kakaoId)).willReturn(Optional.of(existingUser));
         BDDMockito.given(tokenService.issueTokens(AuthRole.USER, existingUser.getId()))
                 .willReturn(new TokenPair("accessToken", "refreshToken"));
 
         // when
-        final LoginResponse actual = userService.kakaoLogin(code);
+        final LoginResponse actual = userService.kakaoLogin(code, redirectUri);
 
         // then
         assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
@@ -124,12 +125,13 @@ public class UserServiceTest {
     void kakaoLoginNewUser() {
         // given
         final String code = "authCode";
+        final String redirectUri = "http://localhost:3000/api/auth/callback/kakao";
         final String kakaoId = "kakao-99999999";
         final String nickname = "모꼬지";
 
         final LoginResponse expected = LoginResponse.of("accessToken", "refreshToken", true);
 
-        BDDMockito.given(kakaoSocialLoginService.login(code))
+        BDDMockito.given(kakaoSocialLoginService.login(code, redirectUri))
                 .willReturn(Fixture.createKakaoUserInfoResponse(kakaoId, nickname));
         BDDMockito.given(userRepository.findByKakaoId(kakaoId)).willReturn(Optional.empty());
         BDDMockito.given(userRepository.save(any())).willAnswer(invocation -> {
@@ -141,7 +143,7 @@ public class UserServiceTest {
                 .willReturn(new TokenPair("accessToken", "refreshToken"));
 
         // when
-        final LoginResponse actual = userService.kakaoLogin(code);
+        final LoginResponse actual = userService.kakaoLogin(code, redirectUri);
 
         // then
         assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
@@ -156,11 +158,12 @@ public class UserServiceTest {
     void kakaoLoginNewUserWithoutNicknameConsent() {
         // given
         final String code = "authCode";
+        final String redirectUri = "http://localhost:3000/api/auth/callback/kakao";
         final String kakaoId = "kakao-00000000";
 
         final LoginResponse expected = LoginResponse.of("accessToken", "refreshToken", true);
 
-        BDDMockito.given(kakaoSocialLoginService.login(code))
+        BDDMockito.given(kakaoSocialLoginService.login(code, redirectUri))
                 .willReturn(Fixture.createKakaoUserInfoResponseWithoutNickname(kakaoId));
         BDDMockito.given(userRepository.findByKakaoId(kakaoId)).willReturn(Optional.empty());
         BDDMockito.given(userRepository.save(any())).willAnswer(invocation -> {
@@ -172,7 +175,7 @@ public class UserServiceTest {
                 .willReturn(new TokenPair("accessToken", "refreshToken"));
 
         // when
-        final LoginResponse actual = userService.kakaoLogin(code);
+        final LoginResponse actual = userService.kakaoLogin(code, redirectUri);
 
         // then
         assertThat(actual).usingRecursiveComparison().isEqualTo(expected);

--- a/src/test/java/com/greedy/mokkoji/user/service/kakao/KakaoRedirectUriResolverTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/service/kakao/KakaoRedirectUriResolverTest.java
@@ -1,0 +1,47 @@
+package com.greedy.mokkoji.user.service.kakao;
+
+import com.greedy.mokkoji.api.user.service.kakao.KakaoRedirectUriResolver;
+import com.greedy.mokkoji.common.exception.MokkojiException;
+import com.greedy.mokkoji.enums.message.FailMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("카카오 redirect_uri Resolver 테스트")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+public class KakaoRedirectUriResolverTest {
+
+    private static final String CALLBACK_PATH = "/api/auth/callback/kakao";
+
+    private final KakaoRedirectUriResolver resolver = new KakaoRedirectUriResolver(CALLBACK_PATH);
+
+    @Test
+    @DisplayName("Origin 헤더와 콜백 경로를 합쳐 redirect_uri를 만든다.")
+    void resolveSuccessful() {
+        final String origin = "http://localhost:3000";
+
+        final String redirectUri = resolver.resolve(origin);
+
+        assertThat(redirectUri).isEqualTo("http://localhost:3000/api/auth/callback/kakao");
+    }
+
+    @Test
+    @DisplayName("Origin이 null이면 BAD_REQUEST_MISSING_PARAM 예외를 던진다.")
+    void resolveThrowsWhenOriginNull() {
+        assertThatThrownBy(() -> resolver.resolve(null))
+                .isInstanceOf(MokkojiException.class)
+                .hasFieldOrPropertyWithValue("failMessage", FailMessage.BAD_REQUEST_MISSING_PARAM);
+    }
+
+    @Test
+    @DisplayName("Origin이 공백이면 BAD_REQUEST_MISSING_PARAM 예외를 던진다.")
+    void resolveThrowsWhenOriginBlank() {
+        assertThatThrownBy(() -> resolver.resolve("   "))
+                .isInstanceOf(MokkojiException.class)
+                .hasFieldOrPropertyWithValue("failMessage", FailMessage.BAD_REQUEST_MISSING_PARAM);
+    }
+}


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #425 

## 👷 **작업한 내용**
프론트가 **로컬/개발 환경 모두에서 백엔드 개발 서버로 카카오 로그인을 요청**할 때, 백엔드의 `kakao.redirect-uri`가 dev 환경값으로 고정되어 있어 로컬 카카오 로그인이 실패하던 이슈를 해결했습니다.

카카오 OAuth는 인가 코드 발급 시 사용한 `redirect_uri`와 토큰 교환 시 `redirect_uri`가 완전히 일치해야 하므로, **요청의 `Origin` 헤더 + 서버 콜백 경로를 합쳐 `redirect_uri`를 동적으로 구성**하도록 변경했습니다.


## 🚨 **참고 사항**
**dev/prod 서버의 application yml에 아래 키를 직접 추가**해야 합니다:
```yaml
kakao:
  callback-path: /api/auth/callback/kakao
  # 기존 redirect-uri 키는 더 이상 사용되지 않으므로 삭제합시다
