### PR TITLE
Feat: 이미지 업로드 presigned URL에 Cache-Control 헤더 포함

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
+++ b/src/main/java/com/greedy/mokkoji/api/external/AppDataS3Client.java
@@ -30,6 +30,8 @@ public class AppDataS3Client {
 
     private static final int DELETE_OBJECTS_BATCH_SIZE = 1000;
 
+    private static final String IMAGE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+
     private final S3Presigner s3Presigner;
     private final S3Client s3Client;
     private final String bucketName;
@@ -60,6 +62,7 @@ public class AppDataS3Client {
         final PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                 .bucket(bucketName)
                 .key(fileKey)
+                .cacheControl(IMAGE_CACHE_CONTROL)
                 .build();
 
         final PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**

close #495

## 👷 **작업한 내용**

이미지(로고·모집 이미지)가 매번 다시 로딩되는 문제로 프론트에서 브라우저 캐싱을 요청함.
`getPresignedPutUrl`의 presigned PUT URL 서명에 `Cache-Control` 헤더를 포함하여 업로드되는 S3 이미지 객체에 캐시 지시가 박히도록 했습니다.

- 값: `public, max-age=31536000, immutable` (1년)
- 로고·모집 이미지 모두 `getPresignedPutUrl`을 공유하므로 함께 적용됩니다.

## 🚨 **참고 사항**

**왜 1년 + immutable이 안전한가**
- 이미지 조회는 presigned가 아닌 **public URL**(`getPublicUrl`)이라 만료 문제가 없습니다.
- 이미지 수정 시 파일 키가 **UUID로 새로 생성**되어 URL 자체가 바뀝니다(cache busting). 따라서 옛 URL은 더 이상 참조되지 않으므로 긴 max-age를 걸어도 "수정했는데 안 바뀌는" 문제가 없습니다.

**프론트 작업 필요 (필수)**
- presigned에 `Cache-Control`이 서명 조건으로 포함되므로 프론트도 업로드(PUT) 시 **동일한 헤더**를 함께 전송해야 합니다. 불일치 시 S3가 403으로 거부합니다.
  ```
  Cache-Control: public, max-age=31536000, immutable
  ```

**기존 이미지 백필 (배포 후, AWS 접근 가능자가 1회 실행)**
- 이번 변경은 신규/재업로드분부터 적용됩니다. 로고처럼 잘 수정되지 않는 기존 이미지는 헤더가 없으므로 아래 CLI로 일괄 적용 가능합니다(파일 내용·URL 변경 없이 메타데이터만 갱신).
  ```bash
  aws s3 cp s3://mokkoji-app-data/club-logo/ s3://mokkoji-app-data/club-logo/ --recursive --metadata-directive REPLACE --cache-control "public, max-age=31536000, immutable"
  aws s3 cp s3://mokkoji-app-data/recruitment-image/ s3://mokkoji-app-data/recruitment-image/ --recursive --metadata-directive REPLACE --cache-control "public, max-age=31536000, immutable"
  ```