### PR TITLE
Refactor: 이메일 알림 배치 발송 구조로 전환 (#510)

### DIFF
--- a/src/main/java/com/greedy/mokkoji/api/email/service/AbstractEmailSender.java
+++ b/src/main/java/com/greedy/mokkoji/api/email/service/AbstractEmailSender.java
@@ -4,7 +4,6 @@ import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 
@@ -32,35 +31,15 @@ public abstract class AbstractEmailSender {
         this.discordNotifier = discordNotifier;
     }
 
-    protected void sendEmailInternal(
-            List<String> receiverMails,
-            String subject,
-            String htmlContent,
-            Runnable messagingErrorHandler,
-            Runnable mailErrorHandler,
-            Runnable unexpectedErrorHandler
-    ) {
-        try {
-            MimeMessage mimeMessage = mailSender.createMimeMessage();
-            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
-
-            helper.setFrom(senderMail, SENDER_NAME);
-            helper.setTo(OFFICIAL_EMAIL);
-            helper.setBcc(receiverMails.toArray(new String[0]));
-            helper.setSubject(subject);
-            helper.setText(htmlContent, true);
-
-            mailSender.send(mimeMessage);
-        } catch (MessagingException | UnsupportedEncodingException e) {
-            log.error("[MAIL GENERATING ERROR] message={}", e.getMessage(), e);
-            messagingErrorHandler.run();
-        } catch (MailException e) {
-            log.error("[MAIL SEND FAILED] message={}", e.getMessage(), e);
-            mailErrorHandler.run();
-        } catch (Exception e) {
-            log.error("[EMAIL UNEXPECTED ERROR]", e);
-            unexpectedErrorHandler.run();
-        }
+    protected MimeMessage buildMimeMessage(String subject, String htmlContent, List<String> receiverMails)
+            throws MessagingException, UnsupportedEncodingException {
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+        helper.setFrom(senderMail, SENDER_NAME);
+        helper.setTo(OFFICIAL_EMAIL);
+        helper.setBcc(receiverMails.toArray(new String[0]));
+        helper.setSubject(subject);
+        helper.setText(htmlContent, true);
+        return mimeMessage;
     }
 }
-

--- a/src/main/java/com/greedy/mokkoji/api/email/service/EmailService.java
+++ b/src/main/java/com/greedy/mokkoji/api/email/service/EmailService.java
@@ -7,32 +7,47 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class EmailService {
 
+    // emailExecutor corePoolSize와 동일 — 항상 모든 스레드를 활용하기 위해 청크 수를 풀 크기로 고정
+    private static final int EMAIL_POOL_SIZE = 5;
+
     private final RecruitmentNotificationChannel recruitmentNotificationChannel;
     private final FavoriteRepository favoriteRepository;
 
     @Transactional(readOnly = true)
-    public void sendRecruitmentNotification(final Long clubId, final String clubName, final Recruitment recruitment) {
-        List<Favorite> favorites = favoriteRepository.findByClubIdWithFetchJoin(clubId);
+    public void sendBatchRecruitmentNotifications(final List<Recruitment> recruitments) {
+        List<RecruitmentMailPayload> payloads = new ArrayList<>();
 
-        List<String> userEmails = favorites.stream()
-                .map(Favorite::getUser)
-                .filter(user -> user != null && user.isEmailOn())
-                .map(user -> user.getEmail())
-                .filter(email -> email != null && !email.isBlank())
-                .toList();
+        for (Recruitment recruitment : recruitments) {
+            Long clubId = recruitment.getClub().getId();
+            String clubName = recruitment.getClub().getName();
 
-        if (userEmails.isEmpty()) {
-            return;
+            List<String> userEmails = favoriteRepository.findByClubIdWithFetchJoin(clubId).stream()
+                    .map(Favorite::getUser)
+                    .filter(user -> user != null && user.isEmailOn())
+                    .map(user -> user.getEmail())
+                    .filter(email -> email != null && !email.isBlank())
+                    .toList();
+
+            if (!userEmails.isEmpty()) {
+                payloads.add(new RecruitmentMailPayload(
+                        clubId, clubName, userEmails,
+                        recruitment.getRecruitStart(), recruitment.getRecruitEnd()
+                ));
+            }
         }
 
-        recruitmentNotificationChannel.sendNotification(
-                userEmails, clubId, clubName, recruitment.getRecruitStart(), recruitment.getRecruitEnd()
-        );
+        int chunkCount = Math.min(EMAIL_POOL_SIZE, payloads.size());
+        for (int i = 0; i < chunkCount; i++) {
+            int from = i * payloads.size() / chunkCount;
+            int to = (i + 1) * payloads.size() / chunkCount;
+            recruitmentNotificationChannel.sendBatchNotification(payloads.subList(from, to));
+        }
     }
 }

--- a/src/main/java/com/greedy/mokkoji/api/email/service/RecruitmentMailPayload.java
+++ b/src/main/java/com/greedy/mokkoji/api/email/service/RecruitmentMailPayload.java
@@ -1,0 +1,12 @@
+package com.greedy.mokkoji.api.email.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record RecruitmentMailPayload(
+        Long clubId,
+        String clubName,
+        List<String> receiverMails,
+        LocalDateTime recruitStart,
+        LocalDateTime recruitEnd
+) {}

--- a/src/main/java/com/greedy/mokkoji/api/email/service/RecruitmentNotificationChannel.java
+++ b/src/main/java/com/greedy/mokkoji/api/email/service/RecruitmentNotificationChannel.java
@@ -1,14 +1,7 @@
 package com.greedy.mokkoji.api.email.service;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 public interface RecruitmentNotificationChannel {
-    void sendNotification(
-            List<String> receiverMails,
-            Long clubId,
-            String clubName,
-            LocalDateTime recruitStartTime,
-            LocalDateTime recruitEndTime
-    );
+    void sendBatchNotification(List<RecruitmentMailPayload> payloads);
 }

--- a/src/main/java/com/greedy/mokkoji/api/email/service/RecruitmentNotificationEmailChannel.java
+++ b/src/main/java/com/greedy/mokkoji/api/email/service/RecruitmentNotificationEmailChannel.java
@@ -1,13 +1,19 @@
 package com.greedy.mokkoji.api.email.service;
 
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+import java.io.UnsupportedEncodingException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static com.greedy.mokkoji.enums.message.FailMessage.*;
 
@@ -23,25 +29,52 @@ public class RecruitmentNotificationEmailChannel extends AbstractEmailSender imp
 
     @Async("emailExecutor")
     @Override
-    public void sendNotification(
-            final List<String> receiverMails,
-            final Long clubId,
-            final String clubName,
-            final LocalDateTime recruitStartTime,
-            final LocalDateTime recruitEndTime
-    ) {
-        String subject = clubName + SUBJECT_SUFFIX;
-        String htmlContent = generateHtmlText(clubId, clubName, recruitStartTime, recruitEndTime);
-        int receiverCount = receiverMails.size();
+    public void sendBatchNotification(List<RecruitmentMailPayload> payloads) {
+        List<MimeMessage> messages = new ArrayList<>();
+        List<RecruitmentMailPayload> builtPayloads = new ArrayList<>();
 
-        sendEmailInternal(
-                receiverMails,
-                subject,
-                htmlContent,
-                () -> discordNotifier.notifyRecruitmentNotificationEmailFailure(clubId, clubName, receiverCount, INTERNAL_SERVER_ERROR_SMTP_MAIL.getMessage()),
-                () -> discordNotifier.notifyRecruitmentNotificationEmailFailure(clubId, clubName, receiverCount, INTERNAL_SERVER_ERROR_SMTP.getMessage()),
-                () -> discordNotifier.notifyRecruitmentNotificationEmailFailure(clubId, clubName, receiverCount, INTERNAL_SERVER_ERROR.getMessage())
-        );
+        for (RecruitmentMailPayload payload : payloads) {
+            try {
+                String subject = payload.clubName() + SUBJECT_SUFFIX;
+                String html = generateHtmlText(payload.clubId(), payload.clubName(), payload.recruitStart(), payload.recruitEnd());
+                messages.add(buildMimeMessage(subject, html, payload.receiverMails()));
+                builtPayloads.add(payload);
+            } catch (MessagingException | UnsupportedEncodingException e) {
+                log.error("[MAIL GENERATING ERROR] clubId={} message={}", payload.clubId(), e.getMessage(), e);
+                discordNotifier.notifyRecruitmentNotificationEmailFailure(
+                        payload.clubId(), payload.clubName(), payload.receiverMails().size(),
+                        INTERNAL_SERVER_ERROR_SMTP_MAIL.getMessage()
+                );
+            }
+        }
+
+        if (messages.isEmpty()) {
+            return;
+        }
+
+        try {
+            mailSender.send(messages.toArray(new MimeMessage[0]));
+        } catch (MailSendException e) {
+            Map<Object, Exception> failedMessages = e.getFailedMessages();
+            for (int i = 0; i < messages.size(); i++) {
+                if (failedMessages.containsKey(messages.get(i))) {
+                    RecruitmentMailPayload payload = builtPayloads.get(i);
+                    log.error("[MAIL SEND FAILED] clubId={} message={}", payload.clubId(), e.getMessage(), e);
+                    discordNotifier.notifyRecruitmentNotificationEmailFailure(
+                            payload.clubId(), payload.clubName(), payload.receiverMails().size(),
+                            INTERNAL_SERVER_ERROR_SMTP.getMessage()
+                    );
+                }
+            }
+        } catch (Exception e) {
+            log.error("[EMAIL UNEXPECTED ERROR]", e);
+            builtPayloads.forEach(payload ->
+                    discordNotifier.notifyRecruitmentNotificationEmailFailure(
+                            payload.clubId(), payload.clubName(), payload.receiverMails().size(),
+                            INTERNAL_SERVER_ERROR.getMessage()
+                    )
+            );
+        }
     }
 
     private String generateHtmlText(Long clubId, String clubName, LocalDateTime recruitStart, LocalDateTime recruitEnd) {

--- a/src/main/java/com/greedy/mokkoji/api/scheduler/service/RecruitmentNotificationScheduler.java
+++ b/src/main/java/com/greedy/mokkoji/api/scheduler/service/RecruitmentNotificationScheduler.java
@@ -1,7 +1,6 @@
 package com.greedy.mokkoji.api.scheduler.service;
 
 import com.greedy.mokkoji.api.email.service.EmailService;
-import com.greedy.mokkoji.db.club.entity.Club;
 import com.greedy.mokkoji.db.recruitment.entity.Recruitment;
 import com.greedy.mokkoji.db.recruitment.repository.RecruitmentRepository;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +29,6 @@ public class RecruitmentNotificationScheduler {
         final LocalDate threeDaysLater = today.plusDays(3);
 
         List<Recruitment> recruitments = new ArrayList<>(recruitmentRepository.findAllByRecruitStartToday(today));
-
         recruitments.addAll(recruitmentRepository.findAllByRecruitEndToday(today));
         recruitments.addAll(recruitmentRepository.findAllByRecruitEndInThreeDays(threeDaysLater));
 
@@ -39,24 +37,16 @@ public class RecruitmentNotificationScheduler {
                 .collect(Collectors.toMap(
                         recruitment -> recruitment.getClub().getId(),
                         recruitment -> recruitment,
-                        (recruitment1, recruitment2) ->
-                                recruitment1.getCreatedAt().isAfter(recruitment2.getCreatedAt())
-                                        ? recruitment1
-                                        : recruitment2
+                        (r1, r2) -> r1.getCreatedAt().isAfter(r2.getCreatedAt()) ? r1 : r2
                 ))
                 .values()
                 .stream()
                 .toList();
 
-        uniqueAndLatestRecruitments.forEach(recruitment -> {
-            Club club = recruitment.getClub();
-            try {
-                emailService.sendRecruitmentNotification(club.getId(), club.getName(), recruitment);
-            } catch (Exception e) {
-                log.error("[RECRUITMENT NOTI SUBMIT FAILED] clubId={} recruitmentId={} msg={}",
-                        club.getId(), recruitment.getId(), e.getMessage(), e);
-            }
-        });
+        try {
+            emailService.sendBatchRecruitmentNotifications(uniqueAndLatestRecruitments);
+        } catch (Exception e) {
+            log.error("[RECRUITMENT NOTI SUBMIT FAILED] msg={}", e.getMessage(), e);
+        }
     }
 }
-

--- a/src/test/java/com/greedy/mokkoji/notification/BatchEmailSendingBenchmarkTest.java
+++ b/src/test/java/com/greedy/mokkoji/notification/BatchEmailSendingBenchmarkTest.java
@@ -1,0 +1,195 @@
+package com.greedy.mokkoji.notification;
+
+import com.greedy.mokkoji.api.email.service.DiscordNotifier;
+import com.greedy.mokkoji.api.email.service.RecruitmentMailPayload;
+import com.greedy.mokkoji.api.email.service.RecruitmentNotificationEmailChannel;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+/**
+ * async 개별발송(club당 send 1회) vs async+배치발송(청크당 send 1회)의 성능 차이를 수치로 측정하는 벤치마크.
+ *
+ * 실측값(MeasureSmtpLatency, Gmail SMTP 10회):
+ *   H(핸드셰이크): 2,470ms  — send() 1회당 연결·TLS·인증·종료 비용
+ *   S(건당 전송):  1,668ms  — 메시지 자체 전송 비용 (배치 내 건당 동일)
+ *
+ * 두 지표로 모델 예측:
+ *   개별발송 wall time = CEIL(N / POOL) × (H + S) = 4 × 4,138 ≈ 16,552ms
+ *   배치발송 wall time ≈ H + CHUNK_SIZE × S  = 2,470 + 5 × 1,668 ≈ 10,810ms
+ *     → 실측 9,149ms (모델 9,142ms)와 일치
+ *
+ * 이 테스트는 실제 SMTP 발송 없이 send() 지연만 주입해 구조적 효과를 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("이메일 배치 발송 벤치마크 (async 개별 vs async+배치)")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class BatchEmailSendingBenchmarkTest {
+
+    /** send() 1회당 핸드셰이크 비용 (실측 median, ms). */
+    private static final long H = 2_470L;
+    /** 배치 내 건당 전송 비용 (실측값, ms). */
+    private static final long S = 1_668L;
+    /** 동아리(=발송 건) 수. */
+    private static final int CLUB_COUNT = 20;
+    /** 청크 수 = emailExecutor corePoolSize. 항상 모든 스레드를 활용하기 위해 개수를 고정. */
+    private static final int CHUNK_COUNT = 5;
+
+    private static final int CORE_POOL_SIZE = 5;
+    private static final int MAX_POOL_SIZE = 10;
+    private static final int QUEUE_CAPACITY = 300;
+
+    @Mock
+    private JavaMailSender mailSender;
+
+    @Mock
+    private DiscordNotifier discordNotifier;
+
+    private RecruitmentNotificationEmailChannel channel;
+    private List<RecruitmentMailPayload> payloads;
+
+    @BeforeEach
+    void setUp() {
+        channel = new RecruitmentNotificationEmailChannel(mailSender, discordNotifier);
+        ReflectionTestUtils.setField(channel, "senderMail", "test@mokkoji.com");
+        ReflectionTestUtils.setField(channel, "baseUrl", "https://mokkoji.com");
+        ReflectionTestUtils.setField(channel, "mailBannerUrl", "https://mokkoji.com/banner.png");
+
+        BDDMockito.given(mailSender.createMimeMessage())
+                .willAnswer(inv -> new MimeMessage((Session) null));
+
+        payloads = new ArrayList<>();
+        for (int i = 0; i < CLUB_COUNT; i++) {
+            payloads.add(new RecruitmentMailPayload(
+                    (long) i, "동아리" + i,
+                    List.of("user" + i + "@test.com"),
+                    LocalDateTime.now(), LocalDateTime.now().plusDays(7)
+            ));
+        }
+    }
+
+    @Test
+    @DisplayName("async 개별발송: club당 커넥션 1개, 풀 포화 시 직렬 누적")
+    void async_개별발송() throws InterruptedException {
+        // send(MimeMessage) 1회 = H + S (매번 새 핸드셰이크)
+        BDDMockito.willAnswer(inv -> { Thread.sleep(H + S); return null; })
+                .given(mailSender).send(any(MimeMessage.class));
+
+        ThreadPoolTaskExecutor executor = buildEmailExecutor();
+        CountDownLatch done = new CountDownLatch(CLUB_COUNT);
+
+        long start = System.currentTimeMillis();
+
+        for (RecruitmentMailPayload payload : payloads) {
+            executor.execute(() -> {
+                try {
+                    MimeMessage msg = mailSender.createMimeMessage();
+                    mailSender.send(msg);
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        done.await();
+        long totalMs = System.currentTimeMillis() - start;
+        executor.shutdown();
+
+        long expectedMin = (long) Math.ceil((double) CLUB_COUNT / CORE_POOL_SIZE) * (H + S);
+        System.out.printf("[개별발송] 전체 완료 = %dms  (예측 ≥ %dms, 커넥션 %d개)%n",
+                totalMs, expectedMin, CLUB_COUNT);
+
+        // CEIL(N/POOL) 라운드만큼 H+S가 직렬 누적된다
+        assertThat(totalMs).isGreaterThanOrEqualTo(expectedMin);
+    }
+
+    @Test
+    @DisplayName("async+배치발송: 청크당 커넥션 1개, 핸드셰이크 상각")
+    void async_배치발송() throws InterruptedException {
+        // send(MimeMessage[N]) 1회 = H + N×S (핸드셰이크 1번만)
+        // Mockito는 varargs를 개별 인수로 언팩하므로 getArguments().length가 메시지 수
+        BDDMockito.willAnswer(inv -> {
+            int msgCount = inv.getArguments().length;
+            Thread.sleep(H + (long) msgCount * S);
+            return null;
+        }).given(mailSender).send(any(MimeMessage[].class));
+
+        List<List<RecruitmentMailPayload>> chunks = partitionByCount(payloads, CHUNK_COUNT);
+        ThreadPoolTaskExecutor executor = buildEmailExecutor();
+        CountDownLatch done = new CountDownLatch(chunks.size());
+
+        long start = System.currentTimeMillis();
+
+        for (List<RecruitmentMailPayload> chunk : chunks) {
+            executor.execute(() -> {
+                try {
+                    channel.sendBatchNotification(chunk); // @Async 미적용 — 직접 동기 호출
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+
+        done.await();
+        long totalMs = System.currentTimeMillis() - start;
+        executor.shutdown();
+
+        int clubsPerChunk = CLUB_COUNT / CHUNK_COUNT;
+        long chunkTime = H + (long) clubsPerChunk * S;
+        long oldApproachMin = (long) Math.ceil((double) CLUB_COUNT / CORE_POOL_SIZE) * (H + S);
+        System.out.printf("[배치발송] 전체 완료 = %dms  (예측 ≈ %dms, 커넥션 %d개)%n",
+                totalMs, chunkTime, chunks.size());
+        System.out.printf("  → 개별발송 대비 %.1f배 단축 (모델 예측 %.1f배)%n",
+                (double) oldApproachMin / totalMs,
+                (double) oldApproachMin / chunkTime);
+
+        // 모든 청크가 병렬 실행되므로 wall time ≈ H + (N/CHUNK_COUNT)×S
+        // 개별발송 최솟값보다 확실히 빠르다
+        assertThat(totalMs).isLessThan(oldApproachMin);
+        // 커넥션 수 = CHUNK_COUNT (= 풀 크기)
+        assertThat(chunks.size()).isEqualTo(CHUNK_COUNT);
+    }
+
+    /** payloads를 count개 청크로 균등 분할. */
+    private List<List<RecruitmentMailPayload>> partitionByCount(List<RecruitmentMailPayload> list, int count) {
+        int actualCount = Math.min(count, list.size());
+        List<List<RecruitmentMailPayload>> result = new ArrayList<>();
+        for (int i = 0; i < actualCount; i++) {
+            int from = i * list.size() / actualCount;
+            int to = (i + 1) * list.size() / actualCount;
+            result.add(list.subList(from, to));
+        }
+        return result;
+    }
+
+    private ThreadPoolTaskExecutor buildEmailExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(CORE_POOL_SIZE);
+        executor.setMaxPoolSize(MAX_POOL_SIZE);
+        executor.setQueueCapacity(QUEUE_CAPACITY);
+        executor.setThreadNamePrefix("email-async-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/test/java/com/greedy/mokkoji/notification/EmailNotificationRealTest.java
+++ b/src/test/java/com/greedy/mokkoji/notification/EmailNotificationRealTest.java
@@ -1,5 +1,6 @@
 package com.greedy.mokkoji.notification;
 
+import com.greedy.mokkoji.api.email.service.RecruitmentMailPayload;
 import com.greedy.mokkoji.api.email.service.RecruitmentNotificationEmailChannel;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -26,18 +27,19 @@ public class EmailNotificationRealTest {
     @Test
     @DisplayName("수신자 이메일 노출 확인")
     void checkEmailExposure() {
-
         List<String> receiverMails = Arrays.stream(receivers.split(","))
                 .map(String::trim)
                 .filter(s -> !s.isBlank())
                 .toList();
 
-        recruitmentNotificationEmailChannel.sendNotification(
-                receiverMails,
-                1L,
-                "수신자 노출 테스트",
-                LocalDateTime.now(),
-                LocalDateTime.now().plusDays(7)
-        );
+        recruitmentNotificationEmailChannel.sendBatchNotification(List.of(
+                new RecruitmentMailPayload(
+                        1L,
+                        "수신자 노출 테스트",
+                        receiverMails,
+                        LocalDateTime.now(),
+                        LocalDateTime.now().plusDays(7)
+                )
+        ));
     }
 }

--- a/src/test/java/com/greedy/mokkoji/notification/EmailNotificationTest.java
+++ b/src/test/java/com/greedy/mokkoji/notification/EmailNotificationTest.java
@@ -1,5 +1,7 @@
 package com.greedy.mokkoji.notification;
 
+import com.greedy.mokkoji.api.email.service.DiscordNotifier;
+import com.greedy.mokkoji.api.email.service.RecruitmentMailPayload;
 import com.greedy.mokkoji.api.email.service.RecruitmentNotificationEmailChannel;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
@@ -28,30 +30,36 @@ public class EmailNotificationTest {
     @Mock
     private JavaMailSender mailSender;
 
+    @Mock
+    private DiscordNotifier discordNotifier;
+
     @BeforeEach
     void setUp() {
-        // TODO:: 다른 방법 생각해보기
         ReflectionTestUtils.setField(recruitmentNotificationEmailChannel, "senderMail", "test@mokkoji.com");
+        ReflectionTestUtils.setField(recruitmentNotificationEmailChannel, "baseUrl", "https://mokkoji.com");
+        ReflectionTestUtils.setField(recruitmentNotificationEmailChannel, "mailBannerUrl", "https://mokkoji.com/banner.png");
     }
 
     @Test
     @DisplayName("이메일 알림이 발송된다")
     void sendNotificationTest() {
         // given
-        final List<String> receiverMails = List.of("test@test.com");
-        final Long clubId = 1L;
-        final String clubName = "테스트";
-        final LocalDateTime recruitStart = LocalDateTime.now();
-        final LocalDateTime recruitEnd = LocalDateTime.now().plusDays(7);
+        RecruitmentMailPayload payload = new RecruitmentMailPayload(
+                1L,
+                "테스트",
+                List.of("test@test.com"),
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(7)
+        );
 
-        final MimeMessage mimeMessage = new MimeMessage((Session) null);
+        MimeMessage mimeMessage = new MimeMessage((Session) null);
         BDDMockito.when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
-        BDDMockito.doNothing().when(mailSender).send(any(MimeMessage.class));
+        BDDMockito.doNothing().when(mailSender).send(any(MimeMessage[].class));
 
         // when
-        recruitmentNotificationEmailChannel.sendNotification(receiverMails, clubId, clubName, recruitStart, recruitEnd);
+        recruitmentNotificationEmailChannel.sendBatchNotification(List.of(payload));
 
         // then
-        BDDMockito.verify(mailSender, times(1)).send(any(MimeMessage.class));
+        BDDMockito.verify(mailSender, times(1)).send(any(MimeMessage[].class));
     }
 }

--- a/src/test/java/com/greedy/mokkoji/notification/EmailNotificationTest.java
+++ b/src/test/java/com/greedy/mokkoji/notification/EmailNotificationTest.java
@@ -17,7 +17,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.mockito.Mockito.any;
+import org.springframework.mail.MailSendException;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.times;
 
 @ExtendWith(MockitoExtension.class)
@@ -61,5 +65,69 @@ public class EmailNotificationTest {
 
         // then
         BDDMockito.verify(mailSender, times(1)).send(any(MimeMessage[].class));
+    }
+
+    @Test
+    @DisplayName("전달된 payload가 없으면 메일을 발송하지 않는다")
+    void 전달된_payload가_없으면_메일을_발송하지_않는다() {
+        // when
+        recruitmentNotificationEmailChannel.sendBatchNotification(List.of());
+
+        // then
+        BDDMockito.verify(mailSender, never()).send(any(MimeMessage[].class));
+    }
+
+    @Test
+    @DisplayName("예기치 않은 예외 발생 시 모든 payload에 Discord 알림을 보낸다")
+    void 예기치_않은_예외_발생_시_모든_payload에_Discord_알림을_보낸다() {
+        // given
+        RecruitmentMailPayload payload1 = new RecruitmentMailPayload(
+                1L, "동아리A", List.of("a@test.com"),
+                LocalDateTime.now(), LocalDateTime.now().plusDays(7)
+        );
+        RecruitmentMailPayload payload2 = new RecruitmentMailPayload(
+                2L, "동아리B", List.of("b@test.com"),
+                LocalDateTime.now(), LocalDateTime.now().plusDays(7)
+        );
+
+        BDDMockito.when(mailSender.createMimeMessage()).thenReturn(new MimeMessage((Session) null));
+        BDDMockito.willThrow(new RuntimeException("unexpected smtp error"))
+                .given(mailSender).send(any(MimeMessage[].class));
+
+        // when
+        recruitmentNotificationEmailChannel.sendBatchNotification(List.of(payload1, payload2));
+
+        // then — 빌드 성공한 2개 payload 모두에 Discord 에스컬레이션
+        BDDMockito.verify(discordNotifier, times(2))
+                .notifyRecruitmentNotificationEmailFailure(any(), any(), anyInt(), any());
+    }
+
+    @Test
+    @DisplayName("MailSendException 발생 시 실패한 메시지에만 Discord 알림을 보낸다")
+    void MailSendException_발생_시_실패한_메시지에만_Discord_알림을_보낸다() {
+        // given
+        RecruitmentMailPayload payload1 = new RecruitmentMailPayload(
+                1L, "동아리A", List.of("a@test.com"),
+                LocalDateTime.now(), LocalDateTime.now().plusDays(7)
+        );
+        RecruitmentMailPayload payload2 = new RecruitmentMailPayload(
+                2L, "동아리B", List.of("b@test.com"),
+                LocalDateTime.now(), LocalDateTime.now().plusDays(7)
+        );
+
+        BDDMockito.when(mailSender.createMimeMessage()).thenAnswer(inv -> new MimeMessage((Session) null));
+
+        // varargs send()에서 첫 번째 인수(첫 번째 MimeMessage)만 실패로 주입
+        BDDMockito.willAnswer(inv -> {
+            MimeMessage firstMsg = (MimeMessage) inv.getArguments()[0];
+            throw new MailSendException(Map.of(firstMsg, new Exception("send failed")));
+        }).given(mailSender).send(any(MimeMessage[].class));
+
+        // when
+        recruitmentNotificationEmailChannel.sendBatchNotification(List.of(payload1, payload2));
+
+        // then — 2개 중 첫 번째만 실패 → Discord 알림 1번
+        BDDMockito.verify(discordNotifier, times(1))
+                .notifyRecruitmentNotificationEmailFailure(any(), any(), anyInt(), any());
     }
 }

--- a/src/test/java/com/greedy/mokkoji/notification/NotificationTest.java
+++ b/src/test/java/com/greedy/mokkoji/notification/NotificationTest.java
@@ -97,4 +97,77 @@ public class NotificationTest {
         BDDMockito.verify(recruitmentNotificationChannel, times(1))
                 .sendBatchNotification(any());
     }
+
+    @Test
+    @DisplayName("이메일 수신 거부 사용자는 알림에서 제외된다")
+    void 이메일_수신_거부_사용자는_알림에서_제외된다() {
+        // given
+        final User emailOffUser = User.builder()
+                .name("수신거부사용자")
+                .email("off@test.com")
+                .isEmailOn(false)
+                .build();
+
+        final Club club = Club.builder()
+                .name("동아리 이름")
+                .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
+                .clubCategory(ClubCategory.CULTURAL_ART)
+                .logo("로고")
+                .description("설명")
+                .instagram("인스타")
+                .build();
+
+        final Recruitment recruitment = Recruitment.builder()
+                .club(club)
+                .content("소개글")
+                .recruitStart(LocalDateTime.now())
+                .recruitEnd(LocalDateTime.now().plusDays(10))
+                .build();
+
+        final Favorite favorite = Favorite.builder()
+                .user(emailOffUser)
+                .club(club)
+                .build();
+
+        BDDMockito.given(favoriteRepository.findByClubIdWithFetchJoin(any()))
+                .willReturn(List.of(favorite));
+
+        // when
+        emailService.sendBatchRecruitmentNotifications(List.of(recruitment));
+
+        // then — 수신 거부 사용자만 있으므로 채널 호출 없음
+        BDDMockito.verify(recruitmentNotificationChannel, times(0))
+                .sendBatchNotification(any());
+    }
+
+    @Test
+    @DisplayName("즐겨찾기 사용자가 없으면 채널을 호출하지 않는다")
+    void 즐겨찾기_사용자가_없으면_채널을_호출하지_않는다() {
+        // given
+        final Club club = Club.builder()
+                .name("동아리 이름")
+                .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
+                .clubCategory(ClubCategory.CULTURAL_ART)
+                .logo("로고")
+                .description("설명")
+                .instagram("인스타")
+                .build();
+
+        final Recruitment recruitment = Recruitment.builder()
+                .club(club)
+                .content("소개글")
+                .recruitStart(LocalDateTime.now())
+                .recruitEnd(LocalDateTime.now().plusDays(10))
+                .build();
+
+        BDDMockito.given(favoriteRepository.findByClubIdWithFetchJoin(any()))
+                .willReturn(List.of());
+
+        // when
+        emailService.sendBatchRecruitmentNotifications(List.of(recruitment));
+
+        // then
+        BDDMockito.verify(recruitmentNotificationChannel, times(0))
+                .sendBatchNotification(any());
+    }
 }

--- a/src/test/java/com/greedy/mokkoji/notification/NotificationTest.java
+++ b/src/test/java/com/greedy/mokkoji/notification/NotificationTest.java
@@ -1,5 +1,6 @@
 package com.greedy.mokkoji.notification;
 
+import com.greedy.mokkoji.api.email.service.RecruitmentMailPayload;
 import com.greedy.mokkoji.api.email.service.RecruitmentNotificationChannel;
 import com.greedy.mokkoji.api.email.service.EmailService;
 import com.greedy.mokkoji.db.club.entity.Club;
@@ -54,7 +55,6 @@ public class NotificationTest {
                 .isEmailOn(true)
                 .build();
 
-
         final Club club = Club.builder()
                 .name("동아리 이름")
                 .clubAffiliation(ClubAffiliation.CENTRAL_CLUB)
@@ -85,17 +85,16 @@ public class NotificationTest {
                 .willReturn(List.of(favorite1, favorite2));
 
         BDDMockito.doNothing().when(recruitmentNotificationChannel)
-                .sendNotification(any(), any(), any(), any(), any());
+                .sendBatchNotification(any());
 
         // when
-        emailService.sendRecruitmentNotification(club.getId(), club.getName(), recruitment);
+        emailService.sendBatchRecruitmentNotifications(List.of(recruitment));
 
         // then
         BDDMockito.verify(favoriteRepository, times(1))
                 .findByClubIdWithFetchJoin(any());
 
         BDDMockito.verify(recruitmentNotificationChannel, times(1))
-                .sendNotification(any(), any(), any(), any(), any());
-
+                .sendBatchNotification(any());
     }
 }

--- a/src/test/java/com/greedy/mokkoji/notification/RecruitmentNotificationSchedulerTest.java
+++ b/src/test/java/com/greedy/mokkoji/notification/RecruitmentNotificationSchedulerTest.java
@@ -21,8 +21,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.times;
 
 
@@ -84,24 +83,16 @@ public class RecruitmentNotificationSchedulerTest {
 
         BDDMockito.doNothing()
                 .when(emailService)
-                .sendRecruitmentNotification(
-                        nullable(Long.class),
-                        any(String.class),
-                        any(Recruitment.class)
-                );
+                .sendBatchRecruitmentNotifications(anyList());
 
         // when
         recruitmentNotificationScheduler.sendDailyRecruitmentNotifications();
 
-        //then
+        // then
         BDDMockito.verify(recruitmentRepository, times(1))
                 .findAllByRecruitStartToday(currentDateTime.toLocalDate());
 
-        BDDMockito.verify(emailService, times(2))
-                .sendRecruitmentNotification(
-                        nullable(Long.class),
-                        any(String.class),
-                        any(Recruitment.class)
-                );
+        BDDMockito.verify(emailService, times(1))
+                .sendBatchRecruitmentNotifications(anyList());
     }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**

close #510

## 👷 **작업한 내용**

기존에는 스케줄러가 동아리마다 SMTP 커넥션을 개별로 맺어 발송하는 구조였습니다.
발송 건수가 늘수록 커넥션 수도 선형으로 증가하고, 핸드셰이크 비용이 매번 누적되는 문제가 있었습니다.
이를 청크 단위 배치 발송으로 전환해 커넥션 수를 고정했습니다.

### [배치 발송 구조]
- 전체 발송 대상을 스레드 풀 크기(5)와 동일한 수의 청크로 균등 분할
- 각 청크를 `@Async` 스레드에서 `send(MimeMessage[])` 1회로 발송 → 청크당 커넥션 1개
- 기존 동아리당 커넥션 1개 구조 대비 커넥션 수를 풀 크기 수준으로 고정

### [청크 전략 — 청크 수 = 풀 크기]
청크 크기를 고정하는 방식(ex. 5개씩)을 쓰면 동아리 수가 늘어날수록 라운드가 추가됩니다.
대신 청크 수를 풀 크기로 고정하면 동아리 수와 무관하게 항상 1라운드에 모든 스레드를 활용합니다.

### [실패 처리]
- `MailSendException.getFailedMessages()`로 배치 내 부분 실패를 감지
- 실패한 payload만 Discord로 에스컬레이션하고, 성공분은 정상 발송
- MimeMessage 빌드 실패·예기치 않은 예외도 각각 케이스를 나눠 처리

### [RecruitmentMailPayload 레코드 도입]
비동기 스레드 경계를 넘기 전에 JPA 프록시(`Club`, `Recruitment` 엔티티)에서 필요한 값만 추출해 불변 레코드에 담습니다.
스레드 경계 이후 영속성 컨텍스트가 없어 `LazyInitializationException`이 발생하는 문제를 구조적으로 차단했습니다.

### [테스트]
- `BatchEmailSendingBenchmarkTest`: 실측 SMTP 지연값(H=2,470ms, S=1,668ms)을 주입해 개별 발송(≈16,552ms) vs 배치 발송(≈9,149ms) 차이를 수치로 검증
- `EmailNotificationTest`: 정상 발송 외에 빈 payload, `MailSendException` 부분 실패, 예기치 않은 예외 케이스 추가
- `NotificationTest`: 이메일 수신 거부 사용자 필터링, 즐겨찾기 사용자 없을 때 채널 미호출 케이스 추가

## 🚨 **참고 사항**

`EmailNotificationRealTest`는 실제 SMTP로 발송하는 테스트로 `@Disabled` 상태입니다.
직접 발송을 확인해야 할 때만 해제 후 실행하세요.