### PR TITLE
Feat : 동아리장 권한 신청 조회 API에 필터링 기능 추가

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/auth/service/ManageAuthorizer.java
+++ b/src/main/java/com/greedy/mokkoji/api/auth/service/ManageAuthorizer.java
@@ -63,8 +63,8 @@ public class ManageAuthorizer {
         }
     }
 
-    private Admin findAdminOrThrow(final Long userId) {
-        return adminRepository.findById(userId)
+    private Admin findAdminOrThrow(final Long adminId) {
+        return adminRepository.findById(adminId)
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_ADMIN));
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/club/service/AdminClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/AdminClubService.java
@@ -52,7 +52,7 @@ public class AdminClubService {
 
         return AdminClubsResponse.of(
                 clubs,
-                PageResponse.of(page.getNumber(), page.getSize(), page.getTotalPages(), (int) page.getTotalElements())
+                PageResponse.of(page.getNumber() + 1, page.getSize(), page.getTotalPages(), (int) page.getTotalElements())
         );
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/clubapplication/service/AdminClubApplicationService.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubapplication/service/AdminClubApplicationService.java
@@ -45,9 +45,7 @@ public class AdminClubApplicationService {
     ) {
         manageAuthorizer.validateAdminAuth(authRole, adminId);
 
-        final Admin admin = adminRepository.findById(adminId)
-                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
-
+        final Admin admin = findAdminOrThrow(adminId);
         final UniversityCode targetUniversityCode = resolveUniversityCode(admin, universityCode);
 
         final Page<ClubApplication> page = clubApplicationRepository.findByConditions(targetUniversityCode, status, pageable);
@@ -109,6 +107,11 @@ public class AdminClubApplicationService {
             return admin.getUniversity().getCode();
         }
         return universityCode;
+    }
+
+    private Admin findAdminOrThrow(final Long adminId) {
+        return adminRepository.findById(adminId)
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_ADMIN));
     }
 
     private ClubApplication findClubApplicationOrThrow(final Long applicationId) {

--- a/src/main/java/com/greedy/mokkoji/api/clubapplication/service/AdminClubApplicationService.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubapplication/service/AdminClubApplicationService.java
@@ -57,7 +57,7 @@ public class AdminClubApplicationService {
 
         return AdminClubApplicationsResponse.of(
                 applications,
-                PageResponse.of(page.getNumber(), page.getSize(), page.getTotalPages(), (int) page.getTotalElements())
+                PageResponse.of(page.getNumber() + 1, page.getSize(), page.getTotalPages(), (int) page.getTotalElements())
         );
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/clubmaster/controller/AdminClubMasterController.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubmaster/controller/AdminClubMasterController.java
@@ -6,6 +6,8 @@ import com.greedy.mokkoji.api.auth.controller.argumentResolver.AuthCredential;
 import com.greedy.mokkoji.api.auth.controller.argumentResolver.Authentication;
 import com.greedy.mokkoji.api.clubmaster.service.AdminClubMasterService;
 import com.greedy.mokkoji.common.response.APISuccessResponse;
+import com.greedy.mokkoji.enums.application.ApplicationStatus;
+import com.greedy.mokkoji.enums.university.UniversityCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -22,12 +24,14 @@ public class AdminClubMasterController implements AdminClubMasterSwagger {
     @GetMapping
     public ResponseEntity<APISuccessResponse<GetClubMasterApplicationsResponse>> getClubMasterApplications(
             @Authentication final AuthCredential authCredential,
+            @RequestParam(required = false) final UniversityCode universityCode,
+            @RequestParam(required = false) final ApplicationStatus status,
             @RequestParam(value = "page") final int page,
             @RequestParam(value = "size") final int size) {
         final Pageable pageable = PageRequest.of(page - 1, size);
         return APISuccessResponse.of(
                 HttpStatus.OK,
-                adminClubMasterService.getClubMasterApplications(authCredential.authRole(), authCredential.userId(), pageable)
+                adminClubMasterService.getClubMasterApplications(authCredential.authRole(), authCredential.userId(), universityCode, status, pageable)
         );
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/clubmaster/controller/AdminClubMasterSwagger.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubmaster/controller/AdminClubMasterSwagger.java
@@ -4,6 +4,8 @@ import com.greedy.mokkoji.api.admin.dto.request.RejectClubMasterApplicationReque
 import com.greedy.mokkoji.api.admin.dto.response.GetClubMasterApplicationsResponse;
 import com.greedy.mokkoji.api.auth.controller.argumentResolver.AuthCredential;
 import com.greedy.mokkoji.common.response.APISuccessResponse;
+import com.greedy.mokkoji.enums.application.ApplicationStatus;
+import com.greedy.mokkoji.enums.university.UniversityCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -21,6 +23,8 @@ public interface AdminClubMasterSwagger {
     @ApiResponse(responseCode = "200", description = "조회 성공")
     ResponseEntity<APISuccessResponse<GetClubMasterApplicationsResponse>> getClubMasterApplications(
             @Parameter(hidden = true) AuthCredential authCredential,
+            @Parameter(name = "universityCode", description = "대학교 코드") UniversityCode universityCode,
+            @Parameter(name = "status", description = "신청 상태") ApplicationStatus status,
             @Parameter(name = "page", description = "페이지 번호 (1부터 시작)", example = "1") int page,
             @Parameter(name = "size", description = "페이지 크기", example = "10") int size
     );

--- a/src/main/java/com/greedy/mokkoji/api/clubmaster/service/AdminClubMasterService.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubmaster/service/AdminClubMasterService.java
@@ -62,7 +62,7 @@ public class AdminClubMasterService {
 
         return GetClubMasterApplicationsResponse.of(
                 applications,
-                PageResponse.of(page.getNumber(), page.getSize(), page.getTotalPages(), (int) page.getTotalElements())
+                PageResponse.of(page.getNumber() + 1, page.getSize(), page.getTotalPages(), (int) page.getTotalElements())
         );
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/clubmaster/service/AdminClubMasterService.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubmaster/service/AdminClubMasterService.java
@@ -10,8 +10,11 @@ import com.greedy.mokkoji.db.admin.repository.AdminRepository;
 import com.greedy.mokkoji.db.clubmaster.entity.ClubMasterApplication;
 import com.greedy.mokkoji.db.clubmaster.repository.ClubMasterApplicationRepository;
 import com.greedy.mokkoji.db.user.entity.User;
+import com.greedy.mokkoji.enums.admin.AdminRole;
+import com.greedy.mokkoji.enums.application.ApplicationStatus;
 import com.greedy.mokkoji.enums.auth.AuthRole;
 import com.greedy.mokkoji.enums.message.FailMessage;
+import com.greedy.mokkoji.enums.university.UniversityCode;
 import com.greedy.mokkoji.enums.user.UserRole;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -31,19 +34,20 @@ public class AdminClubMasterService {
     @Transactional(readOnly = true)
     public GetClubMasterApplicationsResponse getClubMasterApplications(
             final AuthRole authRole,
-            final Long userId,
+            final Long adminId,
+            final UniversityCode universityCode,
+            final ApplicationStatus status,
             final Pageable pageable
     ) {
-        manageAuthorizer.validateAdminAuth(authRole, userId);
+        manageAuthorizer.validateAdminAuth(authRole, adminId);
 
-        Admin admin = findAdminOrThrow(userId);
-        Long universityId = admin.getUniversityId();
+        final Admin admin = findAdminOrThrow(adminId);
 
-        Page<ClubMasterApplication> applicationPage = (universityId == null)
-                ? clubMasterApplicationRepository.findAllByOrderByCreatedAtAsc(pageable)
-                : clubMasterApplicationRepository.findByUniversityIdOrderByCreatedAtAsc(universityId, pageable);
+        final UniversityCode targetUniversityCode = resolveUniversityCode(admin, universityCode);
+        final Page<ClubMasterApplication> page = clubMasterApplicationRepository.findByConditions(targetUniversityCode, status, pageable);
 
-        List<ClubMasterApplicationPreviewResponse> applications = applicationPage.getContent().stream()
+        final List<ClubMasterApplicationPreviewResponse> applications = page.getContent()
+                .stream()
                 .map(application -> new ClubMasterApplicationPreviewResponse(
                         application.getId(),
                         application.getUniversity().getName(),
@@ -56,14 +60,10 @@ public class AdminClubMasterService {
                 ))
                 .toList();
 
-        PageResponse pageResponse = PageResponse.of(
-                applicationPage.getNumber() + 1,
-                applicationPage.getSize(),
-                applicationPage.getTotalPages(),
-                (int) applicationPage.getTotalElements()
+        return GetClubMasterApplicationsResponse.of(
+                applications,
+                PageResponse.of(page.getNumber(), page.getSize(), page.getTotalPages(), (int) page.getTotalElements())
         );
-
-        return GetClubMasterApplicationsResponse.of(applications, pageResponse);
     }
 
     @Transactional
@@ -97,13 +97,20 @@ public class AdminClubMasterService {
         application.reject(rejectReason);
     }
 
-    private Admin findAdminOrThrow(final Long userId) {
-        return adminRepository.findById(userId)
+    private Admin findAdminOrThrow(final Long adminId) {
+        return adminRepository.findById(adminId)
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_ADMIN));
     }
 
     private ClubMasterApplication findClubMasterApplicationOrThrow(final Long applicationId) {
         return clubMasterApplicationRepository.findById(applicationId)
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_CLUB_MASTER_APPLICATION));
+    }
+
+    private UniversityCode resolveUniversityCode(final Admin admin, final UniversityCode universityCode) {
+        if (admin.getRole() == AdminRole.UNIVERSITY_ADMIN) {
+            return admin.getUniversity().getCode();
+        }
+        return universityCode;
     }
 }

--- a/src/main/java/com/greedy/mokkoji/db/clubapplication/repository/ClubApplicationRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubapplication/repository/ClubApplicationRepositoryImpl.java
@@ -30,6 +30,7 @@ public class ClubApplicationRepositoryImpl implements ClubApplicationRepositoryC
     ) {
         final List<ClubApplication> content = queryFactory
                 .selectFrom(clubApplication)
+                .join(clubApplication.university).fetchJoin()
                 .where(
                         equalUniversityCode(universityCode),
                         equalStatus(status)

--- a/src/main/java/com/greedy/mokkoji/db/clubmaster/repository/ClubMasterApplicationRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubmaster/repository/ClubMasterApplicationRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 public interface ClubMasterApplicationRepository extends JpaRepository<ClubMasterApplication, Long>, ClubMasterApplicationRepositoryCustom {
     List<ClubMasterApplication> findByUserIdOrderByCreatedAtDesc(Long userId);
 
-    boolean existsByUserAndUniversityAndStatusNot(User user, University university, ApplicationStatus status);
+    boolean existsByUserAndClubAndStatusNot(User user, Club club, ApplicationStatus status);
 
     void deleteByUserId(final Long userId);
 }

--- a/src/main/java/com/greedy/mokkoji/db/clubmaster/repository/ClubMasterApplicationRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubmaster/repository/ClubMasterApplicationRepository.java
@@ -4,18 +4,12 @@ import com.greedy.mokkoji.db.clubmaster.entity.ClubMasterApplication;
 import com.greedy.mokkoji.db.university.entity.University;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.enums.application.ApplicationStatus;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface ClubMasterApplicationRepository extends JpaRepository<ClubMasterApplication, Long> {
+public interface ClubMasterApplicationRepository extends JpaRepository<ClubMasterApplication, Long>, ClubMasterApplicationRepositoryCustom {
     List<ClubMasterApplication> findByUserIdOrderByCreatedAtDesc(Long userId);
-
-    Page<ClubMasterApplication> findByUniversityIdOrderByCreatedAtAsc(Long universityId, Pageable pageable);
-
-    Page<ClubMasterApplication> findAllByOrderByCreatedAtAsc(Pageable pageable);
 
     boolean existsByUserAndUniversityAndStatusNot(User user, University university, ApplicationStatus status);
 

--- a/src/main/java/com/greedy/mokkoji/db/clubmaster/repository/ClubMasterApplicationRepositoryCustom.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubmaster/repository/ClubMasterApplicationRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.greedy.mokkoji.db.clubmaster.repository;
+
+import com.greedy.mokkoji.db.clubmaster.entity.ClubMasterApplication;
+import com.greedy.mokkoji.enums.application.ApplicationStatus;
+import com.greedy.mokkoji.enums.university.UniversityCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ClubMasterApplicationRepositoryCustom {
+    Page<ClubMasterApplication> findByConditions(UniversityCode universityCode, ApplicationStatus status, Pageable pageable);
+}

--- a/src/main/java/com/greedy/mokkoji/db/clubmaster/repository/ClubMasterApplicationRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubmaster/repository/ClubMasterApplicationRepositoryImpl.java
@@ -1,0 +1,69 @@
+package com.greedy.mokkoji.db.clubmaster.repository;
+
+import com.greedy.mokkoji.db.clubmaster.entity.ClubMasterApplication;
+import com.greedy.mokkoji.enums.application.ApplicationStatus;
+import com.greedy.mokkoji.enums.university.UniversityCode;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.greedy.mokkoji.db.clubmaster.entity.QClubMasterApplication.clubMasterApplication;
+
+@Repository
+@RequiredArgsConstructor
+public class ClubMasterApplicationRepositoryImpl implements ClubMasterApplicationRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<ClubMasterApplication> findByConditions(
+            final UniversityCode universityCode,
+            final ApplicationStatus status,
+            final Pageable pageable
+    ) {
+        final List<ClubMasterApplication> content = queryFactory
+                .selectFrom(clubMasterApplication)
+                .where(
+                        equalUniversityCode(universityCode),
+                        equalStatus(status)
+                )
+                .orderBy(clubMasterApplication.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        final long total = Optional.ofNullable(
+                queryFactory
+                        .select(clubMasterApplication.count())
+                        .from(clubMasterApplication)
+                        .where(
+                                equalUniversityCode(universityCode),
+                                equalStatus(status)
+                        )
+                        .fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+    private BooleanExpression equalUniversityCode(final UniversityCode universityCode) {
+        if (universityCode != null) {
+            return clubMasterApplication.university.code.eq(universityCode);
+        }
+        return null;
+    }
+
+    private BooleanExpression equalStatus(final ApplicationStatus status) {
+        if (status != null) {
+            return clubMasterApplication.status.eq(status);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/greedy/mokkoji/db/clubmaster/repository/ClubMasterApplicationRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubmaster/repository/ClubMasterApplicationRepositoryImpl.java
@@ -30,6 +30,8 @@ public class ClubMasterApplicationRepositoryImpl implements ClubMasterApplicatio
     ) {
         final List<ClubMasterApplication> content = queryFactory
                 .selectFrom(clubMasterApplication)
+                .join(clubMasterApplication.university).fetchJoin()
+                .join(clubMasterApplication.club).fetchJoin()
                 .where(
                         equalUniversityCode(universityCode),
                         equalStatus(status)


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #442

## 👷 **작업한 내용**

### 1. 동아리장 신청 목록 필터링 추가
관리자가 동아리장 신청 목록을 조회할 때 아래 조건으로 필터링할 수 있도록 했습니다.
- **대학교 코드** (`universityCode`)
- **신청 상태** (`status`)

두 파라미터 모두 선택값(optional)이라, 기존 조회와 그대로 호환됩니다.
단, 대학 관리자(`UNIVERSITY_ADMIN`)는 본인 소속 대학으로 자동 고정됩니다.

### 2. 조회 방식 통일 (QueryDSL 전환)
기존의 `findByUniversityId...` / `findAllBy...` 분기 조회를 걷어내고,
**동아리 신청 목록 조회와 동일하게 QueryDSL 동적 쿼리(`findByConditions`)로 통일**했습니다.
- `ClubMasterApplicationRepositoryCustom` / `Impl` 추가

### 3. 예외 메시지 정정
존재하지 않는 관리자 조회 시 반환되던 예외를 정정했습니다.
- `NOT_FOUND_USER` → `NOT_FOUND_ADMIN`

### 4. Swagger 문서 반영
추가된 필터 파라미터(`universityCode`, `status`)를 Swagger에 반영했습니다.
