### PR TITLE
Chore : 모니터링 서버 포트 수정

### DIFF
--- a/.github/workflows/CICD-prod.yml
+++ b/.github/workflows/CICD-prod.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '21'
+          cache: 'gradle'
 
       - name: application.yml 생성
         run: |

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -3,29 +3,25 @@ services:
     container_name: redis
     image: redis:alpine
     hostname: redis
+    restart: unless-stopped
     ports:
       - "6379:6379"
 
   blue:
     container_name: blue
     image: mokkojiteam/mokkoji
-    expose:
-      - 8080
-      - 9292
     ports:
       - "8081:8080"
-      - "9293:9292"
+      - "9091:9090"
     depends_on:
       - redis
 
   green:
     container_name: green
     image: mokkojiteam/mokkoji
-    expose:
-      - 8080
-      - 9292
     ports:
       - "8082:8080"
-      - "9292:9292"
+      - "9092:9090"
     depends_on:
       - redis
+


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #448

## 👷 **작업한 내용**
### 1. 모니터링 서버 포트 수정
<img width="993" height="651" alt="Screenshot 2026-07-07 at 12 10 34 AM" src="https://github.com/user-attachments/assets/e947e228-1354-49e0-bb86-547cab0ff3bf" />

기존의 모니터링 서버는 9292로 되어있었는 데 (모꼬지 데모데이 시절 만들었던 레거시 코드)
모니터링 서버 포트 를 위의 사진대로 다시 구성하고 프로메테우스 포트(9292->9090)를 수정하였습니다.

### 2. 빌드 속도 개선을 위한 gradle 캐시 적용
(기존 ver)
* 빌드 시 gradle 의존성을 전부 다 다운로드

(수정 ver)
* 빌드 시 gradle 의존성에서 바뀐 부분만 반영

## 🚨 **참고 사항**
* 지금 prod에 있는 파일들은 수동으로 수정해서 반영해두었습니다.
(혹시 몰라 그 전 파일들은 [이 곳](https://app.notion.com/p/mokkoji/3007455c17d0806ea6d7c172ebbd9e94?p=3947455c17d080d495a2c69caea0754f&pm=s)에 정리해주었습니다.)
