### PR TITLE
Feat: Flyway 의존성 추가 및 baseline 스키마 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ dependencies {
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // database migration
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
+
     //lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/resources/db/migration/V1__baseline.sql
+++ b/src/main/resources/db/migration/V1__baseline.sql
@@ -1,0 +1,206 @@
+-- 모꼬지 baseline 스키마
+--
+-- 2026-07-19 기준 dev 환경(mokkoji_dev)의 실제 스키마를 그대로 옮긴 것이다.
+-- Flyway 도입 시점의 기준점 역할을 하며 baseline-on-migrate 설정에 의해 이미 스키마가 존재하는 환경에서는 실행되지 않고 "적용된 것으로 간주"된다.
+--
+-- 이후 모든 스키마 변경은 V2 이상의 새 마이그레이션 파일로 추가한다.
+-- 이 파일은 한 번 머지된 뒤에는 절대 수정하지 않는다(checksum 불일치로 기동 실패).
+
+CREATE TABLE `university`
+(
+    `id`         bigint       NOT NULL AUTO_INCREMENT,
+    `created_at` timestamp    NULL DEFAULT NULL,
+    `updated_at` timestamp    NULL DEFAULT NULL,
+    `code`       varchar(50)  NOT NULL,
+    `logo`       text,
+    `name`       varchar(100) NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `UK57sqjuqfhckx8p0d83h8cc98x` (`code`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE `user`
+(
+    `id`            bigint      NOT NULL AUTO_INCREMENT,
+    `created_at`    timestamp   NULL DEFAULT NULL,
+    `updated_at`    timestamp   NULL DEFAULT NULL,
+    `code`          varchar(50) NOT NULL,
+    `kakao_id`      varchar(50) NOT NULL,
+    `name`          varchar(50)      DEFAULT NULL,
+    `email`         varchar(50)      DEFAULT NULL,
+    `is_email_on`   tinyint(1)  NOT NULL,
+    `role`          varchar(50)      DEFAULT NULL,
+    `university_id` bigint           DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_user_user_code` (`code`),
+    KEY `FK6egtfhd9smck1965dxo86hpa` (`university_id`),
+    CONSTRAINT `FK6egtfhd9smck1965dxo86hpa` FOREIGN KEY (`university_id`) REFERENCES `university` (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE `admin`
+(
+    `id`            bigint       NOT NULL AUTO_INCREMENT,
+    `created_at`    timestamp    NULL DEFAULT NULL,
+    `updated_at`    timestamp    NULL DEFAULT NULL,
+    `login_id`      varchar(100) NOT NULL,
+    `password`      varchar(100) NOT NULL,
+    `role`          varchar(50)  NOT NULL,
+    `university_id` bigint            DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    KEY `FKfxvtexdxtvf4jjl017d4pfaof` (`university_id`),
+    CONSTRAINT `FKfxvtexdxtvf4jjl017d4pfaof` FOREIGN KEY (`university_id`) REFERENCES `university` (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE `club`
+(
+    `id`               bigint      NOT NULL AUTO_INCREMENT,
+    `created_at`       timestamp   NULL DEFAULT NULL,
+    `updated_at`       timestamp   NULL DEFAULT NULL,
+    `name`             varchar(50) NOT NULL,
+    `club_category`    varchar(20) NOT NULL,
+    `club_affiliation` varchar(20) NOT NULL,
+    `description`      text,
+    `instagram`        text,
+    `logo`             text,
+    `master_id`        bigint           DEFAULT NULL,
+    `university_id`    bigint      NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY `idx_club_category` (`club_category`),
+    KEY `idx_club_master_id` (`master_id`),
+    KEY `FKmf82w0dtc98509noons2e6hww` (`university_id`),
+    CONSTRAINT `FK62nm4d35v5fd8ewtiuu8r8r43` FOREIGN KEY (`master_id`) REFERENCES `user` (`id`),
+    CONSTRAINT `FKmf82w0dtc98509noons2e6hww` FOREIGN KEY (`university_id`) REFERENCES `university` (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE `club_application`
+(
+    `id`               bigint      NOT NULL AUTO_INCREMENT,
+    `created_at`       timestamp   NULL DEFAULT NULL,
+    `updated_at`       timestamp   NULL DEFAULT NULL,
+    `applicant_name`   varchar(50) NOT NULL,
+    `club_name`        varchar(50) NOT NULL,
+    `club_category`    varchar(20) NOT NULL,
+    `club_affiliation` varchar(20) NOT NULL,
+    `description`      text        NOT NULL,
+    `instagram`        text,
+    `logo`             text,
+    `status`           varchar(20) NOT NULL,
+    `reject_reason`    text,
+    `applicant_id`     bigint      NOT NULL,
+    `university_id`    bigint      NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY `FKg9n4pqtyva5xrnk0k2pdx3fcb` (`applicant_id`),
+    KEY `FKgtimrbhut3bcfg9b4xxmqc8wf` (`university_id`),
+    CONSTRAINT `FKg9n4pqtyva5xrnk0k2pdx3fcb` FOREIGN KEY (`applicant_id`) REFERENCES `user` (`id`),
+    CONSTRAINT `FKgtimrbhut3bcfg9b4xxmqc8wf` FOREIGN KEY (`university_id`) REFERENCES `university` (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE `club_master_application`
+(
+    `id`            bigint      NOT NULL AUTO_INCREMENT,
+    `created_at`    timestamp   NULL DEFAULT NULL,
+    `updated_at`    timestamp   NULL DEFAULT NULL,
+    `user_name`     varchar(50) NOT NULL,
+    `status`        varchar(20) NOT NULL,
+    `reject_reason` text,
+    `club_id`       bigint      NOT NULL,
+    `user_id`       bigint      NOT NULL,
+    `university_id` bigint      NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY `idx_cma_user_id` (`user_id`),
+    KEY `FKmruj573eokbb3d5q45twfob71` (`club_id`),
+    KEY `FKj68ywqrfgmy6qjpnmncuc25vk` (`university_id`),
+    CONSTRAINT `FKn4lbqhbdmdpc2vu5owbvsx6mj` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`),
+    CONSTRAINT `FKmruj573eokbb3d5q45twfob71` FOREIGN KEY (`club_id`) REFERENCES `club` (`id`),
+    CONSTRAINT `FKj68ywqrfgmy6qjpnmncuc25vk` FOREIGN KEY (`university_id`) REFERENCES `university` (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE `recruitment`
+(
+    `id`                   bigint     NOT NULL AUTO_INCREMENT,
+    `created_at`           timestamp  NULL DEFAULT NULL,
+    `updated_at`           timestamp  NULL DEFAULT NULL,
+    `title`                text       NOT NULL,
+    `content`              text,
+    `recruit_form`         text,
+    `recruit_start`        timestamp  NULL DEFAULT NULL,
+    `recruit_end`          timestamp  NULL DEFAULT NULL,
+    `is_always_recruiting` tinyint(1) NOT NULL,
+    `club_id`              bigint     NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY `idx_recruitment_end` (`recruit_end`),
+    KEY `FKnn5exigvdqh7l9n7d5gia1p0r` (`club_id`),
+    CONSTRAINT `FKnn5exigvdqh7l9n7d5gia1p0r` FOREIGN KEY (`club_id`) REFERENCES `club` (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE `recruitment_image`
+(
+    `id`             bigint    NOT NULL AUTO_INCREMENT,
+    `created_at`     timestamp NULL DEFAULT NULL,
+    `updated_at`     timestamp NULL DEFAULT NULL,
+    `image`          text,
+    `recruitment_id` bigint    NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY `FK2nquyvacyne5nclx00sfwdswd` (`recruitment_id`),
+    CONSTRAINT `FK2nquyvacyne5nclx00sfwdswd` FOREIGN KEY (`recruitment_id`) REFERENCES `recruitment` (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE `comment`
+(
+    `id`         bigint    NOT NULL AUTO_INCREMENT,
+    `created_at` timestamp NULL DEFAULT NULL,
+    `updated_at` timestamp NULL DEFAULT NULL,
+    `content`    text      NOT NULL,
+    `rate`       double    NOT NULL,
+    `club_id`    bigint    NOT NULL,
+    `user_id`    bigint         DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    KEY `FK8kcum44fvpupyw6f5baccx25c` (`user_id`),
+    KEY `FKfas0jm4664vilp9k50ixnqj0h` (`club_id`),
+    CONSTRAINT `FK8kcum44fvpupyw6f5baccx25c` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`),
+    CONSTRAINT `FKfas0jm4664vilp9k50ixnqj0h` FOREIGN KEY (`club_id`) REFERENCES `club` (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE `favorite`
+(
+    `id`      bigint NOT NULL AUTO_INCREMENT,
+    `club_id` bigint NOT NULL,
+    `user_id` bigint NOT NULL,
+    PRIMARY KEY (`id`),
+    KEY `FKdew6h96myfn9p3dj7o4h1iky1` (`club_id`),
+    KEY `FKh3f2dg11ibnht4fvnmx60jcif` (`user_id`),
+    CONSTRAINT `FKdew6h96myfn9p3dj7o4h1iky1` FOREIGN KEY (`club_id`) REFERENCES `club` (`id`),
+    CONSTRAINT `FKh3f2dg11ibnht4fvnmx60jcif` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;
+
+CREATE TABLE `feedback`
+(
+    `id`         bigint    NOT NULL AUTO_INCREMENT,
+    `created_at` timestamp NULL DEFAULT NULL,
+    `updated_at` timestamp NULL DEFAULT NULL,
+    `content`    text      NOT NULL,
+    `rating`     int       NOT NULL,
+    `user_id`    bigint    NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;

--- a/src/main/resources/db/migration/V1__baseline.sql
+++ b/src/main/resources/db/migration/V1__baseline.sql
@@ -30,10 +30,11 @@ CREATE TABLE `user`
     `name`          varchar(50)      DEFAULT NULL,
     `email`         varchar(50)      DEFAULT NULL,
     `is_email_on`   tinyint(1)  NOT NULL,
-    `role`          varchar(50)      DEFAULT NULL,
+    `role`          varchar(50) NOT NULL,
     `university_id` bigint           DEFAULT NULL,
     PRIMARY KEY (`id`),
-    UNIQUE KEY `uk_user_user_code` (`code`),
+    UNIQUE KEY `uk_user_code` (`code`),
+    UNIQUE KEY `uk_user_kakao_id` (`kakao_id`),
     KEY `FK6egtfhd9smck1965dxo86hpa` (`university_id`),
     CONSTRAINT `FK6egtfhd9smck1965dxo86hpa` FOREIGN KEY (`university_id`) REFERENCES `university` (`id`)
 ) ENGINE = InnoDB


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #466

## 👷 **작업한 내용**
## 문제상황
현재 ddl-auto: update를 사용하여 스키마를 관리하고 있습니다.

하지만 update는 새로운 컬럼 추가 등 일부 변경만 반영하며, 컬럼명 변경, 제약조건 제거, 테이블 삭제와 같은 변경 사항은 안정적으로 반영하지 않습니다.

이 때문에 스프린트 4기에서 스키마 변경 작업(#436, #440, #441, userCode 도입 등)이 발생할 때마다 개발자가 DB에 직접 접속하여 쿼리를 실행해 왔습니다.

이 방식은 다음과 같은 문제가 있었습니다.

- 실행한 스키마 변경 내역이 코드로 관리되지 않음
- dev와 prod 환경에 각각 어떤 변경 사항이 적용되었는지 확인하기 어려움
- 환경마다 스키마 상태가 달라질 가능성이 있음

## 해결 방법
DB 스키마 변경 이력을 코드로 관리하기 위해 Flyway를 도입했습니다.

- flyway-core, flyway-mysql 의존성 추가
- 현재 dev DB의 스키마를 V1__baseline.sql로 정의
- Hibernate의 ddl-auto 설정을 update에서 validate로 변경([스키마 생성은 단일 매커니즘 사용 권장](https://docs.spring.io/spring-boot/how-to/data-initialization.html#howto.data-initialization.using-hibernate:~:text=It%20is%20recommended%20to%20use%20a%20single%20mechanism%20for%20schema%20generation.))

앞으로 스키마 변경이 필요한 경우 V2__, V3__와 같이 새로운 마이그레이션 파일을 추가하면 됩니다. (같이 규칙 정해도 좋아보여요)

각 환경에 적용된 마이그레이션 내역은 Flyway가 생성하는 flyway_schema_history 테이블에서 확인할 수 있습니다.

## 🚨 **참고 사항**
**application.yml 설정을 각자 추가해주세요.** 로컬이랑 CI 시크릿(`CICD_APPLICATION_DEV`)에 직접 넣어주셔야 합니다.

```yaml
spring:
  flyway:
    enabled: true
    baseline-on-migrate: true
  jpa:
    hibernate:
      ddl-auto: validate
```


추가로 dev 환경의 엔티티 설정과 실제 DB 스키마가 일치하지 않는 부분을 두 곳 확인했습니다.

| 컬럼 | 엔티티 | 실제 DB |
|---|---|---|
| `user.kakao_id` | `unique = true` | UNIQUE 없음 |
| `user.role` | `nullable = false` | nullable |

kakao_id의 경우 기존 포털 로그인에서 카카오 OAuth 로그인으로 전환하는 과정에서 기존 사용자 데이터의 해당 컬럼을 빈 값으로 채우면서 UNIQUE 제약조건을 적용하지 못한 것으로 알고 있습니다.

Hibernate의 validate는 UNIQUE 및 nullable 제약조건의 불일치까지 검사하지 않기 때문에 현재 상태에서도 검증은 통과하며 이번 Flyway 도입 및 배포에는 영향을 주지 않습니다.

다만 user.role은 엔티티에서 필수 값으로 정의되어 있는 만큼 실제 DB에서도 NOT NULL 제약조건을 적용하는 것이 필요해 보입니다.
해당 변경 사항은 baseline 생성 작업과 분리하기 위해 별도의 이슈를 생성하여 처리하겠습니다.


## prod 서버 관련

이번 PR의 Flyway 설정은 prod 환경에는 아직 적용하면 안 됩니다.

현재 작성한 V1__baseline.sql은 dev DB 스키마를 기준으로 만들어졌지만 prod DB는 dev보다 상당히 이전 버전의 스키마를 사용하고 있습니다. prod DB는 카카오 로그인 도입 이전 상태이기 때문에 현재 애플리케이션 코드와 스키마가 일치하지 않으며 현재 코드로는 정상적으로 기동할 수 없습니다.

단순히 스키마만 변경할 경우 기존 사용자 및 동아리 데이터를 유실하거나 잘못 변환할 가능성이 있으므로 먼저 기존 데이터를 어떤 방식으로 마이그레이션할지 결정해야 합니다.

따라서 prod 스키마 마이그레이션은 이번 PR의 범위에 포함하지 않았으며 CICD_APPLICATION_PROD 설정도 이번에는 변경하지 않습니다. prod 적용은 데이터 마이그레이션 방안을 정리한 뒤 별도의 이슈와 작업으로 진행해야 합니다.