### PR TITLE
Fix: ManageAuthorizer의 validateCanManageClub 메서드 NPE 방지

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/auth/service/ManageAuthorizer.java
+++ b/src/main/java/com/greedy/mokkoji/api/auth/service/ManageAuthorizer.java
@@ -31,7 +31,7 @@ public class ManageAuthorizer {
 
         if (AuthRole.USER.equals(authRole)) {
             User user = findUserOrThrow(accountId);
-            if (user.getRole() == UserRole.CLUB_MASTER && club.getMasterId().equals(accountId)) return;
+            if (user.getRole() == UserRole.CLUB_MASTER && accountId.equals(club.getMasterId())) return;
         }
 
         throw new MokkojiException(FailMessage.FORBIDDEN_MANAGE_CLUB);


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #399 

## 👷 **작업한 내용**
## 👷 **작업한 내용**

동아리의 masterId가 존재하지 않을 수 있어 null일 수 있습니다. 
그래서 `club.getMasterId().equals(accountId)`처럼 호출하면 NPE가 터질 수 있습니다.

이미 `validateAuthenticated(accountId)`로 null 여부를 검증한 accountId를 앞에 두어 NPE를 막았습니다.

```java
    private void validateAuthenticated(final Long accountId) {
        if (accountId == null) {
            throw new MokkojiException(FailMessage.UNAUTHORIZED);
        }
    }
```

## 🚨 **참고 사항**
<!-- 참고할 사항이 있다면 적어주세요. -->
