### PR TITLE
Feat: 학교 없음 선택 로직 삭제

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
@@ -73,8 +73,7 @@ public class UserController implements UserControllerSwagger {
                 updateUserInformationRequest.name(),
                 updateUserInformationRequest.email(),
                 updateUserInformationRequest.isEmailOn(),
-                updateUserInformationRequest.universityCode(),
-                updateUserInformationRequest.clearUniversityCode()
+                updateUserInformationRequest.universityCode()
         );
         return APISuccessResponse.of(HttpStatus.OK, null);
     }

--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserController.java
@@ -31,7 +31,7 @@ public class UserController implements UserControllerSwagger {
             @RequestBody final KakaoSocialLoginRequest request
     ) {
         final String redirectUri = kakaoRedirectUriResolver.resolve(origin);
-        final LoginResponse loginResponse = userService.kakaoLogin(request.code(), redirectUri);
+        final LoginResponse loginResponse = userService.kakaoLogin(request.code(), redirectUri, request.universityCode());
         return APISuccessResponse.of(HttpStatus.OK, loginResponse);
     }
 

--- a/src/main/java/com/greedy/mokkoji/api/user/controller/UserControllerSwagger.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/controller/UserControllerSwagger.java
@@ -63,8 +63,7 @@ public interface UserControllerSwagger {
 
     @Operation(
             summary = "사용자 정보 수정 API",
-            description = "전달된 필드만 수정됩니다. 대학교가 변경되는 경우 기존 즐겨찾기는 모두 삭제됩니다.\n"
-                    + "학교 정보를 초기화하려면 `clearUniversityCode: true`를 전달하세요. `universityCode`와 함께 전달된 경우 `clearUniversityCode`가 우선 적용됩니다.",
+            description = "전달된 필드만 수정됩니다. 대학교가 변경되는 경우 기존 즐겨찾기는 모두 삭제됩니다.",
             security = {@SecurityRequirement(name = "JWT")}
     )
     @ApiResponse(responseCode = "200", description = "사용자 정보 수정 성공")

--- a/src/main/java/com/greedy/mokkoji/api/user/dto/request/UpdateUserInformationRequest.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/dto/request/UpdateUserInformationRequest.java
@@ -13,8 +13,7 @@ public record UpdateUserInformationRequest(
         )
         String email,
         @Schema(example = "false") Boolean isEmailOn,
-        @Schema(example = "SEJONG", description = "학교 코드") UniversityCode universityCode,
-        @Schema(example = "false", description = "true 설정 시 학교 정보를 초기화합니다") Boolean clearUniversityCode
+        @Schema(example = "SEJONG", description = "학교 코드") UniversityCode universityCode
 ) {
 
 }

--- a/src/main/java/com/greedy/mokkoji/api/user/dto/request/kakao/KakaoSocialLoginRequest.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/dto/request/kakao/KakaoSocialLoginRequest.java
@@ -1,6 +1,8 @@
 package com.greedy.mokkoji.api.user.dto.request.kakao;
 
+import com.greedy.mokkoji.enums.university.UniversityCode;
+
 public record KakaoSocialLoginRequest(
-        String code
+        String code, UniversityCode universityCode
 ) {
 }

--- a/src/main/java/com/greedy/mokkoji/api/user/dto/resopnse/UserInformationResponse.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/dto/resopnse/UserInformationResponse.java
@@ -1,6 +1,5 @@
 package com.greedy.mokkoji.api.user.dto.resopnse;
 
-import com.greedy.mokkoji.db.university.entity.University;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.enums.university.UniversityCode;
 import com.greedy.mokkoji.enums.user.UserRole;
@@ -13,12 +12,9 @@ public record UserInformationResponse(
         @Schema(example = "user@sejong.ac.kr") String email,
         @Schema(example = "NORMAL") UserRole role,
         @Schema(example = "true") boolean emailOn,
-        @Schema(example = "KONKUK", description = "학교 미선택 시 null") UniversityCode universityCode
+        @Schema(example = "KONKUK") UniversityCode universityCode
 ) {
     public static UserInformationResponse of(final User user) {
-        final University university = user.getUniversity();
-        final UniversityCode universityCode = university == null ? null : university.getCode();
-
         return new UserInformationResponse(
                 user.getId(),
                 user.getCode(),
@@ -26,7 +22,7 @@ public record UserInformationResponse(
                 user.getEmail(),
                 user.getRole(),
                 user.isEmailOn(),
-                universityCode
+                user.getUniversity().getCode()
         );
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -82,7 +82,7 @@ public class UserService {
     }
 
     @Transactional
-    public void updateUserInformation(Long userId, String name, String email, Boolean isEmailOn, UniversityCode universityCode, Boolean clearUniversityCode) {
+    public void updateUserInformation(Long userId, String name, String email, Boolean isEmailOn, UniversityCode universityCode) {
         User user = findUser(userId);
 
         if (name != null) {
@@ -95,12 +95,6 @@ public class UserService {
 
         if (isEmailOn != null) {
             user.updateEmailOn(isEmailOn);
-        }
-
-        if (Boolean.TRUE.equals(clearUniversityCode)) {
-            favoriteRepository.deleteByUserId(userId);
-            user.updateUniversity(null);
-            return;
         }
 
         if (universityCode != null) {

--- a/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
+++ b/src/main/java/com/greedy/mokkoji/api/user/service/UserService.java
@@ -45,7 +45,7 @@ public class UserService {
     private final TokenService tokenService;
     private final KakaoSocialLoginService kakaoSocialLoginService;
 
-    public LoginResponse kakaoLogin(final String code, final String redirectUri) {
+    public LoginResponse kakaoLogin(final String code, final String redirectUri, final UniversityCode universityCode) {
         final KakaoUserInfoResponse kakaoUserInfo = kakaoSocialLoginService.login(code, redirectUri);
         final String kakaoId = kakaoUserInfo.id();
         final String name = kakaoUserInfo.nickname();
@@ -55,6 +55,7 @@ public class UserService {
         final User user = existingUser.orElseGet(
                 () -> userRepository.save(
                         User.builder()
+                                .university(findUniversityOrThrow(universityCode))
                                 .code(RandomStringUtils.randomAlphanumeric(6))
                                 .kakaoId(kakaoId)
                                 .name(name)
@@ -168,7 +169,6 @@ public class UserService {
     }
 
     private boolean isDifferentUniversity(final User user, final University university) {
-        return user.getUniversity() == null
-                || !user.getUniversity().getId().equals(university.getId());
+        return !user.getUniversity().getId().equals(university.getId());
     }
 }

--- a/src/main/java/com/greedy/mokkoji/db/user/entity/User.java
+++ b/src/main/java/com/greedy/mokkoji/db/user/entity/User.java
@@ -20,7 +20,7 @@ public class User extends BaseTime {
     @Column(name = "id", columnDefinition = "bigint", nullable = false)
     private Long id;
 
-    @JoinColumn(name = "university_id", columnDefinition = "bigint", nullable = false)
+    @JoinColumn(name = "university_id", columnDefinition = "bigint")
     @ManyToOne(fetch = FetchType.LAZY)
     private University university;
 

--- a/src/main/java/com/greedy/mokkoji/db/user/entity/User.java
+++ b/src/main/java/com/greedy/mokkoji/db/user/entity/User.java
@@ -20,7 +20,7 @@ public class User extends BaseTime {
     @Column(name = "id", columnDefinition = "bigint", nullable = false)
     private Long id;
 
-    @JoinColumn(name = "university_id", columnDefinition = "bigint")
+    @JoinColumn(name = "university_id", columnDefinition = "bigint", nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
     private University university;
 

--- a/src/main/resources/db/migration/V3__restore_user_university_not_null.sql
+++ b/src/main/resources/db/migration/V3__restore_user_university_not_null.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `user`
+    MODIFY COLUMN `university_id` bigint NOT NULL;

--- a/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
+++ b/src/test/java/com/greedy/mokkoji/common/fixture/Fixture.java
@@ -31,8 +31,9 @@ public class Fixture {
                 .build();
     }
 
-    public static User createUser() {
+    public static User createUser(University university) {
         return User.builder()
+                .university(university)
                 .code("Ab1234")
                 .name("모꼬지")
                 .kakaoId("kakao-12341234")
@@ -42,8 +43,9 @@ public class Fixture {
                 .build();
     }
 
-    public static User createAnotherUser() {
+    public static User createAnotherUser(University university) {
         return User.builder()
+                .university(university)
                 .code("cD5678")
                 .name("다른사용자")
                 .kakaoId("kakao-87654321")
@@ -53,8 +55,9 @@ public class Fixture {
                 .build();
     }
 
-    public static User createUserWithRole(UserRole role) {
+    public static User createUserWithRole(University university, UserRole role) {
         return User.builder()
+                .university(university)
                 .code("Ed9012")
                 .name("모꼬지")
                 .kakaoId("kakao-22222222")

--- a/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/user/service/UserServiceTest.java
@@ -231,7 +231,7 @@ public class UserServiceTest {
         when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
 
         // when
-        userService.updateUserInformation(1L, null, "updated@email.com", null, null, null);
+        userService.updateUserInformation(1L, null, "updated@email.com", null, null);
 
         // then
         assertThat(user.getEmail()).isEqualTo("updated@email.com");
@@ -249,7 +249,7 @@ public class UserServiceTest {
         when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
 
         // when
-        userService.updateUserInformation(1L, "변경된이름", null, null, null, null);
+        userService.updateUserInformation(1L, "변경된이름", null, null, null);
 
         // then
         assertThat(user.getName()).isEqualTo("변경된이름");
@@ -272,7 +272,7 @@ public class UserServiceTest {
         when(universityRepository.findByCode(UniversityCode.KONKUK)).thenReturn(Optional.of(konkuk));
 
         // when
-        userService.updateUserInformation(1L, null, null, null, UniversityCode.KONKUK, null);
+        userService.updateUserInformation(1L, null, null, null, UniversityCode.KONKUK);
 
         // then
         assertThat(user.getUniversity()).isEqualTo(konkuk);
@@ -291,7 +291,7 @@ public class UserServiceTest {
         when(universityRepository.findByCode(UniversityCode.KONKUK)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> userService.updateUserInformation(1L, null, null, null, UniversityCode.KONKUK, null))
+        assertThatThrownBy(() -> userService.updateUserInformation(1L, null, null, null, UniversityCode.KONKUK))
                 .isInstanceOf(MokkojiException.class)
                 .hasMessage(FailMessage.NOT_FOUND_UNIVERSITY.getMessage());
     }
@@ -344,7 +344,7 @@ public class UserServiceTest {
         when(universityRepository.findByCode(UniversityCode.KONKUK)).thenReturn(Optional.of(konkuk));
 
         // when
-        userService.updateUserInformation(userId, null, null, null, UniversityCode.KONKUK, null);
+        userService.updateUserInformation(userId, null, null, null, UniversityCode.KONKUK);
 
         // then
         BDDMockito.verify(favoriteRepository).deleteByUserId(userId);
@@ -372,90 +372,9 @@ public class UserServiceTest {
         when(universityRepository.findByCode(UniversityCode.SEJONG)).thenReturn(Optional.of(sejong));
 
         // when
-        userService.updateUserInformation(userId, null, null, null, UniversityCode.SEJONG, null);
+        userService.updateUserInformation(userId, null, null, null, UniversityCode.SEJONG);
 
         // then
-        BDDMockito.verify(favoriteRepository, BDDMockito.never()).deleteByUserId(userId);
-    }
-
-    @Test
-    @DisplayName("clearUniversityCode가 true이면 학교 정보가 초기화된다.")
-    void clearUniversityCode() {
-        // given
-        final Long userId = 1L;
-        final University sejong = University.builder()
-                .name("세종대학교")
-                .code(UniversityCode.SEJONG)
-                .build();
-        ReflectionTestUtils.setField(sejong, "id", 1L);
-
-        final User user = User.builder()
-                .name("모꼬지")
-                .kakaoId("kakao-12341234")
-                .university(sejong)
-                .build();
-
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-
-        // when
-        userService.updateUserInformation(userId, null, null, null, null, true);
-
-        // then
-        assertThat(user.getUniversity()).isNull();
-        BDDMockito.verify(favoriteRepository).deleteByUserId(userId);
-    }
-
-    @Test
-    @DisplayName("clearUniversityCode가 true이면 universityCode가 함께 전달되어도 학교 정보가 초기화된다.")
-    void clearUniversityCodeTakesPrecedenceOverUniversityCode() {
-        // given
-        final Long userId = 1L;
-        final University sejong = University.builder()
-                .name("세종대학교")
-                .code(UniversityCode.SEJONG)
-                .build();
-        ReflectionTestUtils.setField(sejong, "id", 1L);
-
-        final User user = User.builder()
-                .name("모꼬지")
-                .kakaoId("kakao-12341234")
-                .university(sejong)
-                .build();
-
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-
-        // when
-        userService.updateUserInformation(userId, null, null, null, UniversityCode.KONKUK, true);
-
-        // then
-        assertThat(user.getUniversity()).isNull();
-        BDDMockito.verify(universityRepository, BDDMockito.never()).findByCode(any());
-    }
-
-    @Test
-    @DisplayName("clearUniversityCode가 false이면 학교 정보가 변경되지 않는다.")
-    void clearUniversityCodeFalseDoesNotClearUniversity() {
-        // given
-        final Long userId = 1L;
-        final University sejong = University.builder()
-                .name("세종대학교")
-                .code(UniversityCode.SEJONG)
-                .build();
-        ReflectionTestUtils.setField(sejong, "id", 1L);
-
-        final User user = User.builder()
-                .name("모꼬지")
-                .kakaoId("kakao-12341234")
-                .university(sejong)
-                .build();
-
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-
-        // when
-        userService.updateUserInformation(userId, null, null, null, null, false);
-
-        // then
-        assertThat(user.getUniversity()).isEqualTo(sejong);
         BDDMockito.verify(favoriteRepository, BDDMockito.never()).deleteByUserId(userId);
     }
 


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
close #486

## 👷 **작업한 내용**
* 학교 없음 선택 로직 삭제
* 사용자 정보 수정 API에서 clearUniversityCode 파라미터 제거
* 관련 Swagger 설명 및 테스트 정리

## 🚨 **참고 사항**
* `User.university_id`에 `NOT NULL` 제약을 추가 안 함
-> 카카오 로그인 시 신규 유저를 `university` 없이 생성한 뒤, 이후 학교 정보를 설정하는 흐름이라 `university_id`가 NULL인 상태로 INSERT가 발생하기 때문. 추후 프론트측에서 유저 생성과 학교 설정을 한번에 하는 구조로 바꿔준다면, 그때 마이그레이션과 함께 `NOT NULL` 제약 적용가능

* 테스트 코드 작성 보류
[#489](https://github.com/greedy-team/mokkoji-be/pull/489)가 아직 머지되지 않았고, 해당 PR에서 관련 로직이 변경될 예정이라 지금 테스트를 작성하면 머지 후 다시 손봐야 할 것 같습니다.
→ #489 머지 후 관련 테스트를 추가/수정하겠습니다.