### PR TITLE
Feat: ClubApplication 로고 이미지 presigned URL 방식으로 전환 및 승인 시 S3 이동

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -288,6 +288,10 @@ public class ClubService {
         }
 
         int dotIndex = logo.lastIndexOf('.');
+        if (dotIndex == -1) {
+            throw new MokkojiException(FailMessage.BAD_REQUEST_INVALID_LOGO_FILENAME);
+        }
+
         String prevDot = logo.substring(0, dotIndex);
         String nextDot = logo.substring(dotIndex); //jpg와 같은 확장자 부분
         String uuid = UUID.randomUUID().toString();

--- a/src/main/java/com/greedy/mokkoji/api/clubapplication/controller/ClubApplicationController.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubapplication/controller/ClubApplicationController.java
@@ -3,6 +3,7 @@ package com.greedy.mokkoji.api.clubapplication.controller;
 import com.greedy.mokkoji.api.auth.controller.argumentResolver.AuthCredential;
 import com.greedy.mokkoji.api.auth.controller.argumentResolver.Authentication;
 import com.greedy.mokkoji.api.clubapplication.dto.request.ClubApplicationCreateRequest;
+import com.greedy.mokkoji.api.clubapplication.dto.response.ClubApplicationCreateResponse;
 import com.greedy.mokkoji.api.clubapplication.dto.response.ClubApplicationsResponse;
 import com.greedy.mokkoji.api.clubapplication.service.ClubApplicationService;
 import com.greedy.mokkoji.common.response.APISuccessResponse;
@@ -19,12 +20,14 @@ public class ClubApplicationController implements ClubApplicationControllerSwagg
     private final ClubApplicationService clubApplicationService;
 
     @PostMapping
-    public ResponseEntity<APISuccessResponse<Void>> createClubApplication(
+    public ResponseEntity<APISuccessResponse<ClubApplicationCreateResponse>> createClubApplication(
             @RequestBody final ClubApplicationCreateRequest request,
             @Authentication final AuthCredential authCredential
     ) {
-        clubApplicationService.createClubApplication(authCredential.accountId(), request);
-        return APISuccessResponse.of(HttpStatus.CREATED, null);
+        return APISuccessResponse.of(
+                HttpStatus.CREATED,
+                clubApplicationService.createClubApplication(authCredential.accountId(), request)
+        );
     }
 
     @GetMapping("/me")

--- a/src/main/java/com/greedy/mokkoji/api/clubapplication/controller/ClubApplicationControllerSwagger.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubapplication/controller/ClubApplicationControllerSwagger.java
@@ -2,6 +2,7 @@ package com.greedy.mokkoji.api.clubapplication.controller;
 
 import com.greedy.mokkoji.api.auth.controller.argumentResolver.AuthCredential;
 import com.greedy.mokkoji.api.clubapplication.dto.request.ClubApplicationCreateRequest;
+import com.greedy.mokkoji.api.clubapplication.dto.response.ClubApplicationCreateResponse;
 import com.greedy.mokkoji.api.clubapplication.dto.response.ClubApplicationsResponse;
 import com.greedy.mokkoji.common.response.APISuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,7 +20,7 @@ public interface ClubApplicationControllerSwagger {
             security = @SecurityRequirement(name = "JWT")
     )
     @ApiResponse(responseCode = "201", description = "신청 성공")
-    ResponseEntity<APISuccessResponse<Void>> createClubApplication(
+    ResponseEntity<APISuccessResponse<ClubApplicationCreateResponse>> createClubApplication(
             @Parameter(name = "request", description = "동아리 생성 신청 요청 본문") ClubApplicationCreateRequest request,
             @Parameter(hidden = true) AuthCredential authCredential
     );

--- a/src/main/java/com/greedy/mokkoji/api/clubapplication/dto/response/ClubApplicationCreateResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubapplication/dto/response/ClubApplicationCreateResponse.java
@@ -1,0 +1,12 @@
+package com.greedy.mokkoji.api.clubapplication.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ClubApplicationCreateResponse(
+        @Schema(example = "1") Long applicationId,
+        @Schema(example = "https://mokkoji-app-data.s3.ap-northeast-2.amazonaws.com/club-application-logo/1/greedy_logo_{UUID}.jpg") String uploadLogoUrl
+) {
+    public static ClubApplicationCreateResponse of(final Long applicationId, final String uploadLogoUrl) {
+        return new ClubApplicationCreateResponse(applicationId, uploadLogoUrl);
+    }
+}

--- a/src/main/java/com/greedy/mokkoji/api/clubapplication/service/AdminClubApplicationService.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubapplication/service/AdminClubApplicationService.java
@@ -3,6 +3,7 @@ package com.greedy.mokkoji.api.clubapplication.service;
 import com.greedy.mokkoji.api.auth.service.ManageAuthorizer;
 import com.greedy.mokkoji.api.clubapplication.dto.response.AdminClubApplicationResponse;
 import com.greedy.mokkoji.api.clubapplication.dto.response.AdminClubApplicationsResponse;
+import com.greedy.mokkoji.api.external.AppDataS3Client;
 import com.greedy.mokkoji.api.pagination.dto.PageResponse;
 import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.db.admin.entity.Admin;
@@ -34,6 +35,7 @@ public class AdminClubApplicationService {
     private final ClubRepository clubRepository;
     private final AdminRepository adminRepository;
     private final ManageAuthorizer manageAuthorizer;
+    private final AppDataS3Client appDataS3Client;
 
     @Transactional(readOnly = true)
     public AdminClubApplicationsResponse getAdminClubApplications(
@@ -79,14 +81,29 @@ public class AdminClubApplicationService {
                 .university(clubApplication.getUniversity())
                 .clubCategory(clubApplication.getClubCategory())
                 .clubAffiliation(clubApplication.getClubAffiliation())
-                .logo(clubApplication.getLogo())
+                .logo(null)
                 .instagram(clubApplication.getInstagram())
                 .description(clubApplication.getDescription())
                 .master(applicant)
                 .build();
 
         clubRepository.save(club);
+
+        moveLogoToClub(clubApplication.getLogo(), club);
+
         clubApplication.approve();
+    }
+
+    private void moveLogoToClub(final String applicationLogoKey, final Club club) {
+        if (applicationLogoKey == null || applicationLogoKey.isBlank()) {
+            return;
+        }
+
+        final String fileName = applicationLogoKey.substring(applicationLogoKey.lastIndexOf('/') + 1);
+        final String clubLogoKey = String.format("club-logo/%d/%s", club.getId(), fileName);
+
+        appDataS3Client.copyObject(applicationLogoKey, clubLogoKey);
+        club.updateIfPresent(null, null, null, null, clubLogoKey, null);
     }
 
     @Transactional

--- a/src/main/java/com/greedy/mokkoji/api/clubapplication/service/AdminClubApplicationService.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubapplication/service/AdminClubApplicationService.java
@@ -3,6 +3,7 @@ package com.greedy.mokkoji.api.clubapplication.service;
 import com.greedy.mokkoji.api.auth.service.ManageAuthorizer;
 import com.greedy.mokkoji.api.clubapplication.dto.response.AdminClubApplicationResponse;
 import com.greedy.mokkoji.api.clubapplication.dto.response.AdminClubApplicationsResponse;
+import com.greedy.mokkoji.api.external.AfterCommitS3Cleaner;
 import com.greedy.mokkoji.api.external.AppDataS3Client;
 import com.greedy.mokkoji.api.pagination.dto.PageResponse;
 import com.greedy.mokkoji.common.exception.MokkojiException;
@@ -36,6 +37,7 @@ public class AdminClubApplicationService {
     private final AdminRepository adminRepository;
     private final ManageAuthorizer manageAuthorizer;
     private final AppDataS3Client appDataS3Client;
+    private final AfterCommitS3Cleaner afterCommitS3Cleaner;
 
     @Transactional(readOnly = true)
     public AdminClubApplicationsResponse getAdminClubApplications(
@@ -104,6 +106,8 @@ public class AdminClubApplicationService {
 
         appDataS3Client.copyObject(applicationLogoKey, clubLogoKey);
         club.updateIfPresent(null, null, null, null, clubLogoKey, null);
+
+        afterCommitS3Cleaner.deleteAfterCommit(List.of(applicationLogoKey));
     }
 
     @Transactional

--- a/src/main/java/com/greedy/mokkoji/api/clubapplication/service/ClubApplicationService.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubapplication/service/ClubApplicationService.java
@@ -1,8 +1,10 @@
 package com.greedy.mokkoji.api.clubapplication.service;
 
 import com.greedy.mokkoji.api.clubapplication.dto.request.ClubApplicationCreateRequest;
+import com.greedy.mokkoji.api.clubapplication.dto.response.ClubApplicationCreateResponse;
 import com.greedy.mokkoji.api.clubapplication.dto.response.ClubApplicationResponse;
 import com.greedy.mokkoji.api.clubapplication.dto.response.ClubApplicationsResponse;
+import com.greedy.mokkoji.api.external.AppDataS3Client;
 import com.greedy.mokkoji.common.exception.MokkojiException;
 import com.greedy.mokkoji.db.clubapplication.entity.ClubApplication;
 import com.greedy.mokkoji.db.clubapplication.repository.ClubApplicationRepository;
@@ -13,10 +15,12 @@ import com.greedy.mokkoji.db.user.repository.UserRepository;
 import com.greedy.mokkoji.enums.application.ApplicationStatus;
 import com.greedy.mokkoji.enums.message.FailMessage;
 import lombok.RequiredArgsConstructor;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -25,9 +29,10 @@ public class ClubApplicationService {
     private final ClubApplicationRepository clubApplicationRepository;
     private final UserRepository userRepository;
     private final UniversityRepository universityRepository;
+    private final AppDataS3Client appDataS3Client;
 
     @Transactional
-    public void createClubApplication(final Long userId, final ClubApplicationCreateRequest request) {
+    public ClubApplicationCreateResponse createClubApplication(final Long userId, final ClubApplicationCreateRequest request) {
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new MokkojiException(FailMessage.NOT_FOUND_USER));
 
@@ -47,12 +52,34 @@ public class ClubApplicationService {
                 .clubName(clubName)
                 .clubCategory(request.clubCategory())
                 .clubAffiliation(request.clubAffiliation())
-                .logo(request.logo())
+                .logo(null)
                 .instagram(request.instagram())
                 .description(request.description())
                 .build();
 
         clubApplicationRepository.save(clubApplication);
+
+        final String logoKey = extractLogoKey(clubApplication.getId(), request.logo());
+        clubApplication.updateLogo(logoKey);
+
+        final String uploadLogoUrl = appDataS3Client.getPresignedPutUrl(logoKey);
+
+        return ClubApplicationCreateResponse.of(clubApplication.getId(), uploadLogoUrl);
+    }
+
+    @Nullable
+    private String extractLogoKey(final Long applicationId, final String logo) {
+        if (logo == null || logo.isBlank()) {
+            return null;
+        }
+
+        final int dotIndex = logo.lastIndexOf('.');
+        final String prevDot = logo.substring(0, dotIndex);
+        final String nextDot = logo.substring(dotIndex);
+        final String uuid = UUID.randomUUID().toString();
+        final String fileName = prevDot + "_" + uuid + nextDot;
+
+        return String.format("club-application-logo/%d/%s", applicationId, fileName);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/greedy/mokkoji/api/clubapplication/service/ClubApplicationService.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubapplication/service/ClubApplicationService.java
@@ -74,6 +74,10 @@ public class ClubApplicationService {
         }
 
         final int dotIndex = logo.lastIndexOf('.');
+        if (dotIndex == -1) {
+            throw new MokkojiException(FailMessage.BAD_REQUEST_INVALID_LOGO_FILENAME);
+        }
+
         final String prevDot = logo.substring(0, dotIndex);
         final String nextDot = logo.substring(dotIndex);
         final String uuid = UUID.randomUUID().toString();

--- a/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
+++ b/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.Delete;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
@@ -124,5 +125,20 @@ public class AppDataS3Client {
 
     private boolean isInvalidFileKey(String fileKey) {
         return fileKey == null || fileKey.isBlank();
+    }
+
+    public void copyObject(final String sourceKey, final String destKey) {
+        if (isInvalidFileKey(sourceKey) || isInvalidFileKey(destKey)) {
+            return;
+        }
+
+        final CopyObjectRequest copyObjectRequest = CopyObjectRequest.builder()
+                .sourceBucket(bucketName)
+                .sourceKey(sourceKey)
+                .destinationBucket(bucketName)
+                .destinationKey(destKey)
+                .build();
+
+        s3Client.copyObject(copyObjectRequest);
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
+++ b/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
@@ -123,10 +123,6 @@ public class AppDataS3Client {
         }
     }
 
-    private boolean isInvalidFileKey(String fileKey) {
-        return fileKey == null || fileKey.isBlank();
-    }
-
     public void copyObject(final String sourceKey, final String destKey) {
         if (isInvalidFileKey(sourceKey) || isInvalidFileKey(destKey)) {
             return;
@@ -140,5 +136,9 @@ public class AppDataS3Client {
                 .build();
 
         s3Client.copyObject(copyObjectRequest);
+    }
+
+    private boolean isInvalidFileKey(String fileKey) {
+        return fileKey == null || fileKey.isBlank();
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/greedy/mokkoji/api/recruitment/service/RecruitmentService.java
@@ -255,6 +255,10 @@ public class RecruitmentService {
 
     private String extractImageKey(Recruitment recruitment, String fileName) {
         int dotIndex = fileName.lastIndexOf('.');
+        if (dotIndex == -1) {
+            throw new MokkojiException(FailMessage.BAD_REQUEST_INVALID_IMAGE_FILENAME);
+        }
+
         String nextDot = fileName.substring(dotIndex); //jpg와 같은 확장자 부분
 
         String uuid = UUID.randomUUID().toString();

--- a/src/main/java/com/greedy/mokkoji/db/clubapplication/entity/ClubApplication.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubapplication/entity/ClubApplication.java
@@ -85,6 +85,10 @@ public class ClubApplication extends BaseTime {
         this.description = description;
     }
 
+    public void updateLogo(final String logo) {
+        this.logo = logo;
+    }
+
     public void approve() {
         this.status = ApplicationStatus.APPROVED;
     }

--- a/src/main/java/com/greedy/mokkoji/enums/message/FailMessage.java
+++ b/src/main/java/com/greedy/mokkoji/enums/message/FailMessage.java
@@ -14,6 +14,7 @@ public enum FailMessage {
     BAD_REQUEST_MISSING_PARAM(HttpStatus.BAD_REQUEST, 40002, "필수 파라미터가 없습니다."),
     BAD_REQUEST_METHOD_ARGUMENT_TYPE(HttpStatus.BAD_REQUEST, 40003, "메서드 인자타입이 잘못되었습니다."),
     BAD_REQUEST_NOT_READABLE(HttpStatus.BAD_REQUEST, 40004, "Json 오류 혹은 요청본문 필드 오류 입니다. "),
+    BAD_REQUEST_INVALID_LOGO_FILENAME(HttpStatus.BAD_REQUEST, 40005, "로고 파일명에 확장자가 없습니다."),
 
     //401
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40100, "인증이 필요합니다."),

--- a/src/main/java/com/greedy/mokkoji/enums/message/FailMessage.java
+++ b/src/main/java/com/greedy/mokkoji/enums/message/FailMessage.java
@@ -15,6 +15,7 @@ public enum FailMessage {
     BAD_REQUEST_METHOD_ARGUMENT_TYPE(HttpStatus.BAD_REQUEST, 40003, "메서드 인자타입이 잘못되었습니다."),
     BAD_REQUEST_NOT_READABLE(HttpStatus.BAD_REQUEST, 40004, "Json 오류 혹은 요청본문 필드 오류 입니다. "),
     BAD_REQUEST_INVALID_LOGO_FILENAME(HttpStatus.BAD_REQUEST, 40005, "로고 파일명에 확장자가 없습니다."),
+    BAD_REQUEST_INVALID_IMAGE_FILENAME(HttpStatus.BAD_REQUEST, 40006, "이미지 파일명에 확장자가 없습니다."),
 
     //401
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, 40100, "인증이 필요합니다."),


### PR DESCRIPTION
# 🔥 Pull Request

## ⛳️ 작업한 브랜치

Closes #460

## 👷 작업한 내용

## 문제 상황

기존 `club-application`에는 로고 이미지 업로드를 위한 Presigned URL 방식이 적용되어 있지 않았습니다.

신청 생성 시 로고 키를 DB에 저장할 수는 있었지만 클라이언트가 실제 이미지를 S3에 업로드할 방법이 없었습니다. 
또 신청 승인 시에도 로고 키만 `Club`에 전달할 뿐 실제 S3 객체를 `club-logo` 경로로 복사하지 않았습니다.

## 해결 방법

새로운 업로드 구조를 별도로 도입하기보다는 기존 `Club`, `Recruitment`의 이미지 업로드 흐름과 컨벤션을 최대한 유지해 변경 범위를 최소화했습니다.

#### 신청 생성 시

객체 키에 applicationId 가 필요하므로 신청을 먼저 저장한 뒤 생성된 ID를 기반으로 객체 키와 Presigned URL을 생성했습니다.

* `club-application-logo/{applicationId}/...` 형식의 객체 키 생성
* Presigned PUT URL 반환
* 생성 API 응답을 `Void`에서 `ClubApplicationCreateResponse`로 변경
* Swagger 명세 반영

#### 신청 승인 시

* `club-application-logo/...` 경로의 이미지를 `club-logo/{clubId}/...` 경로로 복사
* S3 복사 중 예외가 발생하면 DB 트랜잭션이 롤백되도록 처리

#### 추가 변경 사항

* `AwsConfig`에 `S3Client` Bean 추가
* `AppDataS3Client`에 `copyObject` 메서드 추가

> S3 작업은 DB 트랜잭션에 포함되지 않으므로 S3 복사 성공 후 DB 커밋이 실패하는 경우까지 원자적으로 롤백되지는 않습니다.

## 🚨 참고 사항

작업 과정에서 S3 객체 키 생성 로직이 `ClubService`, `RecruitmentService` 등 여러 곳에 중복되어 있는 것을 확인했습니다.
`S3KeyGenerator`와 같은 공통 컴포넌트로 분리하는 방안도 고려했지만 이번 PR에서 함께 진행하면 변경 범위가 커질 수 있어 기존 `String.format` 방식과 문자열 컨벤션을 유지했습니다. 리팩토링하면 좋아보여요!

또한 현재 `club-application`에는 로고만 변경하는 `updateLogo` 메서드가 있습니다. 
이름, 카테고리, 설명 등의 수정 기능이 추가되면 `Club`의 `updateIfPresent`와 같은 부분 수정 패턴으로 통일하는 것이 좋을 것 같습니다.
