### PR TITLE
Refactor: AuthCredential.userId -> accountId 로 네이밍 변경

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/admin/controller/AdminController.java
+++ b/src/main/java/com/greedy/mokkoji/api/admin/controller/AdminController.java
@@ -35,7 +35,7 @@ public class AdminController implements AdminControllerSwagger {
     public ResponseEntity<APISuccessResponse<AdminInfoResponse>> getAdminInfo(
             @Authentication final AuthCredential authCredential
     ) {
-        final AdminInfoResponse response = adminAuthService.getAdminInfo(authCredential.authRole(), authCredential.userId());
+        final AdminInfoResponse response = adminAuthService.getAdminInfo(authCredential.authRole(), authCredential.accountId());
         return APISuccessResponse.of(HttpStatus.OK, response);
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/auth/controller/argumentResolver/AuthCredential.java
+++ b/src/main/java/com/greedy/mokkoji/api/auth/controller/argumentResolver/AuthCredential.java
@@ -4,6 +4,6 @@ import com.greedy.mokkoji.enums.auth.AuthRole;
 
 public record AuthCredential(
         AuthRole authRole,
-        Long userId
+        Long accountId
 ) {
 }

--- a/src/main/java/com/greedy/mokkoji/api/auth/service/ManageAuthorizer.java
+++ b/src/main/java/com/greedy/mokkoji/api/auth/service/ManageAuthorizer.java
@@ -21,24 +21,24 @@ public class ManageAuthorizer {
     private final UserRepository userRepository;
     private final AdminRepository adminRepository;
 
-    public void validateCanManageClub(final AuthRole authRole, final Long userId, final Club club) {
-        validateAuthenticated(userId);
+    public void validateCanManageClub(final AuthRole authRole, final Long accountId, final Club club) {
+        validateAuthenticated(accountId);
 
         if (AuthRole.ADMIN.equals(authRole)) {
-            Admin admin = findAdminOrThrow(userId);
+            Admin admin = findAdminOrThrow(accountId);
             if (AdminRole.MOKKOJI_ADMIN.equals(admin.getRole())) return;
         }
 
         if (AuthRole.USER.equals(authRole)) {
-            User user = findUserOrThrow(userId);
-            if (user.getRole() == UserRole.CLUB_MASTER && club.getMasterId().equals(userId)) return;
+            User user = findUserOrThrow(accountId);
+            if (user.getRole() == UserRole.CLUB_MASTER && club.getMasterId().equals(accountId)) return;
         }
 
         throw new MokkojiException(FailMessage.FORBIDDEN_MANAGE_CLUB);
     }
 
-    public void validateAdminAuth(final AuthRole authRole, final Long userId) {
-        validateAuthenticated(userId);
+    public void validateAdminAuth(final AuthRole authRole, final Long accountId) {
+        validateAuthenticated(accountId);
 
         if (AuthRole.ADMIN.equals(authRole)) return;
 
@@ -57,14 +57,14 @@ public class ManageAuthorizer {
         throw new MokkojiException(FailMessage.FORBIDDEN_MANAGE_CLUB);
     }
 
-    private void validateAuthenticated(final Long userId) {
-        if (userId == null) {
+    private void validateAuthenticated(final Long accountId) {
+        if (accountId == null) {
             throw new MokkojiException(FailMessage.UNAUTHORIZED);
         }
     }
 
-    private Admin findAdminOrThrow(final Long userId) {
-        return adminRepository.findById(userId)
+    private Admin findAdminOrThrow(final Long adminId) {
+        return adminRepository.findById(adminId)
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_ADMIN));
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/club/controller/AdminClubController.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/controller/AdminClubController.java
@@ -33,7 +33,7 @@ public class AdminClubController implements AdminClubControllerSwagger {
         final Pageable pageable = PageRequest.of(page - 1, size);
         return APISuccessResponse.of(
                 HttpStatus.OK,
-                adminClubService.getAdminClubs(authCredential.authRole(), authCredential.userId(), universityCode, pageable)
+                adminClubService.getAdminClubs(authCredential.authRole(), authCredential.accountId(), universityCode, pageable)
         );
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/club/controller/ClubController.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/controller/ClubController.java
@@ -34,7 +34,7 @@ public class ClubController implements ClubControllerSwagger {
     ) {
         return APISuccessResponse.of(
                 HttpStatus.OK,
-                clubService.findClub(authCredential.userId(), clubId)
+                clubService.findClub(authCredential.accountId(), clubId)
         );
     }
 
@@ -50,7 +50,7 @@ public class ClubController implements ClubControllerSwagger {
         return APISuccessResponse.of(
                 HttpStatus.OK,
                 clubService.findClubsByConditions(
-                        authCredential.userId(),
+                        authCredential.accountId(),
                         universityCode,
                         clubSearchCond.keyword(),
                         clubSearchCond.category(),
@@ -74,7 +74,7 @@ public class ClubController implements ClubControllerSwagger {
         final Pageable pageable = PageRequest.of(page - 1, size);
         return APISuccessResponse.of(
                 HttpStatus.OK,
-                clubService.getAllClubs(authCredential.userId(), universityCode, keyword, affiliation, category, pageable)
+                clubService.getAllClubs(authCredential.accountId(), universityCode, keyword, affiliation, category, pageable)
         );
     }
 
@@ -88,7 +88,7 @@ public class ClubController implements ClubControllerSwagger {
                 HttpStatus.OK,
                 clubService.updateClub(
                         authCredential.authRole(),
-                        authCredential.userId(),
+                        authCredential.accountId(),
                         clubId,
                         clubUpdateRequest.name(),
                         clubUpdateRequest.category(),

--- a/src/main/java/com/greedy/mokkoji/api/clubapplication/controller/AdminClubApplicationController.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubapplication/controller/AdminClubApplicationController.java
@@ -33,7 +33,7 @@ public class AdminClubApplicationController implements AdminClubApplicationContr
         final Pageable pageable = PageRequest.of(page - 1, size);
         return APISuccessResponse.of(
                 HttpStatus.OK,
-                adminClubApplicationService.getAdminClubApplications(authCredential.authRole(), authCredential.userId(), universityCode, status, pageable)
+                adminClubApplicationService.getAdminClubApplications(authCredential.authRole(), authCredential.accountId(), universityCode, status, pageable)
         );
     }
 
@@ -42,7 +42,7 @@ public class AdminClubApplicationController implements AdminClubApplicationContr
             @Authentication final AuthCredential authCredential,
             @PathVariable final Long applicationId
     ) {
-        adminClubApplicationService.approveClubApplication(authCredential.authRole(), authCredential.userId(), applicationId);
+        adminClubApplicationService.approveClubApplication(authCredential.authRole(), authCredential.accountId(), applicationId);
         return APISuccessResponse.of(HttpStatus.OK, null);
     }
 
@@ -52,7 +52,7 @@ public class AdminClubApplicationController implements AdminClubApplicationContr
             @PathVariable final Long applicationId,
             @RequestBody final ClubApplicationRejectRequest request
     ) {
-        adminClubApplicationService.rejectClubApplication(authCredential.authRole(), authCredential.userId(), applicationId, request.rejectReason());
+        adminClubApplicationService.rejectClubApplication(authCredential.authRole(), authCredential.accountId(), applicationId, request.rejectReason());
         return APISuccessResponse.of(HttpStatus.OK, null);
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/clubapplication/controller/ClubApplicationController.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubapplication/controller/ClubApplicationController.java
@@ -23,7 +23,7 @@ public class ClubApplicationController implements ClubApplicationControllerSwagg
             @RequestBody final ClubApplicationCreateRequest request,
             @Authentication final AuthCredential authCredential
     ) {
-        clubApplicationService.createClubApplication(authCredential.userId(), request);
+        clubApplicationService.createClubApplication(authCredential.accountId(), request);
         return APISuccessResponse.of(HttpStatus.CREATED, null);
     }
 
@@ -33,7 +33,7 @@ public class ClubApplicationController implements ClubApplicationControllerSwagg
     ) {
         return APISuccessResponse.of(
                 HttpStatus.OK,
-                clubApplicationService.getMyClubApplications(authCredential.userId())
+                clubApplicationService.getMyClubApplications(authCredential.accountId())
         );
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/clubmaster/controller/AdminClubMasterController.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubmaster/controller/AdminClubMasterController.java
@@ -27,7 +27,7 @@ public class AdminClubMasterController implements AdminClubMasterSwagger {
         final Pageable pageable = PageRequest.of(page - 1, size);
         return APISuccessResponse.of(
                 HttpStatus.OK,
-                adminClubMasterService.getClubMasterApplications(authCredential.authRole(), authCredential.userId(), pageable)
+                adminClubMasterService.getClubMasterApplications(authCredential.authRole(), authCredential.accountId(), pageable)
         );
     }
 
@@ -36,7 +36,7 @@ public class AdminClubMasterController implements AdminClubMasterSwagger {
             @Authentication final AuthCredential authCredential,
             @PathVariable(name = "applicationId") final Long applicationId
     ) {
-        adminClubMasterService.approveClubMasterApplication(authCredential.authRole(), authCredential.userId(), applicationId);
+        adminClubMasterService.approveClubMasterApplication(authCredential.authRole(), authCredential.accountId(), applicationId);
         return APISuccessResponse.of(HttpStatus.CREATED, null);
     }
 
@@ -46,7 +46,7 @@ public class AdminClubMasterController implements AdminClubMasterSwagger {
             @PathVariable(name = "applicationId") final Long applicationId,
             @RequestBody RejectClubMasterApplicationRequest request
     ) {
-        adminClubMasterService.rejectClubMasterApplication(authCredential.authRole(), authCredential.userId(), applicationId, request.rejectReason());
+        adminClubMasterService.rejectClubMasterApplication(authCredential.authRole(), authCredential.accountId(), applicationId, request.rejectReason());
         return APISuccessResponse.of(HttpStatus.CREATED, null);
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/clubmaster/controller/ClubMasterController.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubmaster/controller/ClubMasterController.java
@@ -27,7 +27,7 @@ public class ClubMasterController implements ClubMasterControllerSwagger {
             @RequestBody final CreateClubMasterApplicationRequest request
     ) {
         clubMasterApplicationService.createClubMasterApplication(
-                authCredential.userId(),
+                authCredential.accountId(),
                 request.universityCode(),
                 request.clubId(),
                 request.userName()
@@ -42,7 +42,7 @@ public class ClubMasterController implements ClubMasterControllerSwagger {
     ) {
         return APISuccessResponse.of(
                 HttpStatus.OK,
-                clubMasterApplicationService.getMyClubMasterApplications(authCredential.userId())
+                clubMasterApplicationService.getMyClubMasterApplications(authCredential.accountId())
         );
     }
 
@@ -53,7 +53,7 @@ public class ClubMasterController implements ClubMasterControllerSwagger {
     ) {
         clubMasterApplicationService.applyClubMasterTransfer(
                 authCredential.authRole(),
-                authCredential.userId(),
+                authCredential.accountId(),
                 request.clubId(),
                 request.nextClubMasterName(),
                 request.nextClubMasterEmail()
@@ -67,7 +67,7 @@ public class ClubMasterController implements ClubMasterControllerSwagger {
             @Authentication final AuthCredential authCredential,
             @PathVariable("uuid") final String uuid
     ) {
-        clubMasterApplicationService.acceptClubMasterTransfer(authCredential.userId(), uuid);
+        clubMasterApplicationService.acceptClubMasterTransfer(authCredential.accountId(), uuid);
 
         return APISuccessResponse.of(HttpStatus.OK, null);
     }

--- a/src/main/java/com/greedy/mokkoji/api/comment/controller/CommentController.java
+++ b/src/main/java/com/greedy/mokkoji/api/comment/controller/CommentController.java
@@ -28,7 +28,7 @@ public class CommentController implements CommentControllerSwagger {
             @Authentication final AuthCredential authCredential
     ) {
         commentService.createComment(
-                authCredential.userId(),
+                authCredential.accountId(),
                 clubId,
                 commentCreateRequest.rate(),
                 commentCreateRequest.content()
@@ -43,7 +43,7 @@ public class CommentController implements CommentControllerSwagger {
     ) {
         return APISuccessResponse.of(
                 HttpStatus.OK,
-                commentService.getComments(authCredential.userId(), clubId)
+                commentService.getComments(authCredential.accountId(), clubId)
         );
     }
 
@@ -53,7 +53,7 @@ public class CommentController implements CommentControllerSwagger {
     ) {
         return APISuccessResponse.of(
                 HttpStatus.OK,
-                commentService.getAllMyComments(authCredential.userId())
+                commentService.getAllMyComments(authCredential.accountId())
         );
     }
 
@@ -64,7 +64,7 @@ public class CommentController implements CommentControllerSwagger {
             @Authentication final AuthCredential authCredential
     ) {
         commentService.updateComment(
-                authCredential.userId(),
+                authCredential.accountId(),
                 commentId,
                 commentUpdateRequest.rate(),
                 commentUpdateRequest.content()
@@ -77,7 +77,7 @@ public class CommentController implements CommentControllerSwagger {
             @PathVariable(name = "commentId") final Long commentId,
             @Authentication final AuthCredential authCredential
     ) {
-        commentService.deleteComment(authCredential.userId(), commentId);
+        commentService.deleteComment(authCredential.accountId(), commentId);
         return APISuccessResponse.of(HttpStatus.OK, null);
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/greedy/mokkoji/api/favorite/controller/FavoriteController.java
@@ -28,7 +28,7 @@ public class FavoriteController implements FavoriteControllerSwagger {
             @Authentication final AuthCredential authCredential,
             @PathVariable(name = "clubId") final Long clubId
     ) {
-        return APISuccessResponse.of(HttpStatus.CREATED, favoriteService.addFavorite(authCredential.userId(), clubId));
+        return APISuccessResponse.of(HttpStatus.CREATED, favoriteService.addFavorite(authCredential.accountId(), clubId));
     }
 
     @GetMapping
@@ -38,7 +38,7 @@ public class FavoriteController implements FavoriteControllerSwagger {
             @RequestParam(value = "size") final int size
     ) {
         final Pageable pageable = PageRequest.of(page - 1, size);
-        return APISuccessResponse.of(HttpStatus.OK, favoriteService.findFavoriteClubs(authCredential.userId(), pageable));
+        return APISuccessResponse.of(HttpStatus.OK, favoriteService.findFavoriteClubs(authCredential.accountId(), pageable));
     }
 
     @DeleteMapping("/{clubId}")
@@ -46,7 +46,7 @@ public class FavoriteController implements FavoriteControllerSwagger {
             @Authentication final AuthCredential authCredential,
             @PathVariable(name = "clubId") final Long clubId
     ) {
-        return APISuccessResponse.of(HttpStatus.NO_CONTENT, favoriteService.deleteFavorite(authCredential.userId(), clubId));
+        return APISuccessResponse.of(HttpStatus.NO_CONTENT, favoriteService.deleteFavorite(authCredential.accountId(), clubId));
     }
 
     @GetMapping("/recruit")
@@ -54,6 +54,6 @@ public class FavoriteController implements FavoriteControllerSwagger {
             @Authentication final AuthCredential authCredential,
             @RequestParam(name = "yearMonth") YearMonth yearMonth
     ) {
-        return APISuccessResponse.of(HttpStatus.OK, favoriteService.getRecruitClubs(authCredential.userId(), yearMonth));
+        return APISuccessResponse.of(HttpStatus.OK, favoriteService.getRecruitClubs(authCredential.accountId(), yearMonth));
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/feedback/controller/FeedbackController.java
+++ b/src/main/java/com/greedy/mokkoji/api/feedback/controller/FeedbackController.java
@@ -27,7 +27,7 @@ public class FeedbackController implements FeedbackControllerSwagger {
     ) {
         return APISuccessResponse.of(
                 HttpStatus.CREATED,
-                feedbackService.createFeedback(authCredential.userId(), feedbackRequest.rating(), feedbackRequest.content())
+                feedbackService.createFeedback(authCredential.accountId(), feedbackRequest.rating(), feedbackRequest.content())
         );
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/jwt/JwtUtil.java
+++ b/src/main/java/com/greedy/mokkoji/api/jwt/JwtUtil.java
@@ -34,7 +34,7 @@ public class JwtUtil {
 
     public String generateAccessToken(AuthCredential credential) {
         return Jwts.builder()
-                .setSubject(String.valueOf(credential.userId()))
+                .setSubject(String.valueOf(credential.accountId()))
                 .claim(AUTH_ROLE_KEY, credential.authRole().name())
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_EXPIRATION))
@@ -44,7 +44,7 @@ public class JwtUtil {
 
     public String generateRefreshToken(AuthCredential credential) {
         return Jwts.builder()
-                .setSubject(String.valueOf(credential.userId()))
+                .setSubject(String.valueOf(credential.accountId()))
                 .claim(AUTH_ROLE_KEY, credential.authRole().name())
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_EXPIRATION))
@@ -60,10 +60,10 @@ public class JwtUtil {
                     .parseClaimsJws(token)
                     .getBody();
 
-            Long userId = Long.parseLong(claims.getSubject());
+            Long accountId = Long.parseLong(claims.getSubject());
             AuthRole authRole = AuthRole.valueOf(claims.get(AUTH_ROLE_KEY, String.class));
 
-            return new AuthCredential(authRole, userId);
+            return new AuthCredential(authRole, accountId);
 
         } catch (ExpiredJwtException e) {
             throw new MokkojiException(FailMessage.UNAUTHORIZED_EXPIRED);

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/controller/RecruitmentController.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/controller/RecruitmentController.java
@@ -39,7 +39,7 @@ public class RecruitmentController implements RecruitmentControllerSwagger {
                 HttpStatus.CREATED,
                 recruitmentService.createRecruitment(
                         authCredential.authRole(),
-                        authCredential.userId(),
+                        authCredential.accountId(),
                         clubId,
                         request.title(),
                         request.content(),
@@ -60,7 +60,7 @@ public class RecruitmentController implements RecruitmentControllerSwagger {
     ) {
         UpdateRecruitmentResponse response = recruitmentService.updateRecruitment(
                 authCredential.authRole(),
-                authCredential.userId(),
+                authCredential.accountId(),
                 recruitmentId,
                 request.title(),
                 request.content(),
@@ -79,7 +79,7 @@ public class RecruitmentController implements RecruitmentControllerSwagger {
             @PathVariable("recruitmentId") final Long recruitmentId
     ) {
         DeleteRecruitmentResponse response =
-                recruitmentService.deleteRecruitment(authCredential.authRole(), authCredential.userId(), recruitmentId);
+                recruitmentService.deleteRecruitment(authCredential.authRole(), authCredential.accountId(), recruitmentId);
         return APISuccessResponse.of(HttpStatus.OK, response);
     }
 
@@ -100,7 +100,7 @@ public class RecruitmentController implements RecruitmentControllerSwagger {
     ) {
         return APISuccessResponse.of(
                 HttpStatus.OK,
-                recruitmentService.getRecentRecruitmentOfClub(clubId, authCredential.userId())
+                recruitmentService.getRecentRecruitmentOfClub(clubId, authCredential.accountId())
         );
     }
 
@@ -111,7 +111,7 @@ public class RecruitmentController implements RecruitmentControllerSwagger {
     ) {
         return APISuccessResponse.of(
                 HttpStatus.OK,
-                recruitmentService.getSpecificRecruitment(authCredential.userId(), recruitmentId)
+                recruitmentService.getSpecificRecruitment(authCredential.accountId(), recruitmentId)
         );
     }
 
@@ -126,7 +126,7 @@ public class RecruitmentController implements RecruitmentControllerSwagger {
         final Pageable pageable = PageRequest.of(page - 1, size);
         return APISuccessResponse.of(
                 HttpStatus.OK,
-                recruitmentService.getAllRecruitment(authCredential.userId(), affiliation, category, pageable)
+                recruitmentService.getAllRecruitment(authCredential.accountId(), affiliation, category, pageable)
         );
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
@@ -49,7 +49,7 @@ public class UserController implements UserControllerSwagger {
     public ResponseEntity<APISuccessResponse<Void>> logout(
             @Authentication AuthCredential authCredential
     ) {
-        userService.logout(authCredential.authRole(), authCredential.userId());
+        userService.logout(authCredential.authRole(), authCredential.accountId());
         return APISuccessResponse.of(HttpStatus.OK, null);
     }
 
@@ -57,7 +57,7 @@ public class UserController implements UserControllerSwagger {
     public ResponseEntity<APISuccessResponse<UserInformationResponse>> getUserInformation(
             @Authentication AuthCredential authCredential
     ) {
-        final Long userId = authCredential.userId();
+        final Long userId = authCredential.accountId();
         final UserInformationResponse userInformationResponse = userService.getUserInformation(userId);
         return APISuccessResponse.of(HttpStatus.OK, userInformationResponse);
     }
@@ -67,7 +67,7 @@ public class UserController implements UserControllerSwagger {
             @Authentication AuthCredential authCredential,
             @RequestBody @Valid UpdateUserInformationRequest updateUserInformationRequest
     ) {
-        final Long userId = authCredential.userId();
+        final Long userId = authCredential.accountId();
         userService.updateUserInformation(
                 userId,
                 updateUserInformationRequest.name(),
@@ -83,7 +83,7 @@ public class UserController implements UserControllerSwagger {
     public ResponseEntity<APISuccessResponse<Void>> deleteUser(
             @Authentication AuthCredential authCredential
     ) {
-        userService.deleteUser(authCredential.authRole(), authCredential.userId());
+        userService.deleteUser(authCredential.authRole(), authCredential.accountId());
         return APISuccessResponse.of(HttpStatus.OK, null);
     }
 
@@ -91,13 +91,13 @@ public class UserController implements UserControllerSwagger {
     public ResponseEntity<APISuccessResponse<UserRoleResponse>> getUserRole(
             @Authentication AuthCredential authCredential
     ) {
-        return APISuccessResponse.of(HttpStatus.OK, userService.getUserRole(authCredential.userId()));
+        return APISuccessResponse.of(HttpStatus.OK, userService.getUserRole(authCredential.accountId()));
     }
 
     @GetMapping("/manage/clubs")
     public ResponseEntity<APISuccessResponse<UserManageClubsResponse>> getUserManageClubs(
             @Authentication AuthCredential authCredential
     ) {
-        return APISuccessResponse.of(HttpStatus.OK, userService.getUserManageClubs(authCredential.userId()));
+        return APISuccessResponse.of(HttpStatus.OK, userService.getUserManageClubs(authCredential.accountId()));
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/user/service/TokenService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/TokenService.java
@@ -19,35 +19,35 @@ public class TokenService {
     private final RedisRepository redisRepository;
     private final JwtUtil jwtUtil;
 
-    public TokenPair issueTokens(final AuthRole authRole, final Long userId) {
-        final AuthCredential credential = new AuthCredential(authRole, userId);
+    public TokenPair issueTokens(final AuthRole authRole, final Long accountId) {
+        final AuthCredential credential = new AuthCredential(authRole, accountId);
         final String accessToken = jwtUtil.generateAccessToken(credential);
         final String refreshToken = jwtUtil.generateRefreshToken(credential);
-        saveRefreshToken(authRole, userId, refreshToken);
+        saveRefreshToken(authRole, accountId, refreshToken);
         return new TokenPair(accessToken, refreshToken);
     }
 
-    private void saveRefreshToken(final AuthRole authRole, final Long userId, final String refreshToken) {
+    private void saveRefreshToken(final AuthRole authRole, final Long accountId, final String refreshToken) {
         redisRepository.save(
-                refreshTokenKey(authRole, userId),
+                refreshTokenKey(authRole, accountId),
                 refreshToken,
                 REFRESH_TOKEN_EXPIRATION
         );
     }
 
-    public String getRefreshToken(final AuthRole authRole, final Long userId) {
-        return redisRepository.find(refreshTokenKey(authRole, userId));
+    public String getRefreshToken(final AuthRole authRole, final Long accountId) {
+        return redisRepository.find(refreshTokenKey(authRole, accountId));
     }
 
-    public void deleteRefreshToken(final AuthRole authRole, final Long userId) {
-        redisRepository.delete(refreshTokenKey(authRole, userId));
+    public void deleteRefreshToken(final AuthRole authRole, final Long accountId) {
+        redisRepository.delete(refreshTokenKey(authRole, accountId));
     }
 
-    private String refreshTokenKey(final AuthRole authRole, final Long userId) {
+    private String refreshTokenKey(final AuthRole authRole, final Long accountId) {
         return REFRESH_TOKEN_KEY_PREFIX
                 + KEY_DELIMITER
                 + authRole.name()
                 + KEY_DELIMITER
-                + userId;
+                + accountId;
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -71,7 +71,7 @@ public class UserService {
     @Transactional
     public String refreshAccessToken(String refreshToken) {
         final AuthCredential credential = jwtUtil.getCredentialFromToken(refreshToken);
-        final Long userId = credential.userId();
+        final Long userId = credential.accountId();
 
         String storedRefreshToken = tokenService.getRefreshToken(credential.authRole(), userId);
         if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {


### PR DESCRIPTION
# 🔥 Pull requests

## ⛳️ 작업한 브랜치

close #449

## 👷 작업한 내용

### 문제 상황

기존에는 User 엔티티 하나로 일반 사용자와 관리자를 함께 표현했기 때문에 `AuthCredential`은 인증된 주체의 ID를 `userId`라는 이름으로 가지고 있었습니다.

```java
public record AuthCredential(
        AuthRole authRole,
        Long userId
) {
}
```

하지만 현재 인증 주체는 `USER`와 `ADMIN`으로 나뉘어 있습니다.
따라서 `AuthCredential.userId()`가 항상 `User`의 ID를 의미하지는 않는데 필드명이 `userId`로 되어 있어 코드 흐름을 읽을 때 혼란이 생길 수 있었습니다.

예를 들어 관리자 정보를 조회하는 흐름에서도 다음과 같이 `userId()`를 호출해야 했습니다.
이 경우 실제 값은 `adminId`로 해석되어야 하지만 메서드명은 `userId()`이기 때문에 "관리자인데 왜 userId를 사용하지?"라는 오해가 생길 수 있었습니다.


```java
adminService.getAdminInfo(
        authCredential.authRole(),
        authCredential.userId()
);
```

---

### 해결 방법

`AuthCredential`의 `userId` 필드를 `accountId`로 변경했습니다.

`accountId`는 아직 `User`의 ID인지 `Admin`의 ID인지 확정되지 않은 인증 주체의 식별자입니다.
이후 해당 값을 사용하는 호출부와 파라미터명도 아래 기준에 따라 함께 정리했습니다.

---

### 네이밍 정리 기준

> 이 값이 코드상에서 이미 `User` 또는 `Admin` 중 하나로 확정되었는가?

| 상황 | 이름 | 기준 |
| --- | --- | --- |
| 아직 확정되지 않은 경우 | `accountId` | `AuthRole`에 따라 `userId`일 수도 있고 `adminId`일 수도 있는 값 |
| `User`로 확정된 경우 | `userId` | 사용자 전용 로직이거나 `UserRepository`에 묶여 사용되는 값 |
| `Admin`으로 확정된 경우 | `adminId` | 관리자 전용 로직이거나 `AdminRepository`에 묶여 사용되는 값 |

---

### 흐름 요약

```text
JWT 토큰
  └─ JwtUtil.getCredentialFromToken()
       └─ new AuthCredential(authRole, accountId)
            └─ UserAuthArgumentResolver가 컨트롤러에 주입
                 └─ Controller에서 authCredential.accountId() 사용

                      ├─ User 전용 로직
                      │    └─ accountId → userId로 사용
                      │
                      ├─ Admin 전용 로직
                      │    └─ accountId → adminId로 사용
                      │
                      └─ 공용 권한 검증 로직
                           └─ authRole에 따라 해석
                                ├─ ADMIN → accountId를 adminId로 사용
                                └─ USER  → accountId를 userId로 사용
```

| 위치 | 값의 이름 | 의미 |
| --- | --- | --- |
| `AuthCredential` | `accountId` | 아직 User/Admin이 확정되지 않은 인증 주체 ID |
| `Controller` | `accountId` | 그대로 서비스 또는 검증 로직으로 전달 |
| User 전용 로직 | `userId` | User의 ID로 의미가 확정됨 |
| Admin 전용 로직 | `adminId` | Admin의 ID로 의미가 확정됨 |
| 공용 권한 검증 로직 | `accountId` | `authRole` 분기 후 `userId` 또는 `adminId`로 해석 |
---


## 🚨 참고 사항
변경 범위가 넓은 만큼 놓친 부분이나 잘못 수정한 부분이 있다면 편하게 말씀 부탁드립니다!