### PR TITLE
Feat: 관리자 clubApplication 조회 응답에 소개·인스타그램 필드 추가

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/clubapplication/dto/response/AdminClubApplicationResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/clubapplication/dto/response/AdminClubApplicationResponse.java
@@ -16,6 +16,8 @@ public record AdminClubApplicationResponse(
         @Schema(example = "ACADEMIC_CULTURAL") ClubCategory category,
         @Schema(example = "CENTRAL_CLUB") ClubAffiliation affiliation,
         @Schema(example = "https://s3.amazonaws.com/.../logo.png") String logo,
+        @Schema(example = "즐거운 학술 동아리입니다.") String description,
+        @Schema(example = "https://instagram.com/greedy") String instagram,
         @Schema(example = "REJECTED") ApplicationStatus status,
         @Schema(example = "서류 미비") String rejectReason,
         @Schema(example = "2026-05-18T13:00:00") LocalDateTime createdAt
@@ -29,6 +31,8 @@ public record AdminClubApplicationResponse(
                 clubApplication.getClubCategory(),
                 clubApplication.getClubAffiliation(),
                 clubApplication.getLogo(),
+                clubApplication.getDescription(),
+                clubApplication.getInstagram(),
                 clubApplication.getStatus(),
                 clubApplication.getRejectReason(),
                 clubApplication.getCreatedAt()


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #463

## 👷 **작업한 내용**
관리자 동아리 신청서 조회(`GET .../admin/club-applications`) 응답에 아래 두 필드를 추가했습니다.
- `description`: 동아리 소개
- `instagram`: 인스타그램 URL

## 🚨 **참고 사항**

