### PR TITLE
Refactor: ClubPreviewResponse의 favorite 필드명을 isFavorite으로 통일

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/ClubPreviewResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/dto/response/allClubs/ClubPreviewResponse.java
@@ -9,7 +9,7 @@ public record ClubPreviewResponse(
         @Schema(example = "그리디") String name,
         @Schema(example = "세종대 최고의 코딩 동아리") String description,
         @Schema(example = "https://mokkoji-app-data.s3.ap-northeast-2.amazonaws.com/club-logo/1/greedy_{UUID}.jpg") String logo,
-        @Schema(example = "true") boolean favorite,
+        @Schema(example = "true") boolean isFavorite,
         @Schema(implementation = RecruitmentPreviewResponse.class)
         RecruitmentPreviewResponse recruitmentPreviewResponse
 ) {

--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -161,7 +161,7 @@ public class ClubService {
                 .name(c.name())
                 .description(c.description())
                 .logo(appDataS3Client.getPublicUrl(c.logo()))
-                .favorite(isFavorite)
+                .isFavorite(isFavorite)
                 .recruitmentPreviewResponse(
                         mapToLatestRecruitmentPreviewResponse(c.latestRecruitmentInfo())
                 )
@@ -197,7 +197,7 @@ public class ClubService {
 
         if (userId == null) return recruitmentComparator;
 
-        return Comparator.comparing(ClubPreviewResponse::favorite)
+        return Comparator.comparing(ClubPreviewResponse::isFavorite)
                 .reversed()
                 .thenComparing(recruitmentComparator);
     }

--- a/src/test/java/com/greedy/mokkoji/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/club/controller/ClubControllerTest.java
@@ -124,7 +124,7 @@ public class ClubControllerTest extends ControllerTest {
                         .name(club.getName())
                         .description(club.getDescription())
                         .logo(club.getLogo())
-                        .favorite(true)
+                        .isFavorite(true)
                         .recruitmentPreviewResponse(recruitmentPreviewResponse)
                         .build());
 

--- a/src/test/java/com/greedy/mokkoji/club/service/ClubServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/club/service/ClubServiceTest.java
@@ -172,12 +172,12 @@ class ClubServiceTest {
         assertThat(response.clubs().get(0).name()).isEqualTo("testClub1");
         assertThat(response.clubs().get(0).description()).isEqualTo("testDescription1");
         assertThat(response.clubs().get(0).logo()).isEqualTo("testLogo1");
-        assertThat(response.clubs().get(0).favorite()).isTrue();
+        assertThat(response.clubs().get(0).isFavorite()).isTrue();
 
         assertThat(response.clubs().get(1).name()).isEqualTo("testClub2");
         assertThat(response.clubs().get(1).description()).isEqualTo("testDescription2");
         assertThat(response.clubs().get(1).logo()).isEqualTo("testLogo2");
-        assertThat(response.clubs().get(1).favorite()).isFalse();
+        assertThat(response.clubs().get(1).isFavorite()).isFalse();
 
         assertThat(response.page().totalElements()).isEqualTo(2);
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #454 

## 👷 **작업한 내용**
ClubPreviewResponse 만 다른 dto 와 다른게 isFavorite 이 아닌 favorite 으로 응답을 내려주고 있었습니다. 해당 값을 수정해서 통일 했습니다.

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
