### PR TITLE
Fix: `ClubRepository` 파생 쿼리 메서드명 수정으로 배포 실패 해결

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/clubmaster/service/ClubMasterService.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubmaster/service/ClubMasterService.java
@@ -155,7 +155,7 @@ public class ClubMasterService {
             return;
         }
 
-        boolean isStillClubMaster = clubRepository.existsByMasterId(previousMaster.getId());
+        boolean isStillClubMaster = clubRepository.existsByMaster_Id(previousMaster.getId());
         if (!isStillClubMaster) {
             previousMaster.updateRole(UserRole.NORMAL);
         }

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepository.java
@@ -10,5 +10,5 @@ import java.util.List;
 public interface ClubRepository extends JpaRepository<Club, Long>, ClubRepositoryCustom {
     List<Club> findByMaster_Id(Long userId);
 
-    boolean existsByMasterId(Long masterId);
+    boolean existsByMaster_Id(Long masterId);
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #444 

## 👷 **작업한 내용**
동아리장 위임 권한 정리(#439)가 머지된 뒤, 배포가 실패해 정상적으로 컨테이너가 뜨지 않았습니다.
`clubRepository` 빈을 생성하는 단계에서 ApplicationContext 로딩이 중단되었습니다.
```
  Could not create query for ... ClubRepository.existsByMasterId(java.lang.Long);     
  Could not resolve attribute 'masterId' of 'com.greedy.mokkoji.db.club.entity.Club'
```
### 문제 원인 분석
이번에 추가한 파생 쿼리 `existsByMasterId(Long)` 의 메서드명이 원인이었습니다.

Spring Data는 파생 쿼리 메서드명을 해석할 때 JPA 메타모델뿐 아니라 **자바 빈 프로퍼티(getter)** 도 참조합니다.
`Club`에는 메서드 `getMasterId()`가 있어서, `existsByMasterId` 의 `masterId` 를 **하나의 프로퍼티로 인식**해버립니다.                                                    
하지만 실제로 매핑된 속성은 `master`(연관관계)뿐이고 `masterId` 라는 속성은없기 때문에, 속성 해석에 실패하며 어플리케이션 기동 시점에 예외가 발생했습니다.

**[기존]**
 `existsByMasterId` => `masterId` 를 단일 속성으로 해석 → `getMasterId()` 빈 프로퍼티와 충돌 → 해석 실패                                                                                          
 **[개선]**
`existsByMaster_Id` => 언더스코어로 경로를 명시(`master` 연관관계를 타고`id` 로 traverse)하여 충돌 없이 해석                                                                               
**[이유]**
컴파일 타임엔 잡히지 않고 **기동 시(repository 빈 초기화)에만** 드러나는 결함이라, 메서드명 표기를 안전한 형태로 변경했습니다.


## 🚨 **참고 사항**
-
