### PR TITLE
Feat: 관리자 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/admin/controller/AdminController.java
+++ b/src/main/java/com/greedy/mokkoji/api/admin/controller/AdminController.java
@@ -2,12 +2,16 @@ package com.greedy.mokkoji.api.admin.controller;
 
 import com.greedy.mokkoji.api.admin.dto.request.AdminLoginRequest;
 import com.greedy.mokkoji.api.admin.dto.response.AdminLoginResponse;
+import com.greedy.mokkoji.api.admin.dto.response.AdminInfoResponse;
 import com.greedy.mokkoji.api.admin.service.AdminService;
+import com.greedy.mokkoji.api.auth.controller.argumentResolver.AuthCredential;
+import com.greedy.mokkoji.api.auth.controller.argumentResolver.Authentication;
 import com.greedy.mokkoji.common.response.APISuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +28,14 @@ public class AdminController implements AdminControllerSwagger {
             @RequestBody @Valid final AdminLoginRequest request
     ) {
         final AdminLoginResponse response = adminAuthService.login(request.loginId(), request.password());
+        return APISuccessResponse.of(HttpStatus.OK, response);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<APISuccessResponse<AdminInfoResponse>> getAdminInfo(
+            @Authentication final AuthCredential authCredential
+    ) {
+        final AdminInfoResponse response = adminAuthService.getAdminInfo(authCredential.authRole(), authCredential.userId());
         return APISuccessResponse.of(HttpStatus.OK, response);
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/admin/controller/AdminControllerSwagger.java
+++ b/src/main/java/com/greedy/mokkoji/api/admin/controller/AdminControllerSwagger.java
@@ -2,6 +2,8 @@ package com.greedy.mokkoji.api.admin.controller;
 
 import com.greedy.mokkoji.api.admin.dto.request.AdminLoginRequest;
 import com.greedy.mokkoji.api.admin.dto.response.AdminLoginResponse;
+import com.greedy.mokkoji.api.admin.dto.response.AdminInfoResponse;
+import com.greedy.mokkoji.api.auth.controller.argumentResolver.AuthCredential;
 import com.greedy.mokkoji.common.response.APISuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -23,5 +25,18 @@ public interface AdminControllerSwagger {
     })
     ResponseEntity<APISuccessResponse<AdminLoginResponse>> login(
             @Parameter(name = "request", description = "관리자 로그인 요청 본문") AdminLoginRequest request
+    );
+
+    @Operation(
+            summary = "관리자 정보 조회 API",
+            description = "로그인한 관리자의 권한과 소속 학교 코드를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "관리자 정보 조회 성공"),
+            @ApiResponse(responseCode = "403", description = "관리자 권한이 없는 사용자"),
+            @ApiResponse(responseCode = "404", description = "등록되지 않은 계정")
+    })
+    ResponseEntity<APISuccessResponse<AdminInfoResponse>> getAdminInfo(
+            @Parameter(hidden = true) AuthCredential authCredential
     );
 }

--- a/src/main/java/com/greedy/mokkoji/api/admin/dto/response/AdminInfoResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/admin/dto/response/AdminInfoResponse.java
@@ -1,0 +1,19 @@
+package com.greedy.mokkoji.api.admin.dto.response;
+
+import com.greedy.mokkoji.enums.admin.AdminRole;
+import com.greedy.mokkoji.enums.university.UniversityCode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+public record AdminInfoResponse(
+        @Schema(example = "UNIVERSITY_ADMIN") AdminRole role,
+        @Schema(example = "SEJONG") UniversityCode universityCode
+) {
+    public static AdminInfoResponse of(final AdminRole role, final UniversityCode universityCode) {
+        return AdminInfoResponse.builder()
+                .role(role)
+                .universityCode(universityCode)
+                .build();
+    }
+}

--- a/src/main/java/com/greedy/mokkoji/api/admin/service/AdminService.java
+++ b/src/main/java/com/greedy/mokkoji/api/admin/service/AdminService.java
@@ -1,7 +1,9 @@
 package com.greedy.mokkoji.api.admin.service;
 
 import com.greedy.mokkoji.api.admin.dto.response.AdminLoginResponse;
+import com.greedy.mokkoji.api.admin.dto.response.AdminInfoResponse;
 import com.greedy.mokkoji.api.auth.dto.TokenPair;
+import com.greedy.mokkoji.api.auth.service.ManageAuthorizer;
 import com.greedy.mokkoji.api.user.service.TokenService;
 import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.db.admin.entity.Admin;
@@ -20,6 +22,7 @@ public class AdminService {
     private final AdminRepository adminRepository;
     private final PasswordEncoder passwordEncoder;
     private final TokenService tokenService;
+    private final ManageAuthorizer manageAuthorizer;
 
     @Transactional
     public AdminLoginResponse login(final String loginId, final String password) {
@@ -32,5 +35,15 @@ public class AdminService {
 
         final TokenPair tokenPair = tokenService.issueTokens(AuthRole.ADMIN, admin.getId());
         return AdminLoginResponse.of(tokenPair.accessToken(), tokenPair.refreshToken());
+    }
+
+    @Transactional(readOnly = true)
+    public AdminInfoResponse getAdminInfo(final AuthRole authRole, final Long adminId) {
+        manageAuthorizer.validateAdminAuth(authRole, adminId);
+
+        final Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_ADMIN));
+
+        return AdminInfoResponse.of(admin.getRole(), admin.getUniversityCode());
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/auth/service/ManageAuthorizer.java
+++ b/src/main/java/com/greedy/mokkoji/api/auth/service/ManageAuthorizer.java
@@ -42,7 +42,7 @@ public class ManageAuthorizer {
 
         if (AuthRole.ADMIN.equals(authRole)) return;
 
-        throw new MokkojiException(FailMessage.FORBIDDEN_MANAGE_UNIVERSITY_CLUB);
+        throw new MokkojiException(FailMessage.FORBIDDEN_ADMIN);
     }
 
     public void validateCanManageUniversity(final Long adminId, final University university) {

--- a/src/main/java/com/greedy/mokkoji/db/admin/entity/Admin.java
+++ b/src/main/java/com/greedy/mokkoji/db/admin/entity/Admin.java
@@ -3,6 +3,7 @@ package com.greedy.mokkoji.db.admin.entity;
 import com.greedy.mokkoji.db.BaseTime;
 import com.greedy.mokkoji.db.university.entity.University;
 import com.greedy.mokkoji.enums.admin.AdminRole;
+import com.greedy.mokkoji.enums.university.UniversityCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -50,5 +51,10 @@ public class Admin extends BaseTime {
     public Long getUniversityId() {
         if (university == null) return null;
         return university.getId();
+    }
+
+    public UniversityCode getUniversityCode() {
+        if (university == null) return null;
+        return university.getCode();
     }
 }

--- a/src/main/java/com/greedy/mokkoji/enums/message/FailMessage.java
+++ b/src/main/java/com/greedy/mokkoji/enums/message/FailMessage.java
@@ -28,7 +28,7 @@ public enum FailMessage {
     FORBIDDEN_MANAGE_CLUB(HttpStatus.FORBIDDEN, 40301, "동아리를 관리할 수 있는 권한이 없습니다."),
     FORBIDDEN_ALREADY_EXIST_COMMENT(HttpStatus.FORBIDDEN, 40302, "이미 댓글이 존재합니다."),
     FORBIDDEN_NOT_COMMENT_WRITER(HttpStatus.FORBIDDEN, 40303, "댓글을 작성한 사용자가 아닙니다."),
-    FORBIDDEN_MANAGE_UNIVERSITY_CLUB(HttpStatus.FORBIDDEN, 40304, "대학 동아리들을 관리할 수 있는 권한이 없습니다."),
+    FORBIDDEN_ADMIN(HttpStatus.FORBIDDEN, 40304, "관리자 권한이 없습니다."),
     FORBIDDEN_ALREADY_EXIST_CLUB_MASTER(HttpStatus.FORBIDDEN, 40305, "해당 동아리에 이미 등록된 동아리장이 존재합니다."),
 
     //404

--- a/src/test/java/com/greedy/mokkoji/admin/service/AdminAuthServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/admin/service/AdminAuthServiceTest.java
@@ -1,15 +1,20 @@
 package com.greedy.mokkoji.admin.service;
 
 import com.greedy.mokkoji.api.admin.dto.response.AdminLoginResponse;
+import com.greedy.mokkoji.api.admin.dto.response.AdminInfoResponse;
 import com.greedy.mokkoji.api.admin.service.AdminService;
 import com.greedy.mokkoji.api.auth.dto.TokenPair;
+import com.greedy.mokkoji.api.auth.service.ManageAuthorizer;
 import com.greedy.mokkoji.api.user.service.TokenService;
 import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.common.fixture.Fixture;
 import com.greedy.mokkoji.db.admin.entity.Admin;
 import com.greedy.mokkoji.db.admin.repository.AdminRepository;
+import com.greedy.mokkoji.db.university.entity.University;
+import com.greedy.mokkoji.enums.admin.AdminRole;
 import com.greedy.mokkoji.enums.auth.AuthRole;
 import com.greedy.mokkoji.enums.message.FailMessage;
+import com.greedy.mokkoji.enums.university.UniversityCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -26,6 +31,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -46,6 +52,9 @@ class AdminAuthServiceTest {
 
     @Mock
     private TokenService tokenService;
+
+    @Mock
+    private ManageAuthorizer manageAuthorizer;
 
     @Test
     @DisplayName("아이디와 비밀번호가 일치하면 토큰을 발급한다.")
@@ -100,5 +109,73 @@ class AdminAuthServiceTest {
                 .hasMessage(FailMessage.UNAUTHORIZED_ADMIN_LOGIN.getMessage());
 
         verifyNoInteractions(tokenService);
+    }
+
+    @Test
+    @DisplayName("총동연 관리자의 정보를 조회하면 권한과 소속 학교 코드를 반환한다.")
+    void getAdminInfo_universityAdmin() {
+        //given
+        final University university = Fixture.createUniversity();
+        final Admin admin = Admin.builder()
+                .university(university)
+                .loginId("univ-admin@sejong.ac.kr")
+                .password("encodedPassword")
+                .role(AdminRole.UNIVERSITY_ADMIN)
+                .build();
+        ReflectionTestUtils.setField(admin, "id", 1L);
+
+        given(adminRepository.findById(1L)).willReturn(Optional.of(admin));
+
+        //when
+        final AdminInfoResponse response = adminAuthService.getAdminInfo(AuthRole.ADMIN, 1L);
+
+        //then
+        assertThat(response.role()).isEqualTo(AdminRole.UNIVERSITY_ADMIN);
+        assertThat(response.universityCode()).isEqualTo(UniversityCode.SEJONG);
+        verify(manageAuthorizer, times(1)).validateAdminAuth(AuthRole.ADMIN, 1L);
+    }
+
+    @Test
+    @DisplayName("모꼬지 관리자의 정보를 조회하면 학교 코드는 null을 반환한다.")
+    void getAdminInfo_mokkojiAdmin() {
+        //given
+        final Admin admin = Fixture.createAdmin();
+        ReflectionTestUtils.setField(admin, "id", 1L);
+
+        given(adminRepository.findById(1L)).willReturn(Optional.of(admin));
+
+        //when
+        final AdminInfoResponse response = adminAuthService.getAdminInfo(AuthRole.ADMIN, 1L);
+
+        //then
+        assertThat(response.role()).isEqualTo(AdminRole.MOKKOJI_ADMIN);
+        assertThat(response.universityCode()).isNull();
+    }
+
+    @Test
+    @DisplayName("관리자 권한이 없으면 예외를 던지고 관리자를 조회하지 않는다.")
+    void getAdminInfo_notAdmin() {
+        //given
+        willThrow(new MokkojiException(FailMessage.FORBIDDEN_MANAGE_UNIVERSITY_CLUB))
+                .given(manageAuthorizer).validateAdminAuth(AuthRole.USER, 1L);
+
+        //when & then
+        assertThatThrownBy(() -> adminAuthService.getAdminInfo(AuthRole.USER, 1L))
+                .isInstanceOf(MokkojiException.class)
+                .hasMessage(FailMessage.FORBIDDEN_MANAGE_UNIVERSITY_CLUB.getMessage());
+
+        verifyNoInteractions(adminRepository);
+    }
+
+    @Test
+    @DisplayName("등록되지 않은 관리자면 NOT_FOUND 예외를 던진다.")
+    void getAdminInfo_notFoundAdmin() {
+        //given
+        given(adminRepository.findById(1L)).willReturn(Optional.empty());
+
+        //when & then
+        assertThatThrownBy(() -> adminAuthService.getAdminInfo(AuthRole.ADMIN, 1L))
+                .isInstanceOf(MokkojiException.class)
+                .hasMessage(FailMessage.NOT_FOUND_ADMIN.getMessage());
     }
 }

--- a/src/test/java/com/greedy/mokkoji/admin/service/AdminAuthServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/admin/service/AdminAuthServiceTest.java
@@ -156,13 +156,13 @@ class AdminAuthServiceTest {
     @DisplayName("관리자 권한이 없으면 예외를 던지고 관리자를 조회하지 않는다.")
     void getAdminInfo_notAdmin() {
         //given
-        willThrow(new MokkojiException(FailMessage.FORBIDDEN_MANAGE_UNIVERSITY_CLUB))
+        willThrow(new MokkojiException(FailMessage.FORBIDDEN_ADMIN))
                 .given(manageAuthorizer).validateAdminAuth(AuthRole.USER, 1L);
 
         //when & then
         assertThatThrownBy(() -> adminAuthService.getAdminInfo(AuthRole.USER, 1L))
                 .isInstanceOf(MokkojiException.class)
-                .hasMessage(FailMessage.FORBIDDEN_MANAGE_UNIVERSITY_CLUB.getMessage());
+                .hasMessage(FailMessage.FORBIDDEN_ADMIN.getMessage());
 
         verifyNoInteractions(adminRepository);
     }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #446 

## 👷 **작업한 내용**
관리자의 권한과 소속 학교 코드를 내려주는 관리자 정보 조회 API를 구현했습니다.
논의된 내용대로, 필요한 값을 로그인 응답에 직접 추가하는 대신 별도의 조회 API로 분리하는 방식으로 채택했습니다~

> **[다른 방안]** 로그인 응답에 `role`, `universityCode` 등을 추가하는 구조: 새 요구사항이 생길 때마다 로그인 스펙을 계속 수정해야 합니다.                  
> **[해당 방안]** 로그인 응답은 토큰 발급(인증) 책임만 유지하고 관리자 정보는 조회 API 응답만 확장: 변경의 영향 범위를 관리자 조회 API 안으로 최소화할 수 있습니다.

## 🚨 **참고 사항**
-