### PR TITLE
Feat: 동아리장 권한 위임 요청에 상태 필드 추가하여 처리 상태 추적

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/clubmaster/service/ClubMasterService.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubmaster/service/ClubMasterService.java
@@ -112,20 +112,23 @@ public class ClubMasterService {
                 .build();
         clubMasterTransferRepository.save(transfer);
 
-        String uri = createClubMasterTransferUri(clubId);
+        String uri = createClubMasterTransferUri(transfer.getId());
         emailService.sendClubMasterTransferNotification(nextClubMasterEmail, club.getName(), uri);
     }
 
     @Transactional
     public void acceptClubMasterTransfer(final Long userId, final String uuid) {
         String key = CLUB_TRANSFER_KEY_PREFIX + KEY_DELIMITER + uuid;
-        String clubId = redisRepository.find(key);
+        String transferId = redisRepository.find(key);
 
-        if (clubId == null) {
+        if (transferId == null) {
             throw new MokkojiException(FailMessage.BAD_REQUEST_INVALID_LINK);
         }
 
-        Club club = findClubOrThrow(Long.parseLong(clubId));
+        ClubMasterTransfer transfer = findClubMasterTransferOrThrow(Long.parseLong(transferId));
+        transfer.approve();
+
+        Club club = transfer.getClub();
 
         User clubMaster = club.getMaster();
         clubMaster.updateRole(UserRole.NORMAL);
@@ -137,10 +140,10 @@ public class ClubMasterService {
         redisRepository.delete(key);
     }
 
-    private String createClubMasterTransferUri(Long clubId) {
+    private String createClubMasterTransferUri(Long transferId) {
         String uuid = UUID.randomUUID().toString();
 
-        redisRepository.save(CLUB_TRANSFER_KEY_PREFIX + KEY_DELIMITER + uuid, String.valueOf(clubId), LINK_EXPIRATION);
+        redisRepository.save(CLUB_TRANSFER_KEY_PREFIX + KEY_DELIMITER + uuid, String.valueOf(transferId), LINK_EXPIRATION);
 
         return ServletUriComponentsBuilder.newInstance()
                 .path("/club-master-transfer/{uuid}")
@@ -161,6 +164,11 @@ public class ClubMasterService {
     private User findUserOrThrow(final Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
+    }
+
+    private ClubMasterTransfer findClubMasterTransferOrThrow(final Long transferId) {
+        return clubMasterTransferRepository.findById(transferId)
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB_MASTER_TRANSFER));
     }
 
     private void validateClubMasterNotExists(Club club) {

--- a/src/main/java/com/greedy/mokkoji/api/clubmaster/service/ClubMasterService.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubmaster/service/ClubMasterService.java
@@ -136,8 +136,6 @@ public class ClubMasterService {
         User nextClubMaster = findUserOrThrow(userId);
         nextClubMaster.updateRole(UserRole.CLUB_MASTER);
         club.updateMaster(nextClubMaster);
-
-        redisRepository.delete(key);
     }
 
     private String createClubMasterTransferUri(Long transferId) {

--- a/src/main/java/com/greedy/mokkoji/db/clubmaster/entity/ClubMasterTransfer.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubmaster/entity/ClubMasterTransfer.java
@@ -1,7 +1,10 @@
 package com.greedy.mokkoji.db.clubmaster.entity;
 
+import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.user.entity.User;
+import com.greedy.mokkoji.enums.clubmaster.TransferStatus;
+import com.greedy.mokkoji.enums.message.FailMessage;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -32,11 +35,27 @@ public class ClubMasterTransfer {
     @Column(name = "next_master_email", columnDefinition = "varchar(50)", nullable = false)
     private String nextMasterEmail;
 
+    @Column(name = "status", columnDefinition = "varchar(20)", nullable = false)
+    @Enumerated(value = EnumType.STRING)
+    private TransferStatus status;
+
     @Builder
     public ClubMasterTransfer(Club club, User previousMaster, String nextMasterName, String nextMasterEmail) {
         this.club = club;
         this.previousMaster = previousMaster;
         this.nextMasterName = nextMasterName;
         this.nextMasterEmail = nextMasterEmail;
+        this.status = TransferStatus.PENDING;
+    }
+
+    public void approve() {
+        validatePendingStatus();
+        this.status = TransferStatus.APPROVED;
+    }
+
+    private void validatePendingStatus() {
+        if (this.status != TransferStatus.PENDING) {
+            throw new MokkojiException(FailMessage.CONFLICT_CLUB_MASTER_TRANSFER_STATUS);
+        }
     }
 }

--- a/src/main/java/com/greedy/mokkoji/db/clubmaster/entity/ClubMasterTransfer.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubmaster/entity/ClubMasterTransfer.java
@@ -1,6 +1,7 @@
 package com.greedy.mokkoji.db.clubmaster.entity;
 
 import com.greedy.mokkoji.common.exception.MokkojiException;
+import com.greedy.mokkoji.db.BaseTime;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.enums.clubmaster.TransferStatus;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "club_master_transfer")
-public class ClubMasterTransfer {
+public class ClubMasterTransfer extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", columnDefinition = "bigint", nullable = false)

--- a/src/main/java/com/greedy/mokkoji/enums/clubmaster/TransferStatus.java
+++ b/src/main/java/com/greedy/mokkoji/enums/clubmaster/TransferStatus.java
@@ -1,0 +1,13 @@
+package com.greedy.mokkoji.enums.clubmaster;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum TransferStatus {
+    PENDING("대기 중"),
+    APPROVED("수락");
+
+    private final String description;
+}

--- a/src/main/java/com/greedy/mokkoji/enums/message/FailMessage.java
+++ b/src/main/java/com/greedy/mokkoji/enums/message/FailMessage.java
@@ -43,6 +43,7 @@ public enum FailMessage {
     NOT_FOUND_ADMIN(HttpStatus.NOT_FOUND, 40408, "관리자를 찾을 수 없습니다."),
     NOT_FOUND_CLUB_APPLICATION(HttpStatus.NOT_FOUND, 40409, "동아리 생성 신청을 찾을 수 없습니다."),
     NOT_FOUND_CLUB_MASTER_APPLICATION(HttpStatus.NOT_FOUND, 40410, "동아리장 신청서를 찾을 수 없습니다."),
+    NOT_FOUND_CLUB_MASTER_TRANSFER(HttpStatus.NOT_FOUND, 40411, "동아리장 위임 요청을 찾을 수 없습니다."),
 
     //405
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, 40500, "잘못된 HTTP 메소드 요청입니다."),
@@ -54,6 +55,7 @@ public enum FailMessage {
     CONFLICT_CLUB_APPLICATION(HttpStatus.CONFLICT, 40903, "동아리 생성 신청이 이미 진행 중입니다."),
     CONFLICT_APPLICATION_STATUS(HttpStatus.CONFLICT, 40904, "처리 가능한 상태의 신청이 아닙니다."),
     CONFLICT_CLUB_MASTER_APPLICATION(HttpStatus.CONFLICT, 40905, "동아리장 신청이 이미 진행 중입니다."),
+    CONFLICT_CLUB_MASTER_TRANSFER_STATUS(HttpStatus.CONFLICT, 40906, "처리 가능한 상태의 위임 요청이 아닙니다."),
 
     //500
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50000, "서버 내부 오류가 발생했습니다."),


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #433 

## 👷 **작업한 내용**
위임 요청의 처리 상태를 남겨 추적에 용이하도록 변경했습니다.
기존에는 `ClubMasterTransfer`가 누가 누구에게 위임했는지만 저장하고, 그 요청이 수락됐는지 아닌지는 알 방법이 없었는데요!
이번에 상태 필드를 추가해서 

> 생성 시점엔 `PENDING`, 수락 시점엔 `APPROVED`

로 권한 위임 흐름을 추적할 수 있도록 개선했습니다.

---

### 1. **위임 상태 enum(`TransferStatus`) 추가**
`PENDING`, `APPROVED` 두 값을 가지는 enum을 새로 만들었습니다. 
기존 `ApplicationStatus`를 재사용할 수도 있었지만, 위임 플로우에는 존재하지 않는 `REJECTED`까지 끌려오게 되어서 그냥 위임 전용 enum으로 분리했습니다!!

### 2. **`ClubMasterTransfer` 엔티티에 상태 필드/전이 로직 추가**
`status` 컬럼을 추가하고 생성자에서 `PENDING`으로 초기화합니다.
수락 시 호출되는 `approve()` 메서드는 `ClubMasterApplication.approve()`와 일관되도록 현재 상태가 `PENDING`일 때만 상태 전이를 허용하도록 했습니다.

> => 이미 처리된 요청의 중복 수락을 막기 위함입니다.    

### 3.  **수락 시점에 해당 위임 요청을 특정해 상태 변경**
위임 요청의 상태를 정확히 기록하려면, 수락 링크가 어떤 `ClubMasterTransfer` 요청에 해당하는지 유일하게 식별할 수 있어야 했습니다.

**[기존]**
기존에는 Redis에 `uuid -> clubId`를 저장했지만, 동아리와 위임 요청은 1:N 관계입니다. 
**같은 동아리에 대해 여러 위임 요청이 생성될 수 있기 때문에** `clubId`만으로는 어떤 요청을 `APPROVED`로 변경해야 하는지 모호했습니다.

**[개선]**
그래서 Redis 저장 값을 `uuid -> transferId`로 변경했습니다.  
위임 링크는 요청 1건마다 발급되므로, `uuid -> transferId`로 저장하면 링크와 위임 요청이 1:1로 연결됩니다. 
수락 시에는 해당 `transferId`로 요청을 직접 조회해 `approve()`를 호출하고, 필요한 `club` 정보는 `transfer.getClub()`에서 얻도록 변경했습니다.

=> 결과적으로, 여러 위임 요청이 존재하더라도 실제 수락된 링크에 해당하는 요청만 `APPROVED`로 변경할 수 있습니다. 

---

 ### [검증]                                                                                                                                                      
(클로드 활용해 검증) 로컬에 MySQL/Redis 실서버를 띄우고, 가상의 동아리장/차기 동아리장/동아리 데이터를 시드한 뒤 실제 API를 호출해 시나리오대로 확인했습니다. 
  - **생성** `POST /club-master-transfers` 
  => 상태코드 `201` 
  => transfer `status=PENDING` 저장 확인
  => Redis 값이 `clubId(100)`가 아닌 **`transferId(2)`** 로 들어가는 것도 확인
                                                                                                                                                  
  - **수락** `GET /club-master-transfer/{uuid}`
   => 상태코드 `200`
   => 기존 동아리장 `CLUB_MASTER→NORMAL` / 차기 동아리장 `NORMAL→CLUB_MASTER` / `club.master_id` 이전 /       
   => transfer **`PENDING→APPROVED`** 
   => Redis 키 삭제 확인                                                                                   
  
  - **가드 경로**: 사용/만료된 링크 재사용 
   => 상태코드 `400`
  - **이미 `APPROVED`된 요청 재수락** 
  => 상태코드 `409`
  - **존재하지 않는 transferId** 
  =>  싱테코드 `404` 로 의도대로 막히는 것 확인
                                                                                                                                                                  
## 🚨 **참고 사항**
-