### PR TITLE
Fix: 한 사람이 여러 동아리 생성이 가능하도록 개선

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/clubapplication/service/ClubApplicationService.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubapplication/service/ClubApplicationService.java
@@ -34,7 +34,9 @@ public class ClubApplicationService {
         final University university = universityRepository.findByCode(request.universityCode())
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_UNIVERSITY));
 
-        if (clubApplicationRepository.existsByApplicantAndUniversityAndStatusNot(user, university, ApplicationStatus.REJECTED)) {
+        final String clubName = request.clubName();
+
+        if (clubApplicationRepository.existsByApplicantAndUniversityAndClubNameAndStatusNot(user, university, clubName, ApplicationStatus.REJECTED)) {
             throw new MokkojiException(FailMessage.CONFLICT_CLUB_APPLICATION);
         }
 
@@ -42,7 +44,7 @@ public class ClubApplicationService {
                 .university(university)
                 .applicant(user)
                 .applicantName(request.applicantName())
-                .clubName(request.clubName())
+                .clubName(clubName)
                 .clubCategory(request.clubCategory())
                 .clubAffiliation(request.clubAffiliation())
                 .logo(request.logo())

--- a/src/main/java/com/greedy/mokkoji/db/club/entity/Club.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/entity/Club.java
@@ -49,7 +49,7 @@ public class Club extends BaseTime {
     private String instagram;
 
     @JoinColumn(name = "master_id", columnDefinition = "bigint")
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     private User master;
 
     @Builder

--- a/src/main/java/com/greedy/mokkoji/db/clubapplication/repository/ClubApplicationRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubapplication/repository/ClubApplicationRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Repository
 public interface ClubApplicationRepository extends JpaRepository<ClubApplication, Long>, ClubApplicationRepositoryCustom {
 
-    boolean existsByApplicantAndUniversityAndStatusNot(User applicant, University university, ApplicationStatus status);
+    boolean existsByApplicantAndUniversityAndClubNameAndStatusNot(User applicant, University university, String clubName, ApplicationStatus status);
 
     List<ClubApplication> findByApplicant(User applicant);
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #437 

## 👷 **작업한 내용**
한 사람이 여러 동아리를 생성할 수 있다고 논의된 바 있습니다.
하지만 신청 이력이 하나라도 있으면 추가 신청이 막히는 문제가 있었습니다.

 ### 1. 신청 중복 검증을 동아리명 단위로 완화
**[기존]** 
같은 대학에 `REJECTED`가 아닌 신청이 하나라도 있으면 무조건 `CONFLICT_CLUB_APPLICATION` 예외가 터졌습니다. 
그래서 한 사용자가 하나의 동아리만 신청할 수 있는 구조였습니다.

**[개선]** 
같은 신청자/같은 대학/같은 동아리명일 때만 중복으로 막고, 동아리 이름이 다를 경우 여러 건 신청할 수 있도록 개선했습니다. 
QA 포럼에서 논의됐던 2안(동아리명 단위 차단)을 선택했습니다!

### 2. 동아리장-동아리 연관관계를 `@ManyToOne`으로 변경
앞서 1번으로 신청 중복 검증 로직 완화를 했어도 문제가 있었습니다.

**[기존]**
동아리 신청 승인 시 새로운 `Club`을 만들고 해당 동아리에 신청자를 동아리장으로 지정합니다.
하지만 `Club.master`가 `@OneToOne`이라 한 유저가 여러 동아리의 동아리장이 될 수 없는 구조였습니다. 
이런 구조라면 두 번째 동아리 생성 시 충돌이 납니다. 

**[개선]** 
`Club.master`를 `@ManyToOne`으로 바꿔 한 유저가 여러 동아리의 동아리장이 될 수 있게 개선했습니다.

> 보니까 `ClubRepository.findByMaster_Id`가 이미 `List<Club>`를 반환하고 있네용

## 🚨 참고 사항
-