### PR TITLE
Fix: clearUniversityCode 플래그를 통한 학교 정보 초기화 구현

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
@@ -68,7 +68,8 @@ public class UserController implements UserControllerSwagger {
                 updateUserInformationRequest.name(),
                 updateUserInformationRequest.email(),
                 updateUserInformationRequest.isEmailOn(),
-                updateUserInformationRequest.universityCode()
+                updateUserInformationRequest.universityCode(),
+                updateUserInformationRequest.clearUniversityCode()
         );
         return APISuccessResponse.of(HttpStatus.OK, null);
     }

--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserControllerSwagger.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserControllerSwagger.java
@@ -61,7 +61,7 @@ public interface UserControllerSwagger {
     @Operation(
             summary = "사용자 정보 수정 API",
             description = "전달된 필드만 수정됩니다. 대학교가 변경되는 경우 기존 즐겨찾기는 모두 삭제됩니다.\n"
-                    + "학교 정보를 초기화하려면 `clearUniversityCode: true`를 전달하세요. `universityCode`와 함께 전달된 경우 `clearUniversityCode`가 우선합니다.",
+                    + "학교 정보를 초기화하려면 `clearUniversityCode: true`를 전달하세요. `universityCode`와 함께 전달된 경우 `clearUniversityCode`가 우선 적용됩니다.",
             security = {@SecurityRequirement(name = "JWT")}
     )
     @ApiResponse(responseCode = "200", description = "사용자 정보 수정 성공")

--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserControllerSwagger.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserControllerSwagger.java
@@ -60,7 +60,8 @@ public interface UserControllerSwagger {
 
     @Operation(
             summary = "사용자 정보 수정 API",
-            description = "전달된 필드만 수정됩니다. 대학교가 변경되는 경우 기존 즐겨찾기는 모두 삭제됩니다.",
+            description = "전달된 필드만 수정됩니다. 대학교가 변경되는 경우 기존 즐겨찾기는 모두 삭제됩니다.\n"
+                    + "학교 정보를 초기화하려면 `clearUniversityCode: true`를 전달하세요. `universityCode`와 함께 전달된 경우 `clearUniversityCode`가 우선합니다.",
             security = {@SecurityRequirement(name = "JWT")}
     )
     @ApiResponse(responseCode = "200", description = "사용자 정보 수정 성공")

--- a/src/main/java/com/greedy/mokkoji/api/user/dto/request/UpdateUserInformationRequest.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/dto/request/UpdateUserInformationRequest.java
@@ -13,7 +13,8 @@ public record UpdateUserInformationRequest(
         )
         String email,
         @Schema(example = "false") Boolean isEmailOn,
-        @Schema(example = "SEJONG", description = "학교 코드") UniversityCode universityCode
+        @Schema(example = "SEJONG", description = "학교 코드") UniversityCode universityCode,
+        @Schema(example = "false", description = "true 설정 시 학교 정보를 초기화합니다") Boolean clearUniversityCode
 ) {
 
 }

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -82,7 +82,7 @@ public class UserService {
     }
 
     @Transactional
-    public void updateUserInformation(Long userId, String name, String email, Boolean isEmailOn, UniversityCode universityCode) {
+    public void updateUserInformation(Long userId, String name, String email, Boolean isEmailOn, UniversityCode universityCode, Boolean clearUniversityCode) {
         User user = findUser(userId);
 
         if (name != null) {
@@ -97,14 +97,14 @@ public class UserService {
             user.updateEmailOn(isEmailOn);
         }
 
-        if (universityCode != null) {
-
+        if (Boolean.TRUE.equals(clearUniversityCode)) {
+            favoriteRepository.deleteByUserId(userId);
+            user.updateUniversity(null);
+        } else if (universityCode != null) {
             final University university = findUniversityOrThrow(universityCode);
-
             if (isDifferentUniversity(user, university)) {
                 favoriteRepository.deleteByUserId(userId);
             }
-
             user.updateUniversity(university);
         }
     }

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -100,8 +100,12 @@ public class UserService {
         if (Boolean.TRUE.equals(clearUniversityCode)) {
             favoriteRepository.deleteByUserId(userId);
             user.updateUniversity(null);
-        } else if (universityCode != null) {
+            return;
+        }
+
+        if (universityCode != null) {
             final University university = findUniversityOrThrow(universityCode);
+
             if (isDifferentUniversity(user, university)) {
                 favoriteRepository.deleteByUserId(userId);
             }

--- a/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
@@ -232,7 +232,7 @@ public class UserServiceTest {
         when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
 
         // when
-        userService.updateUserInformation(1L, null, "updated@email.com", null, null);
+        userService.updateUserInformation(1L, null, "updated@email.com", null, null, null);
 
         // then
         assertThat(user.getEmail()).isEqualTo("updated@email.com");
@@ -250,7 +250,7 @@ public class UserServiceTest {
         when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
 
         // when
-        userService.updateUserInformation(1L, "변경된이름", null, null, null);
+        userService.updateUserInformation(1L, "변경된이름", null, null, null, null);
 
         // then
         assertThat(user.getName()).isEqualTo("변경된이름");
@@ -273,7 +273,7 @@ public class UserServiceTest {
         when(universityRepository.findByCode(UniversityCode.KONKUK)).thenReturn(Optional.of(konkuk));
 
         // when
-        userService.updateUserInformation(1L, null, null, null, UniversityCode.KONKUK);
+        userService.updateUserInformation(1L, null, null, null, UniversityCode.KONKUK, null);
 
         // then
         assertThat(user.getUniversity()).isEqualTo(konkuk);
@@ -292,7 +292,7 @@ public class UserServiceTest {
         when(universityRepository.findByCode(UniversityCode.KONKUK)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> userService.updateUserInformation(1L, null, null, null, UniversityCode.KONKUK))
+        assertThatThrownBy(() -> userService.updateUserInformation(1L, null, null, null, UniversityCode.KONKUK, null))
                 .isInstanceOf(MokkojiException.class)
                 .hasMessage(FailMessage.NOT_FOUND_UNIVERSITY.getMessage());
     }
@@ -345,7 +345,7 @@ public class UserServiceTest {
         when(universityRepository.findByCode(UniversityCode.KONKUK)).thenReturn(Optional.of(konkuk));
 
         // when
-        userService.updateUserInformation(userId, null, null, null, UniversityCode.KONKUK);
+        userService.updateUserInformation(userId, null, null, null, UniversityCode.KONKUK, null);
 
         // then
         BDDMockito.verify(favoriteRepository).deleteByUserId(userId);
@@ -373,9 +373,90 @@ public class UserServiceTest {
         when(universityRepository.findByCode(UniversityCode.SEJONG)).thenReturn(Optional.of(sejong));
 
         // when
-        userService.updateUserInformation(userId, null, null, null, UniversityCode.SEJONG);
+        userService.updateUserInformation(userId, null, null, null, UniversityCode.SEJONG, null);
 
         // then
+        BDDMockito.verify(favoriteRepository, BDDMockito.never()).deleteByUserId(userId);
+    }
+
+    @Test
+    @DisplayName("clearUniversityCode가 true이면 학교 정보가 초기화된다.")
+    void clearUniversityCode() {
+        // given
+        final Long userId = 1L;
+        final University sejong = University.builder()
+                .name("세종대학교")
+                .code(UniversityCode.SEJONG)
+                .build();
+        ReflectionTestUtils.setField(sejong, "id", 1L);
+
+        final User user = User.builder()
+                .name("모꼬지")
+                .kakaoId("kakao-12341234")
+                .university(sejong)
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        // when
+        userService.updateUserInformation(userId, null, null, null, null, true);
+
+        // then
+        assertThat(user.getUniversity()).isNull();
+        BDDMockito.verify(favoriteRepository).deleteByUserId(userId);
+    }
+
+    @Test
+    @DisplayName("clearUniversityCode가 true이면 universityCode가 함께 전달되어도 학교 정보가 초기화된다.")
+    void clearUniversityCodeTakesPrecedenceOverUniversityCode() {
+        // given
+        final Long userId = 1L;
+        final University sejong = University.builder()
+                .name("세종대학교")
+                .code(UniversityCode.SEJONG)
+                .build();
+        ReflectionTestUtils.setField(sejong, "id", 1L);
+
+        final User user = User.builder()
+                .name("모꼬지")
+                .kakaoId("kakao-12341234")
+                .university(sejong)
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        // when
+        userService.updateUserInformation(userId, null, null, null, UniversityCode.KONKUK, true);
+
+        // then
+        assertThat(user.getUniversity()).isNull();
+        BDDMockito.verify(universityRepository, BDDMockito.never()).findByCode(any());
+    }
+
+    @Test
+    @DisplayName("clearUniversityCode가 false이면 학교 정보가 변경되지 않는다.")
+    void clearUniversityCodeFalseDoesNotClearUniversity() {
+        // given
+        final Long userId = 1L;
+        final University sejong = University.builder()
+                .name("세종대학교")
+                .code(UniversityCode.SEJONG)
+                .build();
+        ReflectionTestUtils.setField(sejong, "id", 1L);
+
+        final User user = User.builder()
+                .name("모꼬지")
+                .kakaoId("kakao-12341234")
+                .university(sejong)
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        // when
+        userService.updateUserInformation(userId, null, null, null, null, false);
+
+        // then
+        assertThat(user.getUniversity()).isEqualTo(sejong);
         BDDMockito.verify(favoriteRepository, BDDMockito.never()).deleteByUserId(userId);
     }
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #427 

## 👷 **작업한 내용**
## 문제상황
`UserService.updateUserInformation()`에서 `universityCode != null` 조건으로 분기하고 있어 필드를 생략한 경우와 명시적으로 `null`을 보낸 경우를 구분하지 못했습니다.

## 해결방법
  `clearUniversityCode: true` 플래그를 추가하여 학교 정보 초기화 의도를 명시적으로 표현할 수 있도록 변경했습니다.

  - clearUniversityCode: true → 학교 정보 초기화 (즐겨찾기도 함께 삭제)
  - clearUniversityCode: false or 필드 생략 + universityCode: "SEJONG" → 학교 변경
  - clearUniversityCode: false or 필드 생략 + universityCode 생략 → 변경 없음

## 🚨 **참고 사항**
초기에는 `universityCode` 필드 타입을 `Optional<UniversityCode>`로 변경하여 필드 생략과 `null` 명시를 구분하려 했습니다.

  그러나 Java record는 생성자를 통해서만 값이 설정되기 때문에 Jackson이 역직렬화 시 필드 생략과 `null` 명시 모두 생성자 파라미터에 `null`을 넘겨 `Optional.empty()`로 처리합니다. 

결국 두 경우를 구분할 수 없어 `clearUniversityCode` 플래그 방식으로 변경했습니다.
