### PR TITLE
 Fix: 동아리장 권한 신청 시 사용자 이름이 변경되지 않도록 수정

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/clubmaster/service/ClubMasterService.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubmaster/service/ClubMasterService.java
@@ -59,8 +59,6 @@ public class ClubMasterService {
         User user = findUserOrThrow(userId);
         validateDuplicateApplication(user, university);
 
-        user.updateName(userName);
-
         ClubMasterApplication application = ClubMasterApplication.builder()
                 .university(university)
                 .club(club)


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #431 

## 👷 **작업한 내용**
 동아리장 권한 신청(`POST /club-master-applications`) 시 신청자가 보낸 이름으로 `User`의 이름까지 덮어써지던 동작을 수정했습니다.                                                                                                    
                                                                                                                                                                  
**[기존] 신청 처리 과정에서 `user.updateName(userName)`을 호출해, 신청 요청에 담긴 이름이 `User` 엔티티의 이름을 변경했습니다.** 

> => 신청이라는 행위만으로 회원의 기본 정보(이름)가 바뀌어 버리는 게 의도와 맞지 않았습니다.                                                                             
                                                                                                                                                                  
[개선] 해당 `user.updateName(userName)` 호출을 제거했습니다.

>  => 요청으로 들어온 이름은 그대로 받아 신청 엔티티(`ClubMasterApplication.userName`)에만 저장되고, `User` 본래의 이름은 변경되지 않습니다. 회원 이름 변경은 기존대로 프로필 수정에서만 이뤄지도록 책임을 분리한 셈입니다.      
                                                                                                                  
## 🚨 **참고 사항**
동아리 생성 신청(`ClubApplication`)은 원래부터 회원 이름을 수정하는 로직이 없어 별도 변경이 필요하지 않았습니다.
