### PR TITLE
Refactor: 관리자 권한 검증 로직을 ManageAuthorizer로 통일

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/auth/service/ManageAuthorizer.java
+++ b/src/main/java/com/greedy/mokkoji/api/auth/service/ManageAuthorizer.java
@@ -50,7 +50,9 @@ public class ManageAuthorizer {
 
         if (AdminRole.MOKKOJI_ADMIN.equals(admin.getRole())) return;
 
-        if (university != null && university.getId().equals(admin.getUniversityId())) return;
+        if (AdminRole.UNIVERSITY_ADMIN.equals(admin.getRole())
+                && university != null
+                && university.getId().equals(admin.getUniversityId())) return;
 
         throw new MokkojiException(FailMessage.FORBIDDEN_MANAGE_CLUB);
     }

--- a/src/main/java/com/greedy/mokkoji/api/club/service/AdminClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/AdminClubService.java
@@ -1,5 +1,6 @@
 package com.greedy.mokkoji.api.club.service;
 
+import com.greedy.mokkoji.api.auth.service.ManageAuthorizer;
 import com.greedy.mokkoji.api.club.dto.response.AdminClubResponse;
 import com.greedy.mokkoji.api.club.dto.response.AdminClubsResponse;
 import com.greedy.mokkoji.api.pagination.dto.PageResponse;
@@ -26,6 +27,7 @@ public class AdminClubService {
 
     private final ClubRepository clubRepository;
     private final AdminRepository adminRepository;
+    private final ManageAuthorizer manageAuthorizer;
 
     @Transactional(readOnly = true)
     public AdminClubsResponse getAdminClubs(
@@ -34,9 +36,7 @@ public class AdminClubService {
             final UniversityCode universityCode,
             final Pageable pageable
     ) {
-        if (!AuthRole.ADMIN.equals(authRole)) {
-            throw new MokkojiException(FailMessage.FORBIDDEN);
-        }
+        manageAuthorizer.validateAdminAuth(authRole, adminId);
 
         final Admin admin = adminRepository.findById(adminId)
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));

--- a/src/main/java/com/greedy/mokkoji/api/clubapplication/service/AdminClubApplicationService.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubapplication/service/AdminClubApplicationService.java
@@ -1,5 +1,6 @@
 package com.greedy.mokkoji.api.clubapplication.service;
 
+import com.greedy.mokkoji.api.auth.service.ManageAuthorizer;
 import com.greedy.mokkoji.api.clubapplication.dto.response.AdminClubApplicationResponse;
 import com.greedy.mokkoji.api.clubapplication.dto.response.AdminClubApplicationsResponse;
 import com.greedy.mokkoji.api.pagination.dto.PageResponse;
@@ -32,6 +33,7 @@ public class AdminClubApplicationService {
     private final ClubApplicationRepository clubApplicationRepository;
     private final ClubRepository clubRepository;
     private final AdminRepository adminRepository;
+    private final ManageAuthorizer manageAuthorizer;
 
     @Transactional(readOnly = true)
     public AdminClubApplicationsResponse getAdminClubApplications(
@@ -41,9 +43,7 @@ public class AdminClubApplicationService {
             final ApplicationStatus status,
             final Pageable pageable
     ) {
-        if (!AuthRole.ADMIN.equals(authRole)) {
-            throw new MokkojiException(FailMessage.FORBIDDEN);
-        }
+        manageAuthorizer.validateAdminAuth(authRole, adminId);
 
         final Admin admin = adminRepository.findById(adminId)
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
@@ -65,20 +65,9 @@ public class AdminClubApplicationService {
 
     @Transactional
     public void approveClubApplication(final AuthRole authRole, final Long adminId, final Long applicationId) {
-        if (!AuthRole.ADMIN.equals(authRole)) {
-            throw new MokkojiException(FailMessage.FORBIDDEN);
-        }
-
-        final Admin admin = adminRepository.findById(adminId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
-
-        final ClubApplication clubApplication = clubApplicationRepository.findById(applicationId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB_APPLICATION));
-
-        if (admin.getRole() == AdminRole.UNIVERSITY_ADMIN &&
-                !admin.getUniversity().getCode().equals(clubApplication.getUniversity().getCode())) {
-            throw new MokkojiException(FailMessage.FORBIDDEN);
-        }
+        manageAuthorizer.validateAdminAuth(authRole, adminId);
+        final ClubApplication clubApplication = findClubApplicationOrThrow(applicationId);
+        manageAuthorizer.validateCanManageUniversity(adminId, clubApplication.getUniversity());
 
         if (clubApplication.getStatus() != ApplicationStatus.PENDING) {
             throw new MokkojiException(FailMessage.CONFLICT_APPLICATION_STATUS);
@@ -104,20 +93,9 @@ public class AdminClubApplicationService {
 
     @Transactional
     public void rejectClubApplication(final AuthRole authRole, final Long adminId, final Long applicationId, final String rejectReason) {
-        if (!AuthRole.ADMIN.equals(authRole)) {
-            throw new MokkojiException(FailMessage.FORBIDDEN);
-        }
-
-        final Admin admin = adminRepository.findById(adminId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
-
-        final ClubApplication clubApplication = clubApplicationRepository.findById(applicationId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB_APPLICATION));
-
-        if (admin.getRole() == AdminRole.UNIVERSITY_ADMIN &&
-                !admin.getUniversity().getCode().equals(clubApplication.getUniversity().getCode())) {
-            throw new MokkojiException(FailMessage.FORBIDDEN);
-        }
+        manageAuthorizer.validateAdminAuth(authRole, adminId);
+        final ClubApplication clubApplication = findClubApplicationOrThrow(applicationId);
+        manageAuthorizer.validateCanManageUniversity(adminId, clubApplication.getUniversity());
 
         if (clubApplication.getStatus() != ApplicationStatus.PENDING) {
             throw new MokkojiException(FailMessage.CONFLICT_APPLICATION_STATUS);
@@ -131,5 +109,10 @@ public class AdminClubApplicationService {
             return admin.getUniversity().getCode();
         }
         return universityCode;
+    }
+
+    private ClubApplication findClubApplicationOrThrow(final Long applicationId) {
+        return clubApplicationRepository.findById(applicationId)
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB_APPLICATION));
     }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #429 

## 👷 **작업한 내용**
변경 전
- AuthRole 비교를 각 메서드 내부에서 직접 수행
- Admin 조회 후 AdminRole 비교를 통해 대학 관리 권한을 직접 검증

변경 후
- ManageAuthorizer.validateAdminAuth() 로 어드민 권한 검증 위임
- ManageAuthorizer.validateCanManageUniversity() 로 대학 관리 권한 검증 위임
- 기존 다른 서비스(AdminClubMasterService)와 동일한 패턴으로 통일


## 🚨 **참고 사항**
혹시 수정 안 된 부분 있으면 알려주시면 감사하겠습니다!