### PR TITLE
Refactor: 목록 조회 API N+1 제거

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
+++ b/src/main/java/com/greedy/mokkoji/api/club/service/ClubService.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -220,11 +221,15 @@ public class ClubService {
     }
 
     private List<ClubResponse> mapToClubResponses(final Long userId, final List<Club> clubs) {
+
+        List<Long> clubIds = clubs.stream().map(Club::getId).toList();
+        final Map<Long, Recruitment> latestByClubId = loadLatestRecruitmentsByClubIds(clubIds);
+        Set<Long> favoriteClubIds = loadFavoriteClubIds(userId);
+
         return clubs.stream()
                 .map(club -> {
-                    Recruitment recruitment = recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(club.getId())
-                            .orElse(null);
-                    boolean isFavorite = getIsFavorite(userId, club.getId());
+                    Recruitment recruitment = latestByClubId.get(club.getId());
+                    boolean isFavorite = favoriteClubIds.contains(club.getId());
                     return ClubResponse.of(club.getId(),
                             club.getName(),
                             club.getClubCategory(),
@@ -240,6 +245,19 @@ public class ClubService {
                 })
                 .sorted(getFavoriteComparator())
                 .toList();
+    }
+
+    private Map<Long, Recruitment> loadLatestRecruitmentsByClubIds(final List<Long> clubIds) {
+        if (clubIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return recruitmentRepository.findLatestRecruitmentsByClubIds(clubIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        recruitment -> recruitment.getClub().getId(),
+                        recruitment -> recruitment,
+                        (a, b) -> a));
     }
 
     private ClubDetailResponse mapToClubDetailResponse(final Club club, final Recruitment recruitment,

--- a/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
+++ b/src/main/java/com/greedy/mokkoji/api/favorite/service/FavoriteService.java
@@ -24,6 +24,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -60,11 +62,13 @@ public class FavoriteService {
         final User user = getUserById(userId);
 
         final List<Favorite> favorites = favoritePage.getContent();
+        final List<Long> clubIds = favorites.stream().map(favorite -> favorite.getClub().getId()).toList();
+        final Map<Long, Recruitment> latestByClubId = loadLatestRecruitmentsByClubIds(clubIds);
+
         List<ClubResponse> clubResponses = favorites.stream()
                 .map(favorite -> {
                     final Club club = favorite.getClub();
-                    Recruitment recruitment = recruitmentRepository.findTopByClubIdOrderByCreatedAtDesc(club.getId())
-                            .orElse(null);
+                    Recruitment recruitment = latestByClubId.get(club.getId());
                     return ClubResponse.of(
                             club.getId(),
                             club.getName(),
@@ -84,6 +88,19 @@ public class FavoriteService {
         final PageResponse pageResponse = createPageResponse(favoritePage);
 
         return new ClubsPaginationResponse(clubResponses, pageResponse);
+    }
+
+    private Map<Long, Recruitment> loadLatestRecruitmentsByClubIds(final List<Long> clubIds) {
+        if (clubIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return recruitmentRepository.findLatestRecruitmentsByClubIds(clubIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        recruitment -> recruitment.getClub().getId(),
+                        recruitment -> recruitment,
+                        (a, b) -> a));
     }
 
     @Transactional
@@ -109,7 +126,7 @@ public class FavoriteService {
             return null;
         }
 
-        final List<Recruitment> recruitments = recruitmentRepository.findLatestRecruitmentsByFavoriteClubs(favoriteClubIds);
+        final List<Recruitment> recruitments = recruitmentRepository.findLatestRecruitmentsByClubIds(favoriteClubIds);
 
         if (recruitments == null || recruitments.isEmpty()) {
             return null;

--- a/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/club/repository/ClubRepositoryImpl.java
@@ -67,6 +67,7 @@ public class ClubRepositoryImpl implements ClubRepositoryCustom {
 
         final List<Club> clubs = queryFactory.selectFrom(club)
                 .leftJoin(recruitment).on(club.eq(recruitment.club))
+                .leftJoin(club.university).fetchJoin()
                 .where(
                         likeClubName(keyword),
                         equalCategory(category),

--- a/src/main/java/com/greedy/mokkoji/db/clubapplication/repository/ClubApplicationRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubapplication/repository/ClubApplicationRepository.java
@@ -5,6 +5,8 @@ import com.greedy.mokkoji.db.university.entity.University;
 import com.greedy.mokkoji.db.user.entity.User;
 import com.greedy.mokkoji.enums.application.ApplicationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -14,7 +16,8 @@ public interface ClubApplicationRepository extends JpaRepository<ClubApplication
 
     boolean existsByApplicantAndUniversityAndClubNameAndStatusNot(User applicant, University university, String clubName, ApplicationStatus status);
 
-    List<ClubApplication> findByApplicant(User applicant);
+    @Query("SELECT a FROM ClubApplication a JOIN FETCH a.university WHERE a.applicant = :applicant")
+    List<ClubApplication> findByApplicant(@Param("applicant") User applicant);
 
     void deleteByApplicantId(final Long applicantId);
 }

--- a/src/main/java/com/greedy/mokkoji/db/clubmaster/repository/ClubMasterApplicationRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/clubmaster/repository/ClubMasterApplicationRepository.java
@@ -7,11 +7,17 @@ import com.greedy.mokkoji.enums.application.ApplicationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ClubMasterApplicationRepository extends JpaRepository<ClubMasterApplication, Long>, ClubMasterApplicationRepositoryCustom {
-    List<ClubMasterApplication> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    @Query("SELECT a FROM ClubMasterApplication a "
+            + "JOIN FETCH a.university "
+            + "JOIN FETCH a.club "
+            + "WHERE a.user.id = :userId ORDER BY a.createdAt DESC")
+    List<ClubMasterApplication> findByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
 
     boolean existsByUserAndClubAndStatusNot(User user, Club club, ApplicationStatus status);
 

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepository.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepository.java
@@ -14,15 +14,15 @@ import java.util.Optional;
 @Repository
 public interface RecruitmentRepository extends JpaRepository<Recruitment, Long>, RecruitmentRepositoryCustom {
 
-    @Query("SELECT r FROM Recruitment r WHERE FUNCTION('DATE', r.recruitStart) = :currentDate")
+    @Query("SELECT r FROM Recruitment r JOIN FETCH r.club WHERE FUNCTION('DATE', r.recruitStart) = :currentDate")
     List<Recruitment> findAllByRecruitStartToday(LocalDate currentDate);
 
     // 2. 모집 마감일이 오늘인 경우
-    @Query("SELECT r FROM Recruitment r WHERE FUNCTION('DATE', r.recruitEnd) = :currentDate")
+    @Query("SELECT r FROM Recruitment r JOIN FETCH r.club WHERE FUNCTION('DATE', r.recruitEnd) = :currentDate")
     List<Recruitment> findAllByRecruitEndToday(LocalDate currentDate);
 
     // 3. 모집 마감일이 오늘로부터 3일 전인 경우
-    @Query("SELECT r FROM Recruitment r WHERE FUNCTION('DATE', r.recruitEnd) = :targetDate")
+    @Query("SELECT r FROM Recruitment r JOIN FETCH r.club WHERE FUNCTION('DATE', r.recruitEnd) = :targetDate")
     List<Recruitment> findAllByRecruitEndInThreeDays(@Param("targetDate") LocalDate targetDate);
 
     Optional<Recruitment> findRecruitmentById(Long id);

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryCustom.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryCustom.java
@@ -15,5 +15,5 @@ public interface RecruitmentRepositoryCustom {
             final Pageable pageable
     );
 
-    public List<Recruitment> findLatestRecruitmentsByFavoriteClubs(List<Long> favoriteClubIds);
+    public List<Recruitment> findLatestRecruitmentsByClubIds(List<Long> clubIds);
 }

--- a/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryImpl.java
+++ b/src/main/java/com/greedy/mokkoji/db/recruitment/repository/RecruitmentRepositoryImpl.java
@@ -69,7 +69,7 @@ public class RecruitmentRepositoryImpl implements RecruitmentRepositoryCustom {
     }
 
     @Override
-    public List<Recruitment> findLatestRecruitmentsByFavoriteClubs(List<Long> favoriteClubIds) {
+    public List<Recruitment> findLatestRecruitmentsByClubIds(List<Long> favoriteClubIds) {
         QRecruitment subRecruitment = new QRecruitment("subRecruitment");
 
         return queryFactory.selectFrom(recruitment)

--- a/src/test/java/com/greedy/mokkoji/favorite/servcie/FavoriteServiceTest.java
+++ b/src/test/java/com/greedy/mokkoji/favorite/servcie/FavoriteServiceTest.java
@@ -299,7 +299,7 @@ public class FavoriteServiceTest {
         );
 
         BDDMockito.given(favoriteRepository.findClubIdsByUserId(1L)).willReturn(List.of(1L));
-        BDDMockito.given(recruitmentRepository.findLatestRecruitmentsByFavoriteClubs(List.of(1L)))
+        BDDMockito.given(recruitmentRepository.findLatestRecruitmentsByClubIds(List.of(1L)))
                 .willReturn(List.of(recruitment3));
 
         // when
@@ -316,7 +316,7 @@ public class FavoriteServiceTest {
         assertThat(response.recruitEnd()).isEqualTo("2025-03-30T12:00:00");
 
         BDDMockito.verify(favoriteRepository, times(1)).findClubIdsByUserId(1L);
-        BDDMockito.verify(recruitmentRepository, times(1)).findLatestRecruitmentsByFavoriteClubs(List.of(1L));
+        BDDMockito.verify(recruitmentRepository, times(1)).findLatestRecruitmentsByClubIds(List.of(1L));
     }
 
     @DisplayName("특정 연월에 모집 중인 즐겨찾기 동아리의 최신 모집 정보를 조회한다. - 모집 마감일이 겹치는 경우")
@@ -371,7 +371,7 @@ public class FavoriteServiceTest {
         );
 
         BDDMockito.given(favoriteRepository.findClubIdsByUserId(1L)).willReturn(List.of(1L));
-        BDDMockito.given(recruitmentRepository.findLatestRecruitmentsByFavoriteClubs(List.of(1L)))
+        BDDMockito.given(recruitmentRepository.findLatestRecruitmentsByClubIds(List.of(1L)))
                 .willReturn(List.of(recruitment3));
 
         // when
@@ -388,7 +388,7 @@ public class FavoriteServiceTest {
         assertThat(response.recruitEnd()).isEqualTo("2025-03-30T12:00:00");
 
         BDDMockito.verify(favoriteRepository, times(1)).findClubIdsByUserId(1L);
-        BDDMockito.verify(recruitmentRepository, times(1)).findLatestRecruitmentsByFavoriteClubs(List.of(1L));
+        BDDMockito.verify(recruitmentRepository, times(1)).findLatestRecruitmentsByClubIds(List.of(1L));
     }
 
 
@@ -444,7 +444,7 @@ public class FavoriteServiceTest {
         );
 
         BDDMockito.given(favoriteRepository.findClubIdsByUserId(1L)).willReturn(List.of(1L));
-        BDDMockito.given(recruitmentRepository.findLatestRecruitmentsByFavoriteClubs(List.of(1L)))
+        BDDMockito.given(recruitmentRepository.findLatestRecruitmentsByClubIds(List.of(1L)))
                 .willReturn(List.of(recruitment3));
 
         // when


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**

close #503 

## 👷 **작업한 내용**
목록 조회 API에서 항목마다 개별 쿼리가 발생하던 N+1 문제를 제거했습니다.

반복 조회는 IN 쿼리를 통한 일괄 조회 후 Set으로 대조하도록 변경하고
LAZY 연관관계 조회는 fetch join을 적용해 조회 항목 수(N)가 증가해도 쿼리 수가 증가하지 않도록 개선했습니다.

### 메서드명 변경 이유

`findLatestRecruitmentsByFavoriteClubs` → `findLatestRecruitmentsByClubIds`

- 기존 메서드명에는 `Favorite`이 포함되어 있어 즐겨찾기 전용 메서드처럼 보이지만 실제로는 `club.id IN (:clubIds)` 조건으로 동작해 즐겨찾기 여부와 관계없이 clubId 목록을 조회하는 범용 메서드입니다.
- `/clubs/search`에서도 해당 메서드를 재사용하게 되면서 실제 동작에 맞게 메서드명을 변경했습니다.



## 🚨 **참고 사항**
- 쿼리 수는 항목 수 N을 5→10으로 늘려도 고정임을 확인해 N+1 제거를 검증했습니다.
- `/recruitments`(getAllRecruitment)에도 N+1이 있으나 현재 프론트에서 미사용이라 별도 이슈로 삭제하겠습니다.