### PR TITLE
Fix: club_application 컬럼명 db 명세에 맞게 수정

### DIFF
--- a/src/main/java/com/greedy/mokkoji/db/clubapplication/entity/ClubApplication.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubapplication/entity/ClubApplication.java
@@ -31,10 +31,10 @@ public class ClubApplication extends BaseTime {
     @ManyToOne(fetch = FetchType.LAZY)
     private User applicant;
 
-    @Column(name = "application_name", columnDefinition = "varchar(50)", nullable = false)
+    @Column(name = "applicant_name", columnDefinition = "varchar(50)", nullable = false)
     private String applicantName;
 
-    @Column(name = "name", columnDefinition = "varchar(50)", nullable = false)
+    @Column(name = "club_name", columnDefinition = "varchar(50)", nullable = false)
     private String clubName;
 
     @Column(name = "status", columnDefinition = "varchar(20)", nullable = false)


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #435 

## 👷 **작업한 내용**
club_application 테이블의 컬럼명이 DB 설계 명세와 불일치하여 파악하기 어려운 문제를 수정했습니다.
  - application_name → applicant_name
  - name → club_name
<img width="747" height="296" alt="image" src="https://github.com/user-attachments/assets/acf87f1b-adc3-4884-8c6a-06a8c9de8de0" />


## 🚨 **참고 사항**
DB 마이그레이션 스크립트 함께 적용 필요합니다
```sql
ALTER TABLE club_application RENAME COLUMN application_name TO applicant_name;
ALTER TABLE club_application RENAME COLUMN name TO club_name;
```
