### PR TITLE
Refactor: dev 서버 GC를 Serial에서 G1으로 변경

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -11,5 +11,7 @@ services:
     image: mokkojiteam/mokkoji:dev
     ports:
       - "8080:8080"
+    environment:
+      JAVA_TOOL_OPTIONS: "-XX:+UseG1GC"
     depends_on:
       - redis


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**

close #505 

## 👷 **작업한 내용**
ocker-compose-dev.yml의 app 서비스에 JAVA_TOOL_OPTIONS로 G1GC를 지정했습니다.

t3.micro(RAM 1GB)는 server-class 조건 미달로 Serial GC로 폴백돼 있어 부하 시 Full GC STW가 최대 25초까지 발생했습니다. 같은 조건 실측에서 G1으로 바꾸니 부하 중 Full GC가 0건(최대 STW 27ms)이 되어 G1으로 전환합니다.

## 🚨 **참고 사항**
힙 크기는 이번엔 기본값을 유지했습니다. 변수를 하나만 바꿔 G1 효과를 먼저 보려고 합니다. 상주하는 백엔드 서버는 초기 힙과 최대 힙을 같게 고정해 확장,축소 비용을 없애는 게 좋다고 하네요. 실사용 힙 사용량을 지켜본 뒤 적정 값으로 고정하는 건 나중에 따로 진행할 생각입니다.
배포 후 며칠 지켜보고 문제 없으면 유지하고 이상이 있으면 되돌리거나 옵션을 조정하려 합니다. 참고로 G1 전환은 STW를 막는 것이고 스왑(RAM 부족) 자체는 남습니다. 

- 실측 참고: 같은 조건에서 Serial Full GC 7.9초 vs G1 Full GC 0건
