### PR TITLE
Test: 통합 테스트 Testcontainers(MySQL) 도입 및 기존 테스트 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,10 @@ dependencies {
     testImplementation 'org.mockito:mockito-core'
     testImplementation 'io.rest-assured:rest-assured:5.1.1'
 
+    // 통합 테스트용 Testcontainers (MySQL)
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:mysql'
+
     // 모니터링
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
@@ -95,6 +99,13 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+
+    def colimaSocket = "${System.getProperty('user.home')}/.colima/default/docker.sock"
+    if (System.getenv('DOCKER_HOST') == null && file(colimaSocket).exists()) {
+        environment 'DOCKER_HOST', "unix://${colimaSocket}"
+        environment 'TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE', '/var/run/docker.sock'
+        systemProperty 'api.version', '1.44'
+    }
 }
 
 //JaCoCo 플러그인 설정

--- a/src/test/java/com/greedy/mokkoji/MokkojiApplicationTests.java
+++ b/src/test/java/com/greedy/mokkoji/MokkojiApplicationTests.java
@@ -1,12 +1,11 @@
 package com.greedy.mokkoji;
 
+import com.greedy.mokkoji.common.AbstractTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("test")
 @SpringBootTest
-class MokkojiApplicationTests {
+class MokkojiApplicationTests extends AbstractTest {
 
     @Test
     void contextLoads() {

--- a/src/test/java/com/greedy/mokkoji/auth/service/ManageAuthorizerTest.java
+++ b/src/test/java/com/greedy/mokkoji/auth/service/ManageAuthorizerTest.java
@@ -7,7 +7,9 @@ import com.greedy.mokkoji.db.admin.repository.AdminRepository;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.db.user.repository.UserRepository;
+import com.greedy.mokkoji.enums.admin.AdminRole;
 import com.greedy.mokkoji.enums.auth.AuthRole;
+import com.greedy.mokkoji.enums.user.UserRole;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,14 +48,14 @@ class ManageAuthorizerTest {
         final Admin admin = mock(Admin.class);
 
         BDDMockito.given(adminRepository.findById(adminId)).willReturn(Optional.of(admin));
-        BDDMockito.given(admin.canManageAllUniversitiesAndClubs()).willReturn(true);
+        BDDMockito.given(admin.getRole()).willReturn(AdminRole.MOKKOJI_ADMIN);
 
         //when & then
         assertThatCode(() -> clubManageAuthorizer.validateCanManageClub(AuthRole.ADMIN, adminId, club))
                 .doesNotThrowAnyException();
 
         verify(adminRepository, times(1)).findById(adminId);
-        verify(admin, times(1)).canManageAllUniversitiesAndClubs();
+        verify(admin, times(1)).getRole();
         verifyNoInteractions(userRepository);
     }
 
@@ -65,14 +67,14 @@ class ManageAuthorizerTest {
         final Admin admin = mock(Admin.class);
 
         BDDMockito.given(adminRepository.findById(adminId)).willReturn(Optional.of(admin));
-        BDDMockito.given(admin.canManageAllUniversitiesAndClubs()).willReturn(false);
+        BDDMockito.given(admin.getRole()).willReturn(AdminRole.UNIVERSITY_ADMIN);
 
         //when & then
         assertThatThrownBy(() -> clubManageAuthorizer.validateCanManageClub(AuthRole.ADMIN, adminId, club))
                 .isInstanceOf(MokkojiException.class);
 
         verify(adminRepository, times(1)).findById(adminId);
-        verify(admin, times(1)).canManageAllUniversitiesAndClubs();
+        verify(admin, times(1)).getRole();
         verifyNoInteractions(userRepository);
     }
 
@@ -100,14 +102,15 @@ class ManageAuthorizerTest {
         final User user = mock(User.class);
 
         BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        BDDMockito.given(user.canManageClub(club)).willReturn(true);
+        BDDMockito.given(user.getRole()).willReturn(UserRole.CLUB_MASTER);
+        BDDMockito.given(club.getMasterId()).willReturn(userId);
 
         //when & then
         assertThatCode(() -> clubManageAuthorizer.validateCanManageClub(AuthRole.USER, userId, club))
                 .doesNotThrowAnyException();
 
         verify(userRepository, times(1)).findById(userId);
-        verify(user, times(1)).canManageClub(club);
+        verify(user, times(1)).getRole();
         verifyNoInteractions(adminRepository);
     }
 
@@ -135,14 +138,14 @@ class ManageAuthorizerTest {
         final User user = mock(User.class);
 
         BDDMockito.given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        BDDMockito.given(user.canManageClub(club)).willReturn(false);
+        BDDMockito.given(user.getRole()).willReturn(UserRole.NORMAL);
 
         //when & then
         assertThatThrownBy(() -> clubManageAuthorizer.validateCanManageClub(AuthRole.USER, userId, club))
                 .isInstanceOf(MokkojiException.class);
 
         verify(userRepository, times(1)).findById(userId);
-        verify(user, times(1)).canManageClub(club);
+        verify(user, times(1)).getRole();
         verifyNoInteractions(adminRepository);
     }
 

--- a/src/test/java/com/greedy/mokkoji/club/controller/ClubControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/club/controller/ClubControllerTest.java
@@ -48,11 +48,6 @@ public class ClubControllerTest extends ControllerTest {
     @BeforeEach
     @Transactional
     void setUp() {
-        favoriteRepository.deleteAll();
-        recruitmentRepository.deleteAll();
-        clubRepository.deleteAll();
-        userRepository.deleteAll();
-        universityRepository.deleteAll();
         prepareData();
     }
 

--- a/src/test/java/com/greedy/mokkoji/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/comment/controller/CommentControllerTest.java
@@ -11,6 +11,7 @@ import com.greedy.mokkoji.common.fixture.Fixture;
 import com.greedy.mokkoji.common.response.APIErrorResponse;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.comment.entity.Comment;
+import com.greedy.mokkoji.db.university.entity.University;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.enums.message.FailMessage;
 import io.restassured.response.ExtractableResponse;
@@ -31,6 +32,7 @@ public class CommentControllerTest extends ControllerTest {
 
     private User user;
     private User anotherUser;
+    private University university;
     private Club club;
     private Club anotherClub;
 
@@ -41,14 +43,16 @@ public class CommentControllerTest extends ControllerTest {
         recruitmentRepository.deleteAll();
         clubRepository.deleteAll();
         userRepository.deleteAll();
+        universityRepository.deleteAll();
         prepareData();
     }
 
     private void prepareData() {
         user = userRepository.save(Fixture.createUser());
         anotherUser = userRepository.save(Fixture.createAnotherUser());
-        club = clubRepository.save(Fixture.createClub());
-        anotherClub = clubRepository.save(Fixture.createAnotherClub());
+        university = universityRepository.save(Fixture.createUniversity());
+        club = clubRepository.save(Fixture.createClub(university));
+        anotherClub = clubRepository.save(Fixture.createAnotherClub(university));
     }
 
     @Test

--- a/src/test/java/com/greedy/mokkoji/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/comment/controller/CommentControllerTest.java
@@ -38,12 +38,6 @@ public class CommentControllerTest extends ControllerTest {
 
     @BeforeEach
     void setUp() {
-        commentRepository.deleteAll();
-        favoriteRepository.deleteAll();
-        recruitmentRepository.deleteAll();
-        clubRepository.deleteAll();
-        userRepository.deleteAll();
-        universityRepository.deleteAll();
         prepareData();
     }
 

--- a/src/test/java/com/greedy/mokkoji/common/AbstractTest.java
+++ b/src/test/java/com/greedy/mokkoji/common/AbstractTest.java
@@ -9,9 +9,31 @@ import com.greedy.mokkoji.db.university.repository.UniversityRepository;
 import com.greedy.mokkoji.db.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MySQLContainer;
 
 @ActiveProfiles("test")
 public class AbstractTest {
+
+    // 통합 테스트 전용 MySQL 컨테이너(dev와 동일한 MySQL 엔진).
+    protected static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("mokkoji_test")
+            .withUsername("test")
+            .withPassword("test");
+
+    static {
+        MYSQL.start();
+    }
+
+    @DynamicPropertySource
+    static void datasourceProperties(final DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", () -> "root");
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+    }
+
     @Autowired
     protected UserRepository userRepository;
 

--- a/src/test/java/com/greedy/mokkoji/common/AbstractTest.java
+++ b/src/test/java/com/greedy/mokkoji/common/AbstractTest.java
@@ -7,6 +7,7 @@ import com.greedy.mokkoji.db.recruitment.repository.RecruitmentImageRepository;
 import com.greedy.mokkoji.db.recruitment.repository.RecruitmentRepository;
 import com.greedy.mokkoji.db.university.repository.UniversityRepository;
 import com.greedy.mokkoji.db.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -32,6 +33,18 @@ public class AbstractTest {
         registry.add("spring.datasource.username", MYSQL::getUsername);
         registry.add("spring.datasource.password", MYSQL::getPassword);
         registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+    }
+
+    // 공유 컨테이너라 클래스 간 데이터가 남으므로, 매 테스트 전에 FK 자식 테이블부터 역순으로 정리한다.
+    @BeforeEach
+    void cleanUpDatabase() {
+        recruitmentImageRepository.deleteAll();
+        favoriteRepository.deleteAll();
+        commentRepository.deleteAll();
+        recruitmentRepository.deleteAll();
+        clubRepository.deleteAll();
+        userRepository.deleteAll();
+        universityRepository.deleteAll();
     }
 
     @Autowired

--- a/src/test/java/com/greedy/mokkoji/common/AbstractTest.java
+++ b/src/test/java/com/greedy/mokkoji/common/AbstractTest.java
@@ -29,7 +29,7 @@ public class AbstractTest {
     @DynamicPropertySource
     static void datasourceProperties(final DynamicPropertyRegistry registry) {
         registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
-        registry.add("spring.datasource.username", () -> "root");
+        registry.add("spring.datasource.username", MYSQL::getUsername);
         registry.add("spring.datasource.password", MYSQL::getPassword);
         registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
     }

--- a/src/test/java/com/greedy/mokkoji/common/AbstractTest.java
+++ b/src/test/java/com/greedy/mokkoji/common/AbstractTest.java
@@ -18,9 +18,10 @@ import org.testcontainers.containers.MySQLContainer;
 public class AbstractTest {
 
     // 통합 테스트 전용 MySQL 컨테이너(dev와 동일한 MySQL 엔진).
+    // Flyway가 시작 시 performance_schema를 조회하므로 해당 권한이 있는 root 계정으로 접속한다.
     protected static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
             .withDatabaseName("mokkoji_test")
-            .withUsername("test")
+            .withUsername("root")
             .withPassword("test");
 
     static {

--- a/src/test/java/com/greedy/mokkoji/favorite/controller/FavoriteControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/favorite/controller/FavoriteControllerTest.java
@@ -5,6 +5,7 @@ import com.greedy.mokkoji.common.ControllerTest;
 import com.greedy.mokkoji.common.fixture.Fixture;
 import com.greedy.mokkoji.common.response.APIErrorResponse;
 import com.greedy.mokkoji.db.club.entity.Club;
+import com.greedy.mokkoji.db.university.entity.University;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.enums.message.FailMessage;
 import io.restassured.RestAssured;
@@ -24,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class FavoriteControllerTest extends ControllerTest {
 
     private User user;
+    private University university;
     private Club favoriteClub;
     private Club notFavoriteClub;
 
@@ -34,13 +36,15 @@ public class FavoriteControllerTest extends ControllerTest {
         userRepository.deleteAll();
         recruitmentRepository.deleteAll();
         clubRepository.deleteAll();
+        universityRepository.deleteAll();
         prepareData();
     }
 
     private void prepareData() {
         user = userRepository.save(Fixture.createUser());
-        favoriteClub = clubRepository.save(Fixture.createClub());
-        notFavoriteClub = clubRepository.save(Fixture.createClub());
+        university = universityRepository.save(Fixture.createUniversity());
+        favoriteClub = clubRepository.save(Fixture.createClub(university));
+        notFavoriteClub = clubRepository.save(Fixture.createClub(university));
         recruitmentRepository.saveAll(
                 List.of(Fixture.createRecruitment(favoriteClub), Fixture.createRecruitment(notFavoriteClub))
         );

--- a/src/test/java/com/greedy/mokkoji/favorite/controller/FavoriteControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/favorite/controller/FavoriteControllerTest.java
@@ -31,12 +31,6 @@ public class FavoriteControllerTest extends ControllerTest {
 
     @BeforeEach
     void setUp() {
-        favoriteRepository.deleteAll();
-        commentRepository.deleteAll();
-        userRepository.deleteAll();
-        recruitmentRepository.deleteAll();
-        clubRepository.deleteAll();
-        universityRepository.deleteAll();
         prepareData();
     }
 

--- a/src/test/java/com/greedy/mokkoji/favorite/servcie/FavoriteServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/favorite/servcie/FavoriteServiceTest.java
@@ -5,6 +5,7 @@ import com.greedy.mokkoji.api.external.AppDataS3Client;
 import com.greedy.mokkoji.api.favorite.dto.response.RecruitClubsResponse;
 import com.greedy.mokkoji.api.favorite.service.FavoriteService;
 import com.greedy.mokkoji.common.exception.MokkojiException;
+import com.greedy.mokkoji.common.fixture.Fixture;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.club.repository.ClubRepository;
 import com.greedy.mokkoji.db.favorite.entity.Favorite;
@@ -70,9 +71,6 @@ public class FavoriteServiceTest {
         final User user = User.builder()
                 .name("사용자 이름")
                 .email("사용자 이메일")
-                .grade("4")
-                .department("사용자 학과")
-                .studentId("사용자 학번")
                 .build();
         ReflectionTestUtils.setField(user, "id", 1L);
 
@@ -104,9 +102,6 @@ public class FavoriteServiceTest {
         final User user = User.builder()
                 .name("사용자 이름")
                 .email("사용자 이메일")
-                .grade("4")
-                .department("사용자 학과")
-                .studentId("사용자 학번")
                 .build();
         ReflectionTestUtils.setField(user, "id", 1L);
 
@@ -139,9 +134,6 @@ public class FavoriteServiceTest {
         final User user = User.builder()
                 .name("사용자 이름")
                 .email("사용자 이메일")
-                .grade("4")
-                .department("사용자 학과")
-                .studentId("사용자 학번")
                 .build();
         ReflectionTestUtils.setField(user, "id", 1L);
 
@@ -172,9 +164,6 @@ public class FavoriteServiceTest {
         final User user = User.builder()
                 .name("사용자 이름")
                 .email("사용자 이메일")
-                .grade("4")
-                .department("사용자 학과")
-                .studentId("사용자 학번")
                 .build();
         ReflectionTestUtils.setField(user, "id", 1L);
 
@@ -205,9 +194,6 @@ public class FavoriteServiceTest {
         final User user = User.builder()
                 .name("사용자 이름")
                 .email("사용자 이메일")
-                .grade("4")
-                .department("사용자 학과")
-                .studentId("사용자 학번")
                 .build();
         ReflectionTestUtils.setField(user, "id", 1L);
 
@@ -240,6 +226,8 @@ public class FavoriteServiceTest {
         BDDMockito.given(favoriteRepository.findByUserId(any(), any())).willReturn(favoritePage);
         BDDMockito.given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(any())).willReturn(Optional.of(recruitment));
         BDDMockito.given(appDataS3Client.getPublicUrl(any())).willReturn("testLogo1");
+        BDDMockito.given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+        ReflectionTestUtils.setField(club, "university", Fixture.createUniversity());
 
         //when
         final ClubsPaginationResponse favoriteClubs = favoriteService.findFavoriteClubs(user.getId(), PageRequest.of(0, 10));
@@ -266,9 +254,6 @@ public class FavoriteServiceTest {
         final User user = User.builder()
                 .name("사용자 이름")
                 .email("사용자 이메일")
-                .grade("4")
-                .department("사용자 학과")
-                .studentId("사용자 학번")
                 .build();
         ReflectionTestUtils.setField(user, "id", 1L);
 
@@ -341,9 +326,6 @@ public class FavoriteServiceTest {
         final User user = User.builder()
                 .name("사용자 이름")
                 .email("사용자 이메일")
-                .grade("4")
-                .department("사용자 학과")
-                .studentId("사용자 학번")
                 .build();
         ReflectionTestUtils.setField(user, "id", 1L);
 
@@ -417,9 +399,6 @@ public class FavoriteServiceTest {
         final User user = User.builder()
                 .name("사용자 이름")
                 .email("사용자 이메일")
-                .grade("4")
-                .department("사용자 학과")
-                .studentId("사용자 학번")
                 .build();
         ReflectionTestUtils.setField(user, "id", 1L);
 

--- a/src/test/java/com/greedy/mokkoji/notification/NotificationTest.java
+++ b/src/test/java/com/greedy/mokkoji/notification/NotificationTest.java
@@ -45,17 +45,13 @@ public class NotificationTest {
         final User user1 = User.builder()
                 .name("사용자 이름")
                 .email("test1@test.com")
-                .grade("4")
-                .department("사용자 학과")
-                .studentId("1111111")
+                .isEmailOn(true)
                 .build();
 
         final User user2 = User.builder()
                 .name("사용자 이름")
                 .email("test2@test.com")
-                .grade("3")
-                .department("사용자 학과")
-                .studentId("222222")
+                .isEmailOn(true)
                 .build();
 
 
@@ -92,7 +88,7 @@ public class NotificationTest {
                 .sendNotification(any(), any(), any(), any(), any());
 
         // when
-        emailService.sendNotification(club.getId(), club.getName(), recruitment);
+        emailService.sendRecruitmentNotification(club.getId(), club.getName(), recruitment);
 
         // then
         BDDMockito.verify(favoriteRepository, times(1))

--- a/src/test/java/com/greedy/mokkoji/notification/RecruitmentNotificationSchedulerTest.java
+++ b/src/test/java/com/greedy/mokkoji/notification/RecruitmentNotificationSchedulerTest.java
@@ -1,6 +1,6 @@
 package com.greedy.mokkoji.notification;
 
-import com.greedy.mokkoji.api.mail.service.EmailService;
+import com.greedy.mokkoji.api.email.service.EmailService;
 import com.greedy.mokkoji.api.scheduler.service.RecruitmentNotificationScheduler;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
@@ -16,6 +16,7 @@ import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -61,6 +62,8 @@ public class RecruitmentNotificationSchedulerTest {
                 .description("동아리 설명2")
                 .instagram("동아리 인스타 링크2")
                 .build();
+        ReflectionTestUtils.setField(club1, "id", 1L);
+        ReflectionTestUtils.setField(club2, "id", 2L);
 
         final Recruitment recruitment1 = Recruitment.builder()
                 .club(club1)

--- a/src/test/java/com/greedy/mokkoji/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/recruitment/controller/RecruitmentControllerTest.java
@@ -53,12 +53,6 @@ public class RecruitmentControllerTest extends ControllerTest {
 
     @BeforeEach
     void setUp() {
-        recruitmentImageRepository.deleteAll();
-        recruitmentRepository.deleteAll();
-        favoriteRepository.deleteAll();
-        clubRepository.deleteAll();
-        userRepository.deleteAll();
-        universityRepository.deleteAll();
         university = universityRepository.save(Fixture.createUniversity());
     }
 

--- a/src/test/java/com/greedy/mokkoji/recruitment/controller/RecruitmentControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/recruitment/controller/RecruitmentControllerTest.java
@@ -11,6 +11,7 @@ import com.greedy.mokkoji.common.fixture.Fixture;
 import com.greedy.mokkoji.common.response.APIErrorResponse;
 import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
+import com.greedy.mokkoji.db.university.entity.University;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.enums.club.ClubAffiliation;
 import com.greedy.mokkoji.enums.club.ClubCategory;
@@ -26,6 +27,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -37,11 +39,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class RecruitmentControllerTest extends ControllerTest {
 
+    private University university;
     private Club club;
     private Recruitment recruitment;
 
     static Stream<UserRole> allowedRoles() {
-        return Stream.of(UserRole.CLUB_MASTER, UserRole.GREEDY_ADMIN, UserRole.CLUB_ADMIN);
+        return Stream.of(UserRole.CLUB_MASTER);
     }
 
     static Stream<UserRole> forbiddenRoles() {
@@ -55,6 +58,8 @@ public class RecruitmentControllerTest extends ControllerTest {
         favoriteRepository.deleteAll();
         clubRepository.deleteAll();
         userRepository.deleteAll();
+        universityRepository.deleteAll();
+        university = universityRepository.save(Fixture.createUniversity());
     }
 
     @ParameterizedTest
@@ -62,9 +67,9 @@ public class RecruitmentControllerTest extends ControllerTest {
     @DisplayName("권한을 가진 관리자는 모집글을 생성할 수 있다.")
     void createRecruitment_allowedRoles_success(UserRole role) {
         //given
-        club = clubRepository.save(Fixture.createClub());
-        recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
         User adminUser = userRepository.save(Fixture.createUserWithRole(role));
+        club = clubRepository.save(Fixture.createClub(university, adminUser));
+        recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
         String authorizationForBearer = authorizationForBearerAccessToken(adminUser);
 
         final CreateRecruitmentRequest request = new CreateRecruitmentRequest(
@@ -102,7 +107,7 @@ public class RecruitmentControllerTest extends ControllerTest {
     @DisplayName("허용되지 않은 권한을 가진 일반 사용자가 모집글 생성 시 403을 반환한다.")
     void createRecruitment_forbiddenRoles_403(UserRole role) {
         // given
-        club = clubRepository.save(Fixture.createClub());
+        club = clubRepository.save(Fixture.createClub(university));
         recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
         User normalUser = userRepository.save(Fixture.createUserWithRole(role));
         String authorizationForBearer = authorizationForBearerAccessToken(normalUser);
@@ -130,8 +135,8 @@ public class RecruitmentControllerTest extends ControllerTest {
         final int actualStatusCode = response.statusCode();
         final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
         final APIErrorResponse expectedResponse = new APIErrorResponse(
-                FailMessage.FORBIDDEN.getCode(),
-                FailMessage.FORBIDDEN.getMessage()
+                FailMessage.FORBIDDEN_MANAGE_CLUB.getCode(),
+                FailMessage.FORBIDDEN_MANAGE_CLUB.getMessage()
         );
 
         assertThat(actualStatusCode).isEqualTo(HttpStatus.FORBIDDEN.value());
@@ -142,7 +147,7 @@ public class RecruitmentControllerTest extends ControllerTest {
     @DisplayName("토큰 없이 모집글 생성 요청 시 401을 반환한다.")
     void createRecruitment_withoutToken_shouldReturn401() {
         // given
-        club = clubRepository.save(Fixture.createClub());
+        club = clubRepository.save(Fixture.createClub(university));
         recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
 
         final CreateRecruitmentRequest request = new CreateRecruitmentRequest(
@@ -180,9 +185,9 @@ public class RecruitmentControllerTest extends ControllerTest {
     @DisplayName("권한을 가진 관리자는 모집글을 수정할 수 있다.")
     void updateRecruitment_allowedRoles_success(UserRole role) {
         // given
-        club = clubRepository.save(Fixture.createClub());
-        recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
         User adminUser = userRepository.save(Fixture.createUserWithRole(role));
+        club = clubRepository.save(Fixture.createClub(university, adminUser));
+        recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
         String authorizationForBearer = authorizationForBearerAccessToken(adminUser);
 
         final UpdateRecruitmentRequest request = new UpdateRecruitmentRequest(
@@ -220,7 +225,7 @@ public class RecruitmentControllerTest extends ControllerTest {
     @DisplayName("허용되지 않은 권한을 가진 일반 사용자가 모집글 수정 시 403을 반환한다.")
     void updateRecruitment_forbiddenRoles_403(UserRole role) {
         // given
-        club = clubRepository.save(Fixture.createClub());
+        club = clubRepository.save(Fixture.createClub(university));
         recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
         User normalUser = userRepository.save(Fixture.createUserWithRole(role));
         String authorizationForBearer = authorizationForBearerAccessToken(normalUser);
@@ -248,8 +253,8 @@ public class RecruitmentControllerTest extends ControllerTest {
         final int actualStatusCode = response.statusCode();
         final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
         final APIErrorResponse expectedResponse = new APIErrorResponse(
-                FailMessage.FORBIDDEN.getCode(),
-                FailMessage.FORBIDDEN.getMessage()
+                FailMessage.FORBIDDEN_MANAGE_CLUB.getCode(),
+                FailMessage.FORBIDDEN_MANAGE_CLUB.getMessage()
         );
 
         assertThat(actualStatusCode).isEqualTo(HttpStatus.FORBIDDEN.value());
@@ -261,9 +266,9 @@ public class RecruitmentControllerTest extends ControllerTest {
     @DisplayName("권한을 가진 관리자는 모집글을 삭제할 수 있다.")
     void deleteRecruitment_allowedRoles_success(UserRole role) {
         // given
-        club = clubRepository.save(Fixture.createClub());
-        recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
         User adminUser = userRepository.save(Fixture.createUserWithRole(role));
+        club = clubRepository.save(Fixture.createClub(university, adminUser));
+        recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
         String authorizationForBearer = authorizationForBearerAccessToken(adminUser);
 
         //when
@@ -283,7 +288,7 @@ public class RecruitmentControllerTest extends ControllerTest {
     @DisplayName("허용되지 않은 권한을 가진 일반 사용자가 모집글 삭제 시 403을 반환한다.")
     void deleteRecruitment_forbiddenRoles_403(UserRole role) {
         // given
-        club = clubRepository.save(Fixture.createClub());
+        club = clubRepository.save(Fixture.createClub(university));
         recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
         User normalUser = userRepository.save(Fixture.createUserWithRole(role));
         String authorizationForBearer = authorizationForBearerAccessToken(normalUser);
@@ -299,8 +304,8 @@ public class RecruitmentControllerTest extends ControllerTest {
         final int actualStatusCode = response.statusCode();
         final APIErrorResponse actualResponse = response.as(APIErrorResponse.class);
         final APIErrorResponse expectedResponse = new APIErrorResponse(
-                FailMessage.FORBIDDEN.getCode(),
-                FailMessage.FORBIDDEN.getMessage()
+                FailMessage.FORBIDDEN_MANAGE_CLUB.getCode(),
+                FailMessage.FORBIDDEN_MANAGE_CLUB.getMessage()
         );
 
         assertThat(actualStatusCode).isEqualTo(HttpStatus.FORBIDDEN.value());
@@ -311,7 +316,7 @@ public class RecruitmentControllerTest extends ControllerTest {
     @DisplayName("특정 동아리의 모든 모집글을 최신순으로 조회한다.")
     void getAllRecruitmentOfClub_shouldReturnNewestFirst() {
         // given
-        club = clubRepository.save(Fixture.createClub());
+        club = clubRepository.save(Fixture.createClub(university));
         recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
         Recruitment olderRecruitment = recruitmentRepository.save(Fixture.createOrderRecruitment(club));
         Recruitment newerRecruitment = recruitmentRepository.save(Fixture.createNewerRecruitment(club));
@@ -344,7 +349,7 @@ public class RecruitmentControllerTest extends ControllerTest {
     @DisplayName("동아리의 모집글이 없는 경우 모집글 관련 필드는 null 혹은 빈 값으로 응답한다.")
     void getRecentRecruitmentOfClub_whenNoRecruitment_shouldReturnNullRecruitmentFields() {
         // given
-        club = clubRepository.save(Fixture.createClub());
+        club = clubRepository.save(Fixture.createClub(university));
         User normalUser = userRepository.save(Fixture.createUserWithRole(UserRole.NORMAL));
         String authorizationForBearer = authorizationForBearerAccessToken(normalUser);
 
@@ -380,12 +385,17 @@ public class RecruitmentControllerTest extends ControllerTest {
     @DisplayName("동아리의 최신 모집글을 조회한다.")
     void getRecentRecruitmentOfClub() {
         // given
-        club = clubRepository.save(Fixture.createClub());
+        club = clubRepository.save(Fixture.createClub(university));
         recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
         User normalUser = userRepository.save(Fixture.createUserWithRole(UserRole.NORMAL));
         String authorizationForBearer = authorizationForBearerAccessToken(normalUser);
 
         Recruitment newerRecruitment = recruitmentRepository.save(Fixture.createNewerRecruitment(club));
+
+        // created_at이 초 단위 timestamp라 같은 초에 저장되면 값이 같아지므로 명시적으로 구분한다.
+        ReflectionTestUtils.setField(recruitment, "createdAt", LocalDateTime.now().minusDays(1));
+        ReflectionTestUtils.setField(newerRecruitment, "createdAt", LocalDateTime.now());
+        recruitmentRepository.saveAll(List.of(recruitment, newerRecruitment));
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -408,7 +418,7 @@ public class RecruitmentControllerTest extends ControllerTest {
     @DisplayName("특정 모집글을 상세 조회한다.")
     void getSpecificRecruitment() {
         // given
-        club = clubRepository.save(Fixture.createClub());
+        club = clubRepository.save(Fixture.createClub(university));
         recruitment = recruitmentRepository.save(Fixture.createRecruitment(club));
         User user = userRepository.save(Fixture.createUserWithRole(UserRole.NORMAL));
         String authorizationForBearer = authorizationForBearerAccessToken(user);
@@ -437,18 +447,18 @@ public class RecruitmentControllerTest extends ControllerTest {
         String authorizationForBearer = authorizationForBearerAccessToken(normaluser);
 
         //필터링에 포함될 동아리 데이터
-        Club club1 = clubRepository.save(Fixture.createClubWithCategoryAndAffiliation(ClubCategory.ACADEMIC_CULTURAL,
+        Club club1 = clubRepository.save(Fixture.createClubWithCategoryAndAffiliation(university,ClubCategory.ACADEMIC_CULTURAL,
                 ClubAffiliation.DEPARTMENT_CLUB));
-        Club club2 = clubRepository.save(Fixture.createClubWithCategoryAndAffiliation(ClubCategory.ACADEMIC_CULTURAL,
+        Club club2 = clubRepository.save(Fixture.createClubWithCategoryAndAffiliation(university,ClubCategory.ACADEMIC_CULTURAL,
                 ClubAffiliation.DEPARTMENT_CLUB));
         recruitmentRepository.save(Fixture.createRecruitment(club1));
         recruitmentRepository.save(Fixture.createRecruitment(club2));
 
         // 필터링에서 걸러질 동아리 데이터
         Club otherClub1 = clubRepository.save(
-                Fixture.createClubWithCategoryAndAffiliation(ClubCategory.CULTURAL_ART, ClubAffiliation.CENTRAL_CLUB));
+                Fixture.createClubWithCategoryAndAffiliation(university,ClubCategory.CULTURAL_ART, ClubAffiliation.CENTRAL_CLUB));
         Club otherClub2 = clubRepository.save(
-                Fixture.createClubWithCategoryAndAffiliation(ClubCategory.CULTURAL_ART, ClubAffiliation.CENTRAL_CLUB));
+                Fixture.createClubWithCategoryAndAffiliation(university,ClubCategory.CULTURAL_ART, ClubAffiliation.CENTRAL_CLUB));
         recruitmentRepository.save(Fixture.createRecruitment(otherClub1));
         recruitmentRepository.save(Fixture.createRecruitment(otherClub2));
 
@@ -490,10 +500,15 @@ public class RecruitmentControllerTest extends ControllerTest {
         User normalUser = userRepository.save(Fixture.createUserWithRole(UserRole.NORMAL));
         String authorizationForBearer = authorizationForBearerAccessToken(normalUser);
 
-        Club targetClub = clubRepository.save(Fixture.createClub());
+        Club targetClub = clubRepository.save(Fixture.createClub(university));
 
         Recruitment olderRecruitment = recruitmentRepository.save(Fixture.createOrderRecruitment(targetClub));
         Recruitment newerRecruitment = recruitmentRepository.save(Fixture.createNewerRecruitment(targetClub));
+
+        // created_at이 초 단위 timestamp라 같은 초에 저장되면 값이 같아 최신 1건 필터링(MAX(created_at))이 깨지므로 명시적으로 구분한다.
+        ReflectionTestUtils.setField(olderRecruitment, "createdAt", LocalDateTime.now().minusDays(1));
+        ReflectionTestUtils.setField(newerRecruitment, "createdAt", LocalDateTime.now());
+        recruitmentRepository.saveAll(List.of(olderRecruitment, newerRecruitment));
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -531,7 +546,7 @@ public class RecruitmentControllerTest extends ControllerTest {
 
         for (int i = 0; i < 11; i++) {
             Club club = clubRepository.save(
-                    Fixture.createClubWithCategoryAndAffiliation(filteringByCategory, filteringByAffiliation));
+                    Fixture.createClubWithCategoryAndAffiliation(university,filteringByCategory, filteringByAffiliation));
             recruitmentRepository.save(Fixture.createNewerRecruitment(club));
         }
 
@@ -586,17 +601,17 @@ public class RecruitmentControllerTest extends ControllerTest {
         ClubCategory filteringByCategory = ClubCategory.ACADEMIC_CULTURAL;
 
         Club favoriteClub = clubRepository.save(
-                Fixture.createClubWithCategoryAndAffiliation(filteringByCategory, filteringByAffiliation));
+                Fixture.createClubWithCategoryAndAffiliation(university,filteringByCategory, filteringByAffiliation));
         Club imminetClub = clubRepository.save(
-                Fixture.createClubWithCategoryAndAffiliation(filteringByCategory, filteringByAffiliation));
+                Fixture.createClubWithCategoryAndAffiliation(university,filteringByCategory, filteringByAffiliation));
         Club openClub = clubRepository.save(
-                Fixture.createClubWithCategoryAndAffiliation(filteringByCategory, filteringByAffiliation));
+                Fixture.createClubWithCategoryAndAffiliation(university,filteringByCategory, filteringByAffiliation));
         Club alwaysClub = clubRepository.save(
-                Fixture.createClubWithCategoryAndAffiliation(filteringByCategory, filteringByAffiliation));
+                Fixture.createClubWithCategoryAndAffiliation(university,filteringByCategory, filteringByAffiliation));
         Club beforeClub = clubRepository.save(
-                Fixture.createClubWithCategoryAndAffiliation(filteringByCategory, filteringByAffiliation));
+                Fixture.createClubWithCategoryAndAffiliation(university,filteringByCategory, filteringByAffiliation));
         Club closedClub = clubRepository.save(
-                Fixture.createClubWithCategoryAndAffiliation(filteringByCategory, filteringByAffiliation));
+                Fixture.createClubWithCategoryAndAffiliation(university,filteringByCategory, filteringByAffiliation));
 
         LocalDateTime now = LocalDateTime.now();
 

--- a/src/test/java/com/greedy/mokkoji/recruitment/service/RecruitmentServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/recruitment/service/RecruitmentServiceTest.java
@@ -374,6 +374,7 @@ public class RecruitmentServiceTest {
                 .image("새 그리디 모집글 이미지.jpg")
                 .build();
 
+        given(clubRepository.findById(1L)).willReturn(Optional.of(club));
         given(recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(1L))
                 .willReturn(Optional.of(newerRecruitment));
         given(recruitmentImageRepository.findByRecruitmentIdOrderByCreatedAtAsc(2L))

--- a/src/test/java/com/greedy/mokkoji/user/controller/AuthInterceptorTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/controller/AuthInterceptorTest.java
@@ -27,10 +27,6 @@ public class AuthInterceptorTest extends ControllerTest {
     }
 
     private void prepareData() {
-        favoriteRepository.deleteAll();
-        recruitmentRepository.deleteAll();
-        clubRepository.deleteAll();
-        userRepository.deleteAll();
         user = userRepository.save(Fixture.createUser());
     }
 

--- a/src/test/java/com/greedy/mokkoji/user/controller/UserControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/controller/UserControllerTest.java
@@ -42,11 +42,6 @@ public class UserControllerTest extends ControllerTest {
 
     @BeforeEach
     void setUp() {
-        favoriteRepository.deleteAll();
-        recruitmentRepository.deleteAll();
-        clubRepository.deleteAll();
-        userRepository.deleteAll();
-        universityRepository.deleteAll();
         prepareData();
     }
 

--- a/src/test/java/com/greedy/mokkoji/user/controller/UserControllerTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/controller/UserControllerTest.java
@@ -172,7 +172,7 @@ public class UserControllerTest extends ControllerTest {
         // given
         final String authorizationForBearer = authorizationForBearerAccessToken(user);
         final String updatedEmail = "updatedEmail@test.com";
-        final UpdateUserInformationRequest updateUserInformationRequest = new UpdateUserInformationRequest(null, updatedEmail, null, null);
+        final UpdateUserInformationRequest updateUserInformationRequest = new UpdateUserInformationRequest(null, updatedEmail, null, null, null);
 
         // when
         final ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -195,7 +195,7 @@ public class UserControllerTest extends ControllerTest {
         // given
         final String authorizationForBearer = authorizationForBearerAccessToken(user);
         final String invalidUpdatedEmail = "updatedEmail.com";
-        final UpdateUserInformationRequest updateUserInformationRequest = new UpdateUserInformationRequest(null, invalidUpdatedEmail, null, null);
+        final UpdateUserInformationRequest updateUserInformationRequest = new UpdateUserInformationRequest(null, invalidUpdatedEmail, null, null, null);
 
         // when
         final ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -219,7 +219,7 @@ public class UserControllerTest extends ControllerTest {
         universityRepository.save(Fixture.createUniversity());
         final String authorizationForBearer = authorizationForBearerAccessToken(user);
         final UpdateUserInformationRequest updateUserInformationRequest =
-                new UpdateUserInformationRequest(null, null, null, UniversityCode.SEJONG);
+                new UpdateUserInformationRequest(null, null, null, UniversityCode.SEJONG, null);
 
         // when
         RestAssured.given().log().all()
@@ -249,7 +249,7 @@ public class UserControllerTest extends ControllerTest {
         // given
         final String authorizationForBearer = authorizationForBearerAccessToken(user);
         final UpdateUserInformationRequest updateUserInformationRequest =
-                new UpdateUserInformationRequest(null, null, null, UniversityCode.KONKUK);
+                new UpdateUserInformationRequest(null, null, null, UniversityCode.KONKUK, null);
 
         // when
         final ExtractableResponse<Response> response = RestAssured.given().log().all()

--- a/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
@@ -546,7 +546,7 @@ public class UserServiceTest {
         Club club2 = Club.builder().name("그리디2").master(user).build();
         ReflectionTestUtils.setField(club2, "id", 2L);
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.existsById(userId)).thenReturn(true);
         when(clubRepository.findByMaster_Id(userId)).thenReturn(List.of(club1, club2));
 
         UserManageClubsResponse expectedResponse = new UserManageClubsResponse(


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #484

---

## 👷 **작업한 내용**
* 테스트 DB를 H2 인메모리 → 실제 MySQL(Testcontainers) 로 전환
* 도메인 변경에 맞춰 기존 테스트 수정

### [Testcontainers]
* AbstractTest에서 mysql:8.0 컨테이너를 띄우고 datasource를 동적 주입
* [build.gradle](https://github.com/greedy-team/mokkoji-be/pull/build.gradle)에 testcontainers:junit-jupiter, testcontainers:mysql 의존성 추가
* H2가 아닌 실제 MySQL 엔진에서 테스트 → 운영 환경과의 정합성 확보

### [Testcontainers 도입이유]
기존에는 test 프로파일로 H2 인메모리 DB에서 테스트를 실행했습니다. 
하지만 H2와 운영 MySQL 간 문법·동작 차이(예약어, 타입, Flyway MySQL 마이그레이션 등)로 인해 테스트는 통과해도 운영에서 깨지는 불일치 가능성이 있었습니다. 
이를 없애기 위해 dev와 동일한 MySQL 엔진에서 테스트가 돌도록 Testcontainers를 도입했습니다.

### [기존 테스트 수정]
* ManageAuthorizerTest: 동아리 관리 권한 로직 변경 반영
* NotificationTest / 알림 관련: EmailService 패키지·User 필드 변경 반영
* FavoriteControllerTest / FavoriteServiceTest: User 필드 제거, Fixture 시그니처 반영
* Comment·User·Recruitment 관련 테스트 수정

---

## 🚨 **참고 사항**
### [로컬에 도커 설치 필요]
Testcontainers가 MySQL 컨테이너를 띄우므로 로컬에 Docker가 설치되어 있어야 합니다.
(설치 방법)
``` 
brew install colima docker   # colima + docker CLI 설치
colima start                 # MySQL 컨테이너를 띄울 VM 시작
```

### [JaCoCo 커버리지 검증 관련 공유]
로컬에서 ./gradlew testCoverage 실행 시, DTO 및 Swagger 설정 클래스까지 집계 대상에 포함되어 
브랜치 커버리지 기준(60%) 미달로 Jacoco 테스트가 실패하고 있습니다.
해당 클래스들을 Jacoco 제외 대상에 등록하는 작업은 별도 브랜치를 통해 해결해보겠습니다.
<img width="600"  alt="Screenshot 2026-07-25 at 7 44 10 PM" src="https://github.com/user-attachments/assets/834b4177-7f84-4914-901e-67f05109f455" />

* 참고로 Gradle / JUnit 테스트는 통과합니다.
<img width="300"  alt="Screenshot 2026-07-25 at 7 45 42 PM" src="https://github.com/user-attachments/assets/38ec11ca-a294-4cff-a7b5-1a1c67790292" />