### PR TITLE
Fix: 한 사람이 여러 동아리장 신청이 가능하도록 개선

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/clubapplication/service/ClubApplicationService.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubapplication/service/ClubApplicationService.java
@@ -34,7 +34,9 @@ public class ClubApplicationService {
         final University university = universityRepository.findByCode(request.universityCode())
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_UNIVERSITY));
 
-        if (clubApplicationRepository.existsByApplicantAndUniversityAndStatusNot(user, university, ApplicationStatus.REJECTED)) {
+        final String clubName = request.clubName();
+
+        if (clubApplicationRepository.existsByApplicantAndUniversityAndClubNameAndStatusNot(user, university, clubName, ApplicationStatus.REJECTED)) {
             throw new MokkojiException(FailMessage.CONFLICT_CLUB_APPLICATION);
         }
 
@@ -42,7 +44,7 @@ public class ClubApplicationService {
                 .university(university)
                 .applicant(user)
                 .applicantName(request.applicantName())
-                .clubName(request.clubName())
+                .clubName(clubName)
                 .clubCategory(request.clubCategory())
                 .clubAffiliation(request.clubAffiliation())
                 .logo(request.logo())

--- a/src/main/java/com/greedy/mokkoji/api/clubmaster/service/ClubMasterService.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubmaster/service/ClubMasterService.java
@@ -127,13 +127,13 @@ public class ClubMasterService {
         transfer.approve();
 
         Club club = transfer.getClub();
-
-        User clubMaster = club.getMaster();
-        clubMaster.updateRole(UserRole.NORMAL);
-
+        User previousMaster = club.getMaster();
         User nextClubMaster = findUserOrThrow(userId);
+
         nextClubMaster.updateRole(UserRole.CLUB_MASTER);
         club.updateMaster(nextClubMaster);
+
+        updatePreviousMasterRoleIfNeeded(previousMaster, nextClubMaster);
     }
 
     private String createClubMasterTransferUri(Long transferId) {
@@ -145,6 +145,20 @@ public class ClubMasterService {
                 .path("/club-master-transfer/{uuid}")
                 .buildAndExpand(uuid)
                 .toUriString();
+    }
+
+    private void updatePreviousMasterRoleIfNeeded(
+            final User previousMaster,
+            final User nextClubMaster
+    ) {
+        if (previousMaster == null || previousMaster.getId().equals(nextClubMaster.getId())) {
+            return;
+        }
+
+        boolean isStillClubMaster = clubRepository.existsByMasterId(previousMaster.getId());
+        if (!isStillClubMaster) {
+            previousMaster.updateRole(UserRole.NORMAL);
+        }
     }
 
     private University findUniversityOrThrow(final UniversityCode universityCode) {

--- a/src/main/java/com/greedy/mokkoji/api/clubmaster/service/ClubMasterService.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubmaster/service/ClubMasterService.java
@@ -57,7 +57,7 @@ public class ClubMasterService {
         validateClubMasterNotExists(club);
 
         User user = findUserOrThrow(userId);
-        validateDuplicateApplication(user, university);
+        validateDuplicateApplication(user, club);
 
         ClubMasterApplication application = ClubMasterApplication.builder()
                 .university(university)
@@ -173,8 +173,8 @@ public class ClubMasterService {
         }
     }
 
-    private void validateDuplicateApplication(User user, University university) {
-        if (clubMasterApplicationRepository.existsByUserAndUniversityAndStatusNot(user, university, ApplicationStatus.REJECTED)) {
+    private void validateDuplicateApplication(User user, Club club) {
+        if (clubMasterApplicationRepository.existsByUserAndClubAndStatusNot(user, club, ApplicationStatus.REJECTED)) {
             throw new MokkojiException(FailMessage.CONFLICT_CLUB_MASTER_APPLICATION);
         }
     }

--- a/src/main/java/com/greedy/mokkoji/db/club/entity/Club.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/entity/Club.java
@@ -49,7 +49,7 @@ public class Club extends BaseTime {
     private String instagram;
 
     @JoinColumn(name = "master_id", columnDefinition = "bigint")
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     private User master;
 
     @Builder

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 @Repository
 public interface ClubRepository extends JpaRepository<Club, Long>, ClubRepositoryCustom {
     List<Club> findByMaster_Id(Long userId);
+
+    boolean existsByMasterId(Long masterId);
 }

--- a/src/main/java/com/greedy/mokkoji/db/clubapplication/repository/ClubApplicationRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubapplication/repository/ClubApplicationRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Repository
 public interface ClubApplicationRepository extends JpaRepository<ClubApplication, Long>, ClubApplicationRepositoryCustom {
 
-    boolean existsByApplicantAndUniversityAndStatusNot(User applicant, University university, ApplicationStatus status);
+    boolean existsByApplicantAndUniversityAndClubNameAndStatusNot(User applicant, University university, String clubName, ApplicationStatus status);
 
     List<ClubApplication> findByApplicant(User applicant);
 

--- a/src/main/java/com/greedy/mokkoji/db/clubmaster/entity/ClubMasterApplication.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubmaster/entity/ClubMasterApplication.java
@@ -33,7 +33,7 @@ public class ClubMasterApplication extends BaseTime {
     private Club club;
 
     @JoinColumn(name = "user_id", columnDefinition = "bigint", nullable = false)
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
     @Column(name = "user_name", columnDefinition = "varchar(50)", nullable = false)

--- a/src/main/java/com/greedy/mokkoji/db/clubmaster/repository/ClubMasterApplicationRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubmaster/repository/ClubMasterApplicationRepository.java
@@ -1,7 +1,7 @@
 package com.greedy.mokkoji.db.clubmaster.repository;
 
+import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.clubmaster.entity.ClubMasterApplication;
-import com.greedy.mokkoji.db.university.entity.University;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.enums.application.ApplicationStatus;
 import org.springframework.data.domain.Page;
@@ -17,7 +17,7 @@ public interface ClubMasterApplicationRepository extends JpaRepository<ClubMaste
 
     Page<ClubMasterApplication> findAllByOrderByCreatedAtAsc(Pageable pageable);
 
-    boolean existsByUserAndUniversityAndStatusNot(User user, University university, ApplicationStatus status);
+    boolean existsByUserAndClubAndStatusNot(User user, Club club, ApplicationStatus status);
 
     void deleteByUserId(final Long userId);
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #439 

## 👷 **작업한 내용**
한 사람이 여러 동아리의 동아리장이 될 수 있다고 논의된 바 있습니다.
하지만 이미 동아리장인 경우 다른 동아리의 권한 신청이 막히는 문제가 있었습니다.

### 1. 동아리장 권한 신청-사용자 연관관계를 `@ManyToOne`으로 변경
**[기존]**
`ClubMasterApplication.user`가 `@OneToOne`이라 `user_id`에 유니크 제약이 걸려 있었습니다.
그래서 한 사용자가 동아리장 권한 신청을 하나만 할 수 있는 구조였습니다.

**[개선]** 
한 사람이 여러 동아리의 동아리장 권한을 신청할 수 있도록 개선했습니다.
`ClubMasterApplication.user`를 `@ManyToOne`으로 변경했습니다.

### 2. 중복 검증을 대학 단위 -> 동아리 단위로 완화
**[기존]** 
같은 사용자/같은 대학에 `REJECTED`가 아닌 신청이 하나라도 있으면 무조건 중복 검증 로직으로 막았습니다.

**[개선]** 
같은 동아리에 대한 중복 신청만 차단하고, 다른 동아리라면 신청할 수 있게 개선했습니다.

🚨 참고 사항 
- 동아리장-동아리 연관관계는 PR #440에서 이미 `@ManyToOne`으로 변경되어 이 PR에서는 다루지 않았습니다! 참고 부탁드립니당